### PR TITLE
Add scripts to check differences in bootstrapped binary

### DIFF
--- a/test/check-bootstrap.bash
+++ b/test/check-bootstrap.bash
@@ -1,25 +1,19 @@
 #!/bin/bash
 
-function line() {
-    echo ================================================================================
-}
-
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do
-  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
-  SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
-if [ $# != 3 ]; then
+. $DIR/common.bash check-bootstrap
+
+if [ $# -lt 3 ]; then
     echo "Usage: check-bootstrap.bash <target> <Aeneas before> <Aeneas after>"
     exit 1
 fi
-
-BLUE='\033[0;34m'
-GREEN='\033[0;32m'
-NC='\033[0m'
 
 target=$1
 shift
@@ -30,35 +24,45 @@ shift
 after=$1
 shift
 
-TMP=/tmp/$USER
-
-OUT_BEFORE=$TMP/before
-OUT_AFTER=$TMP/after
+OUT_BEFORE=$OUT/before
+OUT_AFTER=$OUT/after
+DIFF_FILE=$OUT/diff
 
 mkdir -p $OUT_BEFORE
 mkdir -p $OUT_AFTER
+echo -n "" > $DIFF_FILE
 
-echo -n "" > $TMP/diff
+shopt -s nullglob
+if [ $# -gt 0 ]; then
+    TESTS="$@"
+else
+    TESTS=($DIR/*.v3)
+fi
+
+if [ ${#TESTS[@]} == 0 ]; then
+    echo -e "${RED}No tests given${NORM}"
+    exit 1
+fi
 
 line
-echo -e "${BLUE}$before -output=$OUT_BEFORE -multiple -target=$target $DIR/execute/*.v3${NC}"
-$before -output=$OUT_BEFORE -multiple -target=$target $DIR/execute/*.v3 &> /dev/null
+echo -e "${BLUE}$before -output=$OUT_BEFORE -multiple -target=$target TESTS${NORM}"
+$before -output=$OUT_BEFORE -multiple -target=$target $TESTS &> /dev/null
 
 line
-echo -e "${BLUE}$after -output=$OUT_AFTER -multiple -target=$target $DIR/execute/*.v3${NC}"
-$after -output=$OUT_AFTER -multiple -target=$target $DIR/execute/*.v3 &> /dev/null
+echo -e "${BLUE}$after -output=$OUT_AFTER -multiple -target=$target TESTS${NORM}"
+$after -output=$OUT_AFTER -multiple -target=$target $TESTS &> /dev/null
 
 line
-echo -e "${BLUE}diff -d $OUT_BEFORE $OUT_AFTER${NC}"
+echo -e "${BLUE}diff -d $OUT_BEFORE $OUT_AFTER${NORM}"
 DIFF=$(diff -d $OUT_BEFORE $OUT_AFTER)
 
 set -f
 IFS=$'\n'
 for l in $DIFF; do
     file=$(echo $l | awk '{ print $3 }')
-    echo -n $(wc -c $file | awk '{ print $1 }') "" >> $TMP/diff
-    echo $l >> $TMP/diff
+    echo -n $(wc -c $file | awk '{ print $1 }') "" >> $DIFF_FILE
+    echo $l >> $DIFF_FILE
 done
 
-echo -e "${GREEN}Smallest binaries as per $TMP/diff${NC}:"
-sort -n $TMP/diff | head
+echo -e "${GREEN}Smallest binaries as per $DIFF_FILE${NORM}:"
+sort -n $DIFF_FILE | head

--- a/test/check-bootstrap.bash
+++ b/test/check-bootstrap.bash
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+function line() {
+    echo ================================================================================
+}
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+if [ $# != 3 ]; then
+    echo "Usage: check-bootstrap.bash <target> <Aeneas before> <Aeneas after>"
+    exit 1
+fi
+
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+target=$1
+shift
+
+before=$1
+shift
+
+after=$1
+shift
+
+TMP=/tmp/$USER
+
+OUT_BEFORE=$TMP/before
+OUT_AFTER=$TMP/after
+
+mkdir -p $OUT_BEFORE
+mkdir -p $OUT_AFTER
+
+echo -n "" > $TMP/diff
+
+line
+echo -e "${BLUE}$before -output=$OUT_BEFORE -multiple -target=$target $DIR/execute/*.v3${NC}"
+$before -output=$OUT_BEFORE -multiple -target=$target $DIR/execute/*.v3 &> /dev/null
+
+line
+echo -e "${BLUE}$after -output=$OUT_AFTER -multiple -target=$target $DIR/execute/*.v3${NC}"
+$after -output=$OUT_AFTER -multiple -target=$target $DIR/execute/*.v3 &> /dev/null
+
+line
+echo -e "${BLUE}diff -d $OUT_BEFORE $OUT_AFTER${NC}"
+DIFF=$(diff -d $OUT_BEFORE $OUT_AFTER)
+
+set -f
+IFS=$'\n'
+for l in $DIFF; do
+    file=$(echo $l | awk '{ print $3 }')
+    echo -n $(wc -c $file | awk '{ print $1 }') "" >> $TMP/diff
+    echo $l >> $TMP/diff
+done
+
+echo -e "${GREEN}Smallest binaries as per $TMP/diff${NC}:"
+sort -n $TMP/diff | head

--- a/test/common.bash
+++ b/test/common.bash
@@ -14,6 +14,7 @@ RUN_WASM=${RUN_WASM:=1}
 RUN_JVM=${RUN_JVM:=1}
 RUN_NATIVE=${RUN_NATIVE:=1}
 
+BLUE='[0;34m'
 GREEN='[0;32m'
 YELLOW='[0;33m'
 RED='[0;31m'
@@ -46,6 +47,15 @@ fi
 if [ -z "$TEST_D8" ]; then
     TEST_D8=$VIRGIL_LOC/bin/dev/d8
 fi
+
+function line() {
+    echo ================================================================================
+}
+
+function execute() {
+	echo % $@
+	$@
+}
 
 function print_status() {
     config=$(echo -n $2)
@@ -170,7 +180,7 @@ function execute_tests() {
 
     if [ "$RUN_JVM" = 1 ]; then
         compile_target_tests jvm -jvm.script=false
-        execute_target_tests jvm 
+        execute_target_tests jvm
     fi
 
     if [ "$RUN_NATIVE" = 1 ]; then

--- a/test/compare.bash
+++ b/test/compare.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+function line() {
+    echo ================================================================================
+}
+
+if [ $# != 4 ]; then
+    echo "Usage: compare.bash <target> <one test> <Aeneas before> <Aeneas after>"
+    exit 1
+fi
+
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+target=$1
+shift
+
+TEST=$1
+TEST_NO_EXT=${1%*.*}
+shift
+
+before=$1
+shift
+
+after=$1
+shift
+
+TMP=/tmp/$USER
+
+OUT_BEFORE=$TMP/before
+OUT_AFTER=$TMP/after
+
+mkdir -p $OUT_BEFORE
+mkdir -p $OUT_AFTER
+
+line
+echo -e "${BLUE}$before -print-ssa -print-mach -target=$target $TEST${NC}"
+$before -print-ssa -print-mach -print-bin -target=$target $TEST &> $TMP/before.out
+
+line
+echo -e "${BLUE}$after -print-ssa -print-mach -target=$target $TEST${NC}"
+$after -print-ssa -print-mach -print-bin -target=$target $TEST &> $TMP/after.out
+
+line
+echo -e "${BLUE}diff -u $TMP/before.out $TMP/after.out${NC}"
+diff -u $TMP/before.out $TMP/after.out

--- a/test/compare.bash
+++ b/test/compare.bash
@@ -1,46 +1,40 @@
 #!/bin/bash
 
-function line() {
-    echo ================================================================================
-}
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+    DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+. $DIR/common.bash compare
 
 if [ $# != 4 ]; then
     echo "Usage: compare.bash <target> <one test> <Aeneas before> <Aeneas after>"
     exit 1
 fi
 
-BLUE='\033[0;34m'
-NC='\033[0m'
-
 target=$1
-shift
+TEST=$2
+TEST_NO_EXT=${2%*.*}
+before=$3
+after=$4
 
-TEST=$1
-TEST_NO_EXT=${1%*.*}
-shift
-
-before=$1
-shift
-
-after=$1
-shift
-
-TMP=/tmp/$USER
-
-OUT_BEFORE=$TMP/before
-OUT_AFTER=$TMP/after
+OUT_BEFORE=$OUT/before
+OUT_AFTER=$OUT/after
 
 mkdir -p $OUT_BEFORE
 mkdir -p $OUT_AFTER
 
 line
-echo -e "${BLUE}$before -print-ssa -print-mach -target=$target $TEST${NC}"
-$before -print-ssa -print-mach -print-bin -target=$target $TEST &> $TMP/before.out
+echo -e "${BLUE}$before -print-ssa -print-mach -target=$target $TEST${NORM}"
+$before -print-ssa -print-mach -print-bin -target=$target $TEST &> $OUT/before.out
 
 line
-echo -e "${BLUE}$after -print-ssa -print-mach -target=$target $TEST${NC}"
-$after -print-ssa -print-mach -print-bin -target=$target $TEST &> $TMP/after.out
+echo -e "${BLUE}$after -print-ssa -print-mach -target=$target $TEST${NORM}"
+$after -print-ssa -print-mach -print-bin -target=$target $TEST &> $OUT/after.out
 
 line
-echo -e "${BLUE}diff -u $TMP/before.out $TMP/after.out${NC}"
-diff -u $TMP/before.out $TMP/after.out
+echo -e "${BLUE}diff -u $OUT/before.out $OUT/after.out${NORM}"
+diff -u --color=always $OUT/before.out $OUT/after.out

--- a/test/diagnose.bash
+++ b/test/diagnose.bash
@@ -29,15 +29,6 @@ if [ ! -e "$1" ]; then
         exit 1
 fi
 
-function execute() {
-	echo % $@
-	$@
-}
-
-function line() {
-    echo ================================================================================
-}
-
 line
 execute cat $TESTS
 


### PR DESCRIPTION
Adds two scripts:

1. `test/check-bootstrap.bash`: runs two different versions of Aeneas and outputs the ten smallest binaries which have differences (for ease of debugging).
2. `test/compare.bash`: runs two different versions of Aeneas on a particular test case and outputs the diff of the SSA, instructions, and binary. To be used in conjunction with the above.

~Kunal