### PR TITLE
Add missing SSE instructions to X86 assembler

### DIFF
--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -502,15 +502,42 @@ class X86Assembler(buffer: DataBuffer) {
 	def sqrtss(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF3, 0x0F, 0x51, a, b); }
 	def maxss(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF3, 0x0F, 0x5F, a, b); }
 	def minss(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF3, 0x0F, 0x5D, a, b); }
-	def ucomiss(a: SSEReg, b: SSERm);
-	def cmpeqss(a: SSEReg, b: SSERm);
-	def cmpltss(a: SSEReg, b: SSERm);
-	def cmpless(a: SSEReg, b: SSERm);
-	def cmpunordss(a: SSEReg, b: SSERm);
-	def cmpness(a: SSEReg, b: SSERm);
-	def cmpnltss(a: SSEReg, b: SSERm);
-	def cmpnless(a: SSEReg, b: SSERm);
-	def cmpordss(a: SSEReg, b: SSERm);
+	def ucomiss(a: SSEReg, b: SSERm) {
+		emitbb(0x0F, 0x2E);
+		emit_sm(b, a.index);
+	}
+	def cmpeqss(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
+		emitb(0x0);
+	}
+	def cmpltss(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
+		emitb(0x1);
+	}
+	def cmpless(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
+		emitb(0x2);
+	}
+	def cmpunordss(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
+		emitb(0x3);
+	}
+	def cmpneqss(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
+		emitb(0x4);
+	}
+	def cmpnltss(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
+		emitb(0x5);
+	}
+	def cmpnless(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
+		emitb(0x6);
+	}
+	def cmpordss(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
+		emitb(0x7);
+	}
 	def roundss(a: SSEReg, b: SSERm, c: byte) {
 		emitbbbb_s_sm(0x66, 0x0F, 0x3A, 0x0A, a, b);
 		emitb(c);

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -490,7 +490,10 @@ class X86Assembler(buffer: DataBuffer) {
 		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
 		emitb(0x7);
 	}
-	def roundsd(a: SSERm);
+	def roundsd(a: SSEReg, b: SSERm, c: byte) {
+		emitbbbb_s_sm(0x66, 0x0F, 0x3A, 0x0B, a, b);
+		emitb(c);
+	}
 
 	def addss(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF3, 0x0F, 0x58, a, b); }
 	def subss(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF3, 0x0F, 0x5C, a, b); }
@@ -508,7 +511,10 @@ class X86Assembler(buffer: DataBuffer) {
 	def cmpnltss(a: SSEReg, b: SSERm);
 	def cmpnless(a: SSEReg, b: SSERm);
 	def cmpordss(a: SSEReg, b: SSERm);
-	def roundss(a: SSERm);
+	def roundss(a: SSEReg, b: SSERm, c: byte) {
+		emitbbbb_s_sm(0x66, 0x0F, 0x3A, 0x0A, a, b);
+		emitb(c);
+	}
 
 	def cvtsd2si(a: X86Reg, b: SSERm); // F2 REX.W 0F
 	def cvtss2si(a: X86Reg, b: SSERm); // F3 0F 2C
@@ -536,6 +542,13 @@ class X86Assembler(buffer: DataBuffer) {
 
 	def emitbbb_s_sm(b1: byte, b2: byte, b3: byte, a: SSEReg, b: SSERm) {
 		emitbbb(b1, b2, b3);
+		emit_sm(b, a.index);
+	}
+
+	def emitbbbb_s_sm(b1: byte, b2: byte, b3: byte, b4: byte,
+			a: SSEReg, b: SSERm) {
+		emitbbb(b1, b2, b3);
+		emitb(b4);
 		emit_sm(b, a.index);
 	}
 

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -1,22 +1,11 @@
 // Copyright 2011 Google Inc. All rights reserved.
 // See LICENSE for details of Apache 2.0 license.
 
-enum RoundingMode {
-	TO_NEAREST,
-	TO_NEG_INF,
-	TO_POS_INF,
-	TO_ZERO
-}
-
-component Rounding {
-	def roundingModeToInt(mode: RoundingMode) -> int {
-		match (mode) {
-			TO_NEAREST 	=> return 0;
-			TO_NEG_INF 	=> return 1;
-			TO_POS_INF 	=> return 2;
-			TO_ZERO		=> return 3;
-		}
-	}
+enum RoundingMode(value: int) {
+	TO_NEAREST(0x00),
+	TO_NEG_INF(0x01),
+	TO_POS_INF(0x02),
+	TO_ZERO(0x03)
 }
 
 // either a register or memory location
@@ -510,7 +499,7 @@ class X86Assembler(buffer: DataBuffer) {
 	}
 	def roundsd(a: SSEReg, b: SSERm, c: RoundingMode) {
 		emitbbbb_s_sm(0x66, 0x0F, 0x3A, 0x0B, a, b);
-		emitb(Rounding.roundingModeToInt(c));
+		emitb(c.value);
 	}
 
 	def addss(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF3, 0x0F, 0x58, a, b); }
@@ -558,7 +547,7 @@ class X86Assembler(buffer: DataBuffer) {
 	}
 	def roundss(a: SSEReg, b: SSERm, c: RoundingMode) {
 		emitbbbb_s_sm(0x66, 0x0F, 0x3A, 0x0A, a, b);
-		emitb(Rounding.roundingModeToInt(c));
+		emitb(c.value);
 	}
 
 	def cvtsd2si(a: X86Reg, b: SSERm) {

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -1,6 +1,24 @@
 // Copyright 2011 Google Inc. All rights reserved.
 // See LICENSE for details of Apache 2.0 license.
 
+enum RoundingMode {
+	TO_NEAREST,
+	TO_NEG_INF,
+	TO_POS_INF,
+	TO_ZERO
+}
+
+component Rounding {
+	def roundingModeToInt(mode: RoundingMode) -> int {
+		match (mode) {
+			TO_NEAREST 	=> return 0;
+			TO_NEG_INF 	=> return 1;
+			TO_POS_INF 	=> return 2;
+			TO_ZERO		=> return 3;
+		}
+	}
+}
+
 // either a register or memory location
 class X86Rm {
 	def render(buf: StringBuffer) -> StringBuffer {
@@ -490,9 +508,9 @@ class X86Assembler(buffer: DataBuffer) {
 		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
 		emitb(0x7);
 	}
-	def roundsd(a: SSEReg, b: SSERm, c: byte) {
+	def roundsd(a: SSEReg, b: SSERm, c: RoundingMode) {
 		emitbbbb_s_sm(0x66, 0x0F, 0x3A, 0x0B, a, b);
-		emitb(c);
+		emitb(Rounding.roundingModeToInt(c));
 	}
 
 	def addss(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF3, 0x0F, 0x58, a, b); }
@@ -538,9 +556,9 @@ class X86Assembler(buffer: DataBuffer) {
 		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
 		emitb(0x7);
 	}
-	def roundss(a: SSEReg, b: SSERm, c: byte) {
+	def roundss(a: SSEReg, b: SSERm, c: RoundingMode) {
 		emitbbbb_s_sm(0x66, 0x0F, 0x3A, 0x0A, a, b);
-		emitb(c);
+		emitb(Rounding.roundingModeToInt(c));
 	}
 
 	def cvtsd2si(a: X86Reg, b: SSERm) {

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -543,12 +543,24 @@ class X86Assembler(buffer: DataBuffer) {
 		emitb(c);
 	}
 
-	def cvtsd2si(a: X86Reg, b: SSERm); // F2 REX.W 0F
-	def cvtss2si(a: X86Reg, b: SSERm); // F3 0F 2C
-	def cvtsi2sd(a: SSEReg, b: X86Rm); // F2 0F 2A
-	def cvtsi2ss(a: SSEReg, b: X86Rm); // F3 REX.W 0F 2A
-	def cvtss2sd(a: SSEReg, b: SSERm); // F3 0F 5A
-	def cvtsd2ss(a: SSEReg, b: SSERm); // F2 0F 5A
+	def cvtsd2si(a: X86Reg, b: SSERm) {
+		emitbbb(0xF2, 0x0F, 0x2D);
+		emit_sm(b, a.index);
+	}
+	def cvtss2si(a: X86Reg, b: SSERm) {
+		emitbbb(0xF3, 0x0F, 0x2D);
+		emit_sm(b, a.index);
+	}
+	def cvtsi2sd(a: SSEReg, b: X86Rm) {
+		emitbbb(0xF2, 0x0F, 0x2A);
+		emit_rm(b, a.index);
+	}
+	def cvtsi2ss(a: SSEReg, b: X86Rm) {
+		emitbbb(0xF3, 0x0F, 0x2A);
+		emit_rm(b, a.index);
+	}
+	def cvtss2sd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF3, 0x0F, 0x5A, a, b); }
+	def cvtsd2ss(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF2, 0x0F, 0x5A, a, b); }
 
 	def movss_m_s(a: X86Addr, b: SSEReg) { // store float
 		emitbbb(0xF3, 0x0F, 0x11);

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -457,14 +457,39 @@ class X86Assembler(buffer: DataBuffer) {
 	def maxsd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF2, 0x0F, 0x5F, a, b); }
 	def minsd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF2, 0x0F, 0x5D, a, b); }
 	def ucomisd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0x66, 0x0F, 0x2E, a, b); }
-	def cmpeqsd(a: SSEReg, b: SSERm);
-	def cmpltsd(a: SSEReg, b: SSERm);
-	def cmplesd(a: SSEReg, b: SSERm);
-	def cmpunordsd(a: SSEReg, b: SSERm);
-	def cmpnesd(a: SSEReg, b: SSERm);
-	def cmpnltsd(a: SSEReg, b: SSERm);
-	def cmpnlesd(a: SSEReg, b: SSERm);
-	def cmpordsd(a: SSEReg, b: SSERm);
+
+	def cmpeqsd(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
+		emitb(0x0);
+	}
+	def cmpltsd(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
+		emitb(0x1);
+	}
+	def cmplesd(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
+		emitb(0x2);
+	}
+	def cmpunordsd(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
+		emitb(0x3);
+	}
+	def cmpneqsd(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
+		emitb(0x4);
+	}
+	def cmpnltsd(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
+		emitb(0x5);
+	}
+	def cmpnlesd(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
+		emitb(0x6);
+	}
+	def cmpordsd(a: SSEReg, b: SSERm) {
+		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
+		emitb(0x7);
+	}
 	def roundsd(a: SSERm);
 
 	def addss(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF3, 0x0F, 0x58, a, b); }
@@ -508,12 +533,12 @@ class X86Assembler(buffer: DataBuffer) {
 		emitbbb(0xF2, 0x0F, 0x10);
 		emit_rm(b, a.index);
 	}
-	
+
 	def emitbbb_s_sm(b1: byte, b2: byte, b3: byte, a: SSEReg, b: SSERm) {
 		emitbbb(b1, b2, b3);
 		emit_sm(b, a.index);
 	}
-	
+
 	def emitb_rm(b0: int, a: X86Rm, eop: int) {
 		emitb(b0);
 		emit_rm(a, eop);

--- a/bin/dev/virgil-vim/syntax/virgil.vim
+++ b/bin/dev/virgil-vim/syntax/virgil.vim
@@ -33,20 +33,17 @@ syn match virgilOperator "\v\-\>"
 syn match virgilOperator "\v\=\>"
 syn match virgilOperator "\v\:"
 
+" adapted from neovim runtime/syntax
 syn keyword virgilTodo contained TODO FIXME XXX NOTE
-syn region  virgilComment
-    \ oneline
-    \ contains=virgilTodo
-    \ start="//"
-    \ end="$"
+syn region  virgilComment start="/\*" end="\*/" contains=virgilTodo,@Spell
+syn match   virgilComment "//.*$" contains=virgilTodo,@Spell
 
-" adapted from neovim runtime/syntax/java.vim
 syn match  virgilSpecialCharError display contained +\\\([^0-7nrt\\'"]\|[xX]\x\{2}\)+
-syn match  virgilSpecialChar	  contained "\\\([\"\\'ntr]\|[xX]\x\{2}\)"
-syn region virgilString		  start=+"+ end=+"+ end=+$+ contains=virgilSpecialChar,virgilSpecialCharError,@Spell
-syn match  virgilCharacter	  "'[^']*'" contains=virgilSpecialChar,virgilSpecialCharError
-syn match  virgilCharacter	  "'\\''" contains=virgilSpecialChar
-syn match  virgilCharacter	  "'[^\\]'"
+syn match  virgilSpecialChar      contained "\\\([\"\\'ntr]\|[xX]\x\{2}\)"
+syn region virgilString           start=+"+ end=+"+ end=+$+ contains=virgilSpecialChar,virgilSpecialCharError,@Spell
+syn match  virgilCharacter        "'[^']*'" contains=virgilSpecialChar,virgilSpecialCharError
+syn match  virgilCharacter        "'\\''" contains=virgilSpecialChar
+syn match  virgilCharacter        "'[^\\]'"
 
 syn match virgilNumber "\<\(0[bB][0-1]\+\|0[0-7]*\|0[xX]\x\+\|\d\(\d\|_\d\)*\)[lL]\=\>"
 syn match virgilNumber "\(\<\d\(\d\|_\d\)*\.\(\d\(\d\|_\d\)*\)\=\|\.\d\(\d\|_\d\)*\)\([eE][-+]\=\d\(\d\|_\d\)*\)\=[fFdD]\="
@@ -55,22 +52,22 @@ syn match virgilNumber "\<\d\(\d\|_\d\)*\([eE][-+]\=\d\(\d\|_\d\)*\)\=[fFdD]\>"
 
 hi def link virgilKeyword               Keyword
 hi def link virgilInclude               Include
-hi def link virgilLabel		        Label
-hi def link virgilConditional	        Conditional
-hi def link virgilRepeat	        Repeat
-hi def link virgilStatement	        Statement
-hi def link virgilType		        Type
-hi def link virgilNumber	        Number
-hi def link virgilComment	        Comment
+hi def link virgilLabel                 Label
+hi def link virgilConditional           Conditional
+hi def link virgilRepeat                Repeat
+hi def link virgilStatement             Statement
+hi def link virgilType                  Type
+hi def link virgilNumber                Number
+hi def link virgilComment               Comment
 hi def link virgilOperator              Operator
-hi def link virgilCharacter	        Character
-hi def link virgilString	        String
-hi def link virgilTodo		        Todo
-hi def link virgilSpecial		Special
-hi def link virgilSpecialError		Error
-hi def link virgilSpecialCharError	Error
-hi def link virgilString		String
-hi def link virgilCharacter		Character
-hi def link virgilSpecialChar		SpecialChar
+hi def link virgilCharacter             Character
+hi def link virgilString                String
+hi def link virgilTodo                  Todo
+hi def link virgilSpecial               Special
+hi def link virgilSpecialError          Error
+hi def link virgilSpecialCharError      Error
+hi def link virgilString                String
+hi def link virgilCharacter             Character
+hi def link virgilSpecialChar           SpecialChar
 
 let b:current_syntax = "virgil"

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -30,6 +30,9 @@ def main(a: Array<string>) -> int {
 	gen.do_s_sm("cmpnlesd", gen.asm.cmpnlesd);
 	gen.do_s_sm("cmpordsd", gen.asm.cmpordsd);
 
+	gen.do_s_sm_b("roundsd", gen.asm.roundsd);
+	gen.do_s_sm_b("roundss", gen.asm.roundss);
+
 	Terminal.put(";; passed\n");
 	return 0;
 }
@@ -125,6 +128,27 @@ class X86AsmGen(args: Array<string>) {
 				buf.puts(" ;;== ");
 				render();
 				Terminal.putbln(buf);
+			}
+		}
+	}
+
+	def do_s_sm_b(mnemonic: string, asm_func: (SSEReg, SSERm, byte) -> void) {
+		if (skip(mnemonic)) return;
+		for (addr in SSE_ADDRS) {
+			for (s in [X86Regs.XMM0, X86Regs.XMM1, X86Regs.XMM7]) {
+				for (mode in ['\x00', '\x01', '\x03', '\x04']) {
+					asm_func(s, addr, mode);
+					buf.reset();
+					buf.puts(mnemonic).sp();
+					buf.puts(s.name);
+					buf.puts(", ");
+					addr.render(buf);
+					buf.puts(", ");
+					buf.puti(int.!(mode));
+					buf.puts(" ;;== ");
+					render();
+					Terminal.putbln(buf);
+				}
 			}
 		}
 	}

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -167,11 +167,11 @@ class X86AsmGen(args: Array<string>) {
 		}
 	}
 
-	def do_s_sm_b(mnemonic: string, asm_func: (SSEReg, SSERm, byte) -> void) {
+	def do_s_sm_b(mnemonic: string, asm_func: (SSEReg, SSERm, RoundingMode) -> void) {
 		if (skip(mnemonic)) return;
 		for (addr in SSE_ADDRS) {
 			for (s in [X86Regs.XMM0, X86Regs.XMM1, X86Regs.XMM7]) {
-				for (mode in ['\x00', '\x01', '\x03', '\x04']) {
+				for (mode in RoundingMode) {
 					asm_func(s, addr, mode);
 					buf.reset();
 					buf.puts(mnemonic).sp();
@@ -179,7 +179,7 @@ class X86AsmGen(args: Array<string>) {
 					buf.puts(", ");
 					addr.render(buf);
 					buf.puts(", ");
-					buf.puti(int.!(mode));
+					buf.puti(Rounding.roundingModeToInt(mode));
 					buf.puts(" ;;== ");
 					render();
 					Terminal.putbln(buf);

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -44,6 +44,13 @@ def main(a: Array<string>) -> int {
 	gen.do_s_sm("cmpnless", gen.asm.cmpnless);
 	gen.do_s_sm("cmpordss", gen.asm.cmpordss);
 
+	gen.do_r_sm("cvtsd2si", gen.asm.cvtsd2si);
+	gen.do_r_sm("cvtss2si", gen.asm.cvtss2si);
+	gen.do_s_rm("cvtsi2sd", gen.asm.cvtsi2sd);
+	gen.do_s_rm("cvtsi2ss", gen.asm.cvtsi2ss);
+	gen.do_s_sm("cvtss2sd", gen.asm.cvtss2sd);
+	gen.do_s_sm("cvtsd2ss", gen.asm.cvtsd2ss);
+
 	Terminal.put(";; passed\n");
 	return 0;
 }
@@ -117,6 +124,23 @@ class X86AsmGen(args: Array<string>) {
 				buf.reset();
 				buf.puts(mnemonic).sp();
 				buf.puts(s.name);
+				buf.puts(", ");
+				addr.render(buf);
+				buf.puts(" ;;== ");
+				render();
+				Terminal.putbln(buf);
+			}
+		}
+	}
+
+	def do_r_sm(mnemonic: string, asm_func: (X86Reg, SSERm) -> void) {
+		if (skip(mnemonic)) return;
+		for (addr in SSE_ADDRS) {
+			for (s in [X86Regs.EAX, X86Regs.ECX, X86Regs.EDI]) {
+				asm_func(s, addr);
+				buf.reset();
+				buf.puts(mnemonic).sp();
+				buf.puts(s.name32);
 				buf.puts(", ");
 				addr.render(buf);
 				buf.puts(" ;;== ");

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -21,6 +21,15 @@ def main(a: Array<string>) -> int {
 	gen.do_s_sm("mulss", gen.asm.mulss);
 	gen.do_s_sm("divss", gen.asm.divss);
 
+	gen.do_s_sm("cmpeqsd", gen.asm.cmpeqsd);
+	gen.do_s_sm("cmpltsd", gen.asm.cmpltsd);
+	gen.do_s_sm("cmplesd", gen.asm.cmplesd);
+	gen.do_s_sm("cmpunordsd", gen.asm.cmpunordsd);
+	gen.do_s_sm("cmpneqsd", gen.asm.cmpneqsd);
+	gen.do_s_sm("cmpnltsd", gen.asm.cmpnltsd);
+	gen.do_s_sm("cmpnlesd", gen.asm.cmpnlesd);
+	gen.do_s_sm("cmpordsd", gen.asm.cmpordsd);
+
 	Terminal.put(";; passed\n");
 	return 0;
 }

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -33,6 +33,17 @@ def main(a: Array<string>) -> int {
 	gen.do_s_sm_b("roundsd", gen.asm.roundsd);
 	gen.do_s_sm_b("roundss", gen.asm.roundss);
 
+	gen.do_s_sm("ucomiss", gen.asm.ucomiss);
+
+	gen.do_s_sm("cmpeqss", gen.asm.cmpeqss);
+	gen.do_s_sm("cmpltss", gen.asm.cmpltss);
+	gen.do_s_sm("cmpless", gen.asm.cmpless);
+	gen.do_s_sm("cmpunordss", gen.asm.cmpunordss);
+	gen.do_s_sm("cmpneqss", gen.asm.cmpneqss);
+	gen.do_s_sm("cmpnltss", gen.asm.cmpnltss);
+	gen.do_s_sm("cmpnless", gen.asm.cmpnless);
+	gen.do_s_sm("cmpordss", gen.asm.cmpordss);
+
 	Terminal.put(";; passed\n");
 	return 0;
 }

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -179,7 +179,7 @@ class X86AsmGen(args: Array<string>) {
 					buf.puts(", ");
 					addr.render(buf);
 					buf.puts(", ");
-					buf.puti(Rounding.roundingModeToInt(mode));
+					buf.puti(mode.value);
 					buf.puts(" ;;== ");
 					render();
 					Terminal.putbln(buf);


### PR DESCRIPTION
Adds missing SSE instructions and tests for the X86 assembler. I've tried to keep to idiomatic virgil as much as possible.