### PR TITLE
Add register classes

### DIFF
--- a/aeneas/src/arm/ArmRegSet.v3
+++ b/aeneas/src/arm/ArmRegSet.v3
@@ -65,10 +65,7 @@ component ArmMachRegs {
 		rnames[GPR] = "{gpr}";
 		rnames[ALL] = "{all}";
 
-		var rclasses = Array<byte>.new(1);
-		rclasses[0] = GPR;
-
-		regs = MachRegSet.new(12, rarray, rnames, rclasses, R12, CALLER_SPILL_START, CALLEE_SPILL_START);
+		regs = MachRegSet.new(12, rarray, rnames, [GPR], R12, CALLER_SPILL_START, CALLEE_SPILL_START);
 	}
 }
 // Defines the standard parameter and return registers for Arm calls between Virgil methods.

--- a/aeneas/src/arm/ArmRegSet.v3
+++ b/aeneas/src/arm/ArmRegSet.v3
@@ -65,7 +65,10 @@ component ArmMachRegs {
 		rnames[GPR] = "{gpr}";
 		rnames[ALL] = "{all}";
 
-		regs = MachRegSet.new(12, rarray, rnames, R12, CALLER_SPILL_START, CALLEE_SPILL_START);
+		var rclasses = Array<byte>.new(1);
+		rclasses[0] = GPR;
+
+		regs = MachRegSet.new(12, rarray, rnames, rclasses, R12, CALLER_SPILL_START, CALLEE_SPILL_START);
 	}
 }
 // Defines the standard parameter and return registers for Arm calls between Virgil methods.

--- a/aeneas/src/mach/MachBackend.v3
+++ b/aeneas/src/mach/MachBackend.v3
@@ -20,12 +20,12 @@ class MachMoves {
 	var after: MoveResolver;	// phys -> phys moves, after
 }
 // Machine-independent representation of virtual register classes
-enum RegClass(kind: byte) {
-	REF(0x0),			// XXX: 0 -> GPR, 1 -> floating point register
-	I32(0x0),
-	I64(0x0),
-	F32(0x1),
-	F64(0x1)
+enum RegClass() {
+	REF,
+	I32,
+	I64,
+	F32,
+	F64
 }
 // Conversion functions from V3 Types to RegClasses
 component Regs {

--- a/aeneas/src/mach/MachBackend.v3
+++ b/aeneas/src/mach/MachBackend.v3
@@ -20,7 +20,7 @@ class MachMoves {
 	var after: MoveResolver;	// phys -> phys moves, after
 }
 // Machine-independent representation of virtual register classes
-enum RegClass() {
+enum RegClass {
 	REF,
 	I32,
 	I64,

--- a/aeneas/src/mach/MachBackend.v3
+++ b/aeneas/src/mach/MachBackend.v3
@@ -19,6 +19,33 @@ class MachMoves {
 	var valMoves: List<(Val, int)>; // value -> usepos moves, before
 	var after: MoveResolver;	// phys -> phys moves, after
 }
+// Machine-independent representation of virtual register classes
+enum RegClass(kind: byte) {
+	Ptr(0x0),			// XXX: 0 -> GPR, 1 -> floating point register
+	I32(0x0),
+	I64(0x0),
+	F32(0x1),
+	F64(0x1)
+}
+// Conversion functions from V3 Types to RegClasses
+component Regs {
+	def toRegClass(t: Type) -> RegClass {
+		match (t.typeCon.kind) {
+			V3Kind.INT => return toRegIntClass(IntType.!(t));
+			V3Kind.FLOAT => {
+				var ftc = Float_TypeCon.!(t.typeCon);
+				return if(ftc.is64, RegClass.F64, RegClass.F32);
+			}
+			V3Kind.ENUM => return toRegIntClass(V3.getVariantTagType(t));
+			V3Kind.ENUM_SET => return toRegIntClass(V3.getEnumSetType(t));
+			_ => return RegClass.I32;
+		}
+	}
+
+	def toRegIntClass(t: IntType) -> RegClass {
+		return if(t.width <= 32, RegClass.I32, RegClass.I64);
+	}
+}
 // Machine-independent representation of a virtual register.
 class VReg {
 	// -- state for code gen --------------------------------
@@ -30,6 +57,7 @@ class VReg {
 	var live: bool;			// true if live
 	// -- state for register allocation ---------------------
 	var hint: byte;			// physical register hint
+	var regClass: RegClass;		// required register type
 	var reg: byte;			// assigned physical register
 	var block: SsaBlock;
 	var prev: VReg;			// prev link for list management
@@ -57,8 +85,18 @@ class MachFrame(conv: MachCallConv) {
 	var spillArgs: int;		// space for outgoing spilled arguments
 	var frameSize: int = -1;	// architecture-specific total frame size
 
-	def allocSpill() -> int {
-		return conv.regSet.spillStart + spillVars++;
+	// TODO (kunal): allocate spill for doubles
+	// XXX (kunal): allocate double by using VReg.regClass as argument
+	def allocSpill(regClass: RegClass) -> int {
+		match (regClass) {
+			I64,
+			F64 => {
+				var spill = conv.regSet.spillStart + spillVars;
+				spillVars += 2;
+				return spill;
+			}
+			_ => return conv.regSet.spillStart + spillVars++;
+		}
 	}
 	def allocCallerSpace(conv: MachCallConv) -> MachCallConv {
 		allocOverflow(conv.overflow);
@@ -85,12 +123,13 @@ class MachRegSet {
 	def physRegs: int;			// number of physical registers
 	def regSets: Array<Array<byte>>;	// registers in each set
 	def names: Array<string>;		// names of each register and set
+	def regClasses: Array<byte>;	// registers in each class
 	def scratch: int;
-	def spillStart: int = regSets.length;	
+	def spillStart: int = regSets.length;
 	def callerStart: int;
 	def calleeStart: int;
 	def matrix = BitMatrix.new(physRegs + 1, regSets.length);
-	new(physRegs, regSets, names, scratch, callerStart, calleeStart) {
+	new(physRegs, regSets, names, regClasses, scratch, callerStart, calleeStart) {
 		// compute the matrix of physical register / register set membership
 		for (i < regSets.length) {
 			var rs = regSets[i];
@@ -160,7 +199,7 @@ class MachCallConv {
 	}
 }
 
-// Base class for machine code generators. 
+// Base class for machine code generators.
 class MachCodeGen(mach: MachProgram, context: SsaContext) {
 	def rt = mach.runtime;
 	def rtsrc = rt.src;

--- a/aeneas/src/mach/MachBackend.v3
+++ b/aeneas/src/mach/MachBackend.v3
@@ -85,12 +85,9 @@ class MachFrame(conv: MachCallConv) {
 	var spillArgs: int;		// space for outgoing spilled arguments
 	var frameSize: int = -1;	// architecture-specific total frame size
 
-	// TODO (kunal): allocate spill for doubles
-	// XXX (kunal): allocate double by using VReg.regClass as argument
 	def allocSpill(regClass: RegClass) -> int {
 		match (regClass) {
-			I64,
-			F64 => {
+			I64, F64 => { // TODO: alloc double spill for F32 as well
 				var spill = conv.regSet.spillStart + spillVars;
 				spillVars += 2;
 				return spill;
@@ -238,7 +235,10 @@ class MachCodeGen(mach: MachProgram, context: SsaContext) {
 		var max = context.graph.markGen;
 		if (i.mark >= max) return vars[i.mark - max]; // already has a variable
 		var isConst = SsaConst.?(i);
-		var num = numVars(i), vreg = VReg.new(i, vars.length, num, isConst);
+		var t = i.getType();
+		var num = Tuple.length(t);
+		var vreg = VReg.new(i, vars.length, num, isConst);
+		vreg.regClass = Regs.toRegClass(t);
 		vars.put(vreg);
 		while (--num > 0) vars.put(VReg.new(i, vars.length, 1, isConst));
 		i.mark = vreg.varNum + max; // maps instruction to var
@@ -421,7 +421,6 @@ class MachCodeGen(mach: MachProgram, context: SsaContext) {
 	def varOfUse(use: int) -> VReg {
 		return vars[uses[use] >>> VAR_SHIFT];
 	}
-	def numVars(i: SsaInstr) -> int;
 	def useType(u: int) -> string {
 		u = u & TYPE_MASK;
 		if (u == USE) return "use";

--- a/aeneas/src/mach/MachBackend.v3
+++ b/aeneas/src/mach/MachBackend.v3
@@ -21,7 +21,7 @@ class MachMoves {
 }
 // Machine-independent representation of virtual register classes
 enum RegClass(kind: byte) {
-	Ptr(0x0),			// XXX: 0 -> GPR, 1 -> floating point register
+	REF(0x0),			// XXX: 0 -> GPR, 1 -> floating point register
 	I32(0x0),
 	I64(0x0),
 	F32(0x1),

--- a/aeneas/src/mach/RegAlloc.v3
+++ b/aeneas/src/mach/RegAlloc.v3
@@ -189,15 +189,16 @@ class LinearScanRegAlloc {
 			}
 		}
 		// allocate a free register
-		for (i = 1; i < regState.length; i++) {
-			if (regState[i] == null && !mr.isOverwritten(i)) return i;
+		// TODO (kunal): account for regClass
+		for (r in regSet.regSets[regSet.regClasses[vreg.regClass.kind]]) {
+			if (regState[r] == null && !mr.isOverwritten(r)) return r;
 		}
 		// no free register, allocate a spill slot and immediately free it
-		if (vreg.isConst()) return freeSpill(allocSpill());
+		if (vreg.isConst()) return freeSpill(allocSpill(vreg.regClass));
 		else return spillVar(vreg);
 	}
-	def allocSpill() -> int {
-		if (freeSpills == null) return gen.frame.allocSpill();
+	def allocSpill(regClass: RegClass) -> int {
+		if (freeSpills == null) return gen.frame.allocSpill(regClass);
 		var pos = curPoint.pos;
 		if (freeSpillPos < freeSpills.length) {
 			// allocate spill from free list if possible
@@ -207,7 +208,7 @@ class LinearScanRegAlloc {
 				return t.1; // spill is now free
 			}
 		}
-		return gen.frame.allocSpill();
+		return gen.frame.allocSpill(regClass);
 	}
 	def freeSpill(spill: int) -> int {
 		if (spill <= 0) {
@@ -263,7 +264,7 @@ class LinearScanRegAlloc {
 		for (l = fixedList; l != null; l = l.tail) {
 			var i = l.head.0, dloc = l.head.1, vreg = getVar(i);
 			var vloc = allocReg(vreg);
-			
+
 			if ((uses[i] & gen.UNUSED_MASK) == 0) {
 				allocMovesAt(p.pos).after.addMove(dloc, vloc);
 				makeActive(vreg);
@@ -291,9 +292,10 @@ class LinearScanRegAlloc {
 				if (regState[r] == null) return vreg.reg = r;
 			}
 		}
-		// no hint, or nothing in the hint set is available
-		for (i = 1; i < regState.length; i++) {
-			if (regState[i] == null) return vreg.reg = byte.!(i);
+		// try to allocate a register from its register class
+		// TODO (kunal): account for regClass
+		for (r in regSet.regSets[regSet.regClasses[vreg.regClass.kind]]) {
+			if (regState[r] == null) return vreg.reg = r;
 		}
 		spillVar(vreg);
 		return vreg.spill;
@@ -329,7 +331,7 @@ class LinearScanRegAlloc {
 		}
 	}
 	def spillVar(vreg: VReg) -> int {
-		if (vreg.spill == 0) vreg.spill = allocSpill();
+		if (vreg.spill == 0) vreg.spill = allocSpill(vreg.regClass);
 		return vreg.spill;
 	}
 	def spillTempReg(mm: MachMoves, reg: int) -> int {
@@ -489,7 +491,7 @@ class IntervalBuilder(gen: MachCodeGen, regSet: MachRegSet) {
 				if (fixed == 0) next = USE;
 				else if (regSet.isMultiple(fixed)) next = USE_SET;
 				else next = USE_FIXED;
-			} 
+			}
 			else if (uv == gen.KILL) next = KILL;
 			else if (uv == gen.LIVE) next = KILL;
 			if (next < state) gen.mach.prog.ERROR.fail(Strings.format1("uses/defs out of order at %1", pos));
@@ -613,7 +615,7 @@ class IntervalPrinter(
 	new() {
 		for (i < live.length) live[i] = ' ';
 	}
-	
+
 	def print() {
 		var buf = StringBuffer.new();
 		// print out all LSRA points
@@ -689,7 +691,7 @@ class IntervalPrinter(
 		for (i = u.useStart; i < u.useEnd; i = i + 2) {
 			state[mapVar(gen.varOfUse(i).varNum)] = '+';
 		}
-	} 
+	}
 	def processDefs(d: LsraDef) {
 		for (i = d.defStart; i < d.defEnd; i = i + 2) {
 			var vreg = gen.varOfUse(i);
@@ -712,6 +714,6 @@ class IntervalPrinter(
 		if (LsraKill.?(l)) return ("kill");
 		if (LsraUse.?(l)) return ("use");
 		if (LsraDef.?(l)) return ("def");
-		return "unknown";		
+		return "unknown";
 	}
 }

--- a/aeneas/src/mach/RegAlloc.v3
+++ b/aeneas/src/mach/RegAlloc.v3
@@ -189,7 +189,6 @@ class LinearScanRegAlloc {
 			}
 		}
 		// allocate a free register
-		// TODO (kunal): account for regClass
 		for (r in regSet.regSets[regSet.regClasses[vreg.regClass.kind]]) {
 			if (regState[r] == null && !mr.isOverwritten(r)) return r;
 		}
@@ -293,7 +292,6 @@ class LinearScanRegAlloc {
 			}
 		}
 		// try to allocate a register from its register class
-		// TODO (kunal): account for regClass
 		for (r in regSet.regSets[regSet.regClasses[vreg.regClass.kind]]) {
 			if (regState[r] == null) return vreg.reg = r;
 		}

--- a/aeneas/src/mach/RegAlloc.v3
+++ b/aeneas/src/mach/RegAlloc.v3
@@ -189,7 +189,8 @@ class LinearScanRegAlloc {
 			}
 		}
 		// allocate a free register
-		for (r in regSet.regSets[regSet.regClasses[vreg.regClass.kind]]) {
+		var rclass = (vreg.regClass.tag + 1) >>> 2; // XXX: cheeky way to convert RegClass tag to index for regSet.regClasses
+		for (r in regSet.regSets[regSet.regClasses[rclass]]) {
 			if (regState[r] == null && !mr.isOverwritten(r)) return r;
 		}
 		// no free register, allocate a spill slot and immediately free it
@@ -292,7 +293,8 @@ class LinearScanRegAlloc {
 			}
 		}
 		// try to allocate a register from its register class
-		for (r in regSet.regSets[regSet.regClasses[vreg.regClass.kind]]) {
+		var rclass = (vreg.regClass.tag + 1) >>> 2; // XXX: cheeky way to convert RegClass tag to index for regSet.regClasses
+		for (r in regSet.regSets[regSet.regClasses[rclass]]) {
 			if (regState[r] == null) return vreg.reg = r;
 		}
 		spillVar(vreg);

--- a/aeneas/src/x86/X86CodeGen.v3
+++ b/aeneas/src/x86/X86CodeGen.v3
@@ -545,11 +545,6 @@ class X86CodeGen extends MachCodeGen {
 	def genSwitch(i: SsaSwitch) {
 		gen("sw", asm_tableswitch, (i, context.block.succs(), use(i.input0())));
 	}
-
-	def numVars(i: SsaInstr) -> int {
-		// a call could have multiple return values
-		return Tuple.length(i.getType());
-	}
 	// pattern-match a comparison
 	def matchCmp(i: SsaInstr) -> X86CmpMatch {
 		if (!inSameBlock(i) || !SsaApplyOp.?(i)) return X86CmpMatch.new(X86Conds.NZ, i, null, null);

--- a/aeneas/src/x86/X86RegSet.v3
+++ b/aeneas/src/x86/X86RegSet.v3
@@ -100,18 +100,16 @@ component X86VirgilCallConv {
 
 	private def compute(paramTypes: Array<Type>, returnTypes: Array<Type>) -> MachCallConv {
 		// compute the locations of each parameter
-		// TODO (kunal): check floating type V3Kind.FLOAT
 		var spillStart = X86MachRegs.regs.spillStart;
 		var ploc = Array<int>.new(paramTypes.length);
 		var pspill = 0, iprm = 0, fprm = 0;
 		for (i < ploc.length) {
 			match (Regs.toRegClass(paramTypes[i])) {
-				Ptr,
-				I32 => {
+				Ptr, I32 => {
 					if (iprm < paramRegs.length) ploc[i] = paramRegs[iprm++];
 					else ploc[i] = spillStart + pspill++;
 				}
-				F32 => {
+				F32 => { // TODO: make F32 also spill 2 slots
 					if (fprm < floatParamRegs.length) ploc[i] = floatParamRegs[fprm++];
 					else ploc[i] = spillStart + pspill++;
 				}
@@ -129,12 +127,11 @@ component X86VirgilCallConv {
 		if (returnTypes.length != 0) {	// XXX: working around the return count
 			for (i < rloc.length) {
 				match (Regs.toRegClass(returnTypes[i])) {
-					Ptr,
-					I32 => {
+					Ptr, I32 => {
 						if (iprm < retRegs.length) rloc[i] = retRegs[iprm++];
 						else rloc[i] = spillStart + rspill++;
 					}
-					F32 => {
+					F32 => { // TODO: make F32 also spill 2 slots
 						if (fprm < floatRetRegs.length) rloc[i] = floatRetRegs[fprm++];
 						else rloc[i] = spillStart + rspill++;
 					}

--- a/aeneas/src/x86/X86RegSet.v3
+++ b/aeneas/src/x86/X86RegSet.v3
@@ -3,19 +3,28 @@
 
 // Register sets for X86, used in register allocation.
 component X86MachRegs {
-	def EAX = '\x01'; // A
-	def ECX = '\x02'; // B
-	def EDX = '\x03'; // C
-	def EBX = '\x04'; // D
-	def ESI = '\x05'; // E
-	def EDI = '\x06'; // F
-	def EBP = '\x07'; // G
-	def GPR = '\x08';
-	def BYTE = '\x09';
-	def EAX_EDX = '\x0a';
-	def NOT_EDX = '\x0b';
-	def NOT_ECX = '\x0c';
-	def ALL = '\x0d';
+	def EAX = '\x01';
+	def ECX = '\x02';
+	def EDX = '\x03';
+	def EBX = '\x04';
+	def ESI = '\x05';
+	def EDI = '\x06';
+	def XMM0 = '\x07';
+	def XMM1 = '\x08';
+	def XMM2 = '\x09';
+	def XMM3 = '\x0a';
+	def XMM4 = '\x0b';
+	def XMM5 = '\x0c';
+	def XMM6 = '\x0d';
+	def XMM7 = '\x0e';
+	def EBP = '\x0f';
+	def GPR = '\x10';
+	def BYTE = '\x11';
+	def SSE = '\x12';
+	def EAX_EDX = '\x13';
+	def NOT_EDX = '\x14';
+	def NOT_ECX = '\x15';
+	def ALL = '\x16';
 	def SCRATCH = X86Regs.EBP;
 
 	// a billion spill slots ought to be enough...
@@ -32,13 +41,22 @@ component X86MachRegs {
 		rarray[EDX] = [EDX];
 		rarray[ESI] = [ESI];
 		rarray[EDI] = [EDI];
+		rarray[XMM0] = [XMM0];
+		rarray[XMM1] = [XMM1];
+		rarray[XMM2] = [XMM2];
+		rarray[XMM3] = [XMM3];
+		rarray[XMM4] = [XMM4];
+		rarray[XMM5] = [XMM5];
+		rarray[XMM6] = [XMM6];
+		rarray[XMM7] = [XMM7];
 		rarray[EBP] = [];	// XXX: EBP is off limits because it's scratch
-		rarray[BYTE] = [EDX, ECX, EAX, EBX];
 		rarray[GPR] = [EAX, EBX, ECX, EDX, ESI, EDI];
-		rarray[NOT_EDX] = [EAX, EBX, ECX, ESI, EDI];
-		rarray[ALL] = [EAX, EBX, ECX, EDX, ESI, EDI];
+		rarray[BYTE] = [EDX, ECX, EAX, EBX];
+		rarray[SSE] = [XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7];
 		rarray[EAX_EDX] = [EAX, EDX];
+		rarray[NOT_EDX] = [EAX, EBX, ECX, ESI, EDI];
 		rarray[NOT_ECX] = [EAX, EBX, EDX, ESI, EDI];
+		rarray[ALL] = [EAX, EBX, ECX, EDX, ESI, EDI, XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7];
 
 		var rnames = Array<string>.new(rarray.length);
 		rnames[EAX] = "eax";
@@ -47,38 +65,86 @@ component X86MachRegs {
 		rnames[EDX] = "edx";
 		rnames[ESI] = "esi";
 		rnames[EDI] = "edi";
+		rnames[XMM0] = "xmm0";
+		rnames[XMM1] = "xmm1";
+		rnames[XMM2] = "xmm2";
+		rnames[XMM3] = "xmm3";
+		rnames[XMM4] = "xmm4";
+		rnames[XMM5] = "xmm5";
+		rnames[XMM6] = "xmm6";
+		rnames[XMM7] = "xmm7";
 		rnames[EBP] = "ebp";
-		rnames[BYTE] = "{byte}";
 		rnames[GPR] = "{gpr}";
+		rnames[BYTE] = "{byte}";
+		rnames[SSE] = "{sse}";
 		rnames[EAX_EDX] = "{eax,edx}";
 		rnames[NOT_EDX] = "{~edx}";
+		rnames[NOT_ECX] = "{~ecx}";
 		rnames[ALL] = "{all}";
 
+		var rclasses = Array<byte>.new(2);
+		rclasses[0] = GPR;
+		rclasses[1] = SSE;
+
 		// XXX: don't use EBP for scratch
-		regs = MachRegSet.new(6, rarray, rnames, EBP, CALLER_SPILL_START, CALLEE_SPILL_START);
+		regs = MachRegSet.new(14, rarray, rnames, rclasses, EBP, CALLER_SPILL_START, CALLEE_SPILL_START);
 	}
 }
 // Defines the standard parameter and return registers for X86 calls between Virgil methods.
 component X86VirgilCallConv {
 	def paramRegs = [X86MachRegs.EDI, X86MachRegs.EAX, X86MachRegs.EDX, X86MachRegs.ECX, X86MachRegs.ESI];
 	def retRegs = [X86MachRegs.EAX, X86MachRegs.EDX, X86MachRegs.ECX, X86MachRegs.ESI];
-	
+	def floatParamRegs = [X86MachRegs.XMM0, X86MachRegs.XMM1, X86MachRegs.XMM2, X86MachRegs.XMM3,
+			X86MachRegs.XMM4, X86MachRegs.XMM5, X86MachRegs.XMM6];
+	def floatRetRegs = [X86MachRegs.XMM0, X86MachRegs.XMM1];
+
 	private def compute(paramTypes: Array<Type>, returnTypes: Array<Type>) -> MachCallConv {
 		// compute the locations of each parameter
+		// TODO (kunal): check floating type V3Kind.FLOAT
 		var spillStart = X86MachRegs.regs.spillStart;
 		var ploc = Array<int>.new(paramTypes.length);
-		var pspill = 0;
+		var pspill = 0, iprm = 0, fprm = 0;
 		for (i < ploc.length) {
-			if (i < paramRegs.length) ploc[i] = paramRegs[i];
-			else ploc[i] = spillStart + pspill++;
+			match (Regs.toRegClass(paramTypes[i])) {
+				Ptr,
+				I32 => {
+					if (iprm < paramRegs.length) ploc[i] = paramRegs[iprm++];
+					else ploc[i] = spillStart + pspill++;
+				}
+				F32 => {
+					if (fprm < floatParamRegs.length) ploc[i] = floatParamRegs[fprm++];
+					else ploc[i] = spillStart + pspill++;
+				}
+			} else { // I64 or F64
+				ploc[i] = spillStart + pspill;
+				pspill += 2;
+			}
 		}
 		// compute locations of each return value
 		var len = returnTypes.length;
 		if (len == 0) len = 1;  // TODO: fix return count
 		var rloc = Array<int>.new(len), rspill = 0;
-		for (i < rloc.length) {
-			if (i < retRegs.length) rloc[i] = retRegs[i];
-			else rloc[i] = spillStart + rspill++;
+		iprm = 0;
+		fprm = 0;
+		if (returnTypes.length != 0) {	// XXX: working around the return count
+			for (i < rloc.length) {
+				match (Regs.toRegClass(returnTypes[i])) {
+					Ptr,
+					I32 => {
+						if (iprm < retRegs.length) rloc[i] = retRegs[iprm++];
+						else rloc[i] = spillStart + rspill++;
+					}
+					F32 => {
+						if (fprm < floatRetRegs.length) rloc[i] = floatRetRegs[fprm++];
+						else rloc[i] = spillStart + rspill++;
+					}
+				} else { // I64 or F64
+					rloc[i] = spillStart + rspill;
+					rspill += 2;
+				}
+			}
+		} else {
+			rloc[0] = retRegs[0];
 		}
 		if (pspill > rspill) rspill = pspill;
 		return MachCallConv.new(X86MachRegs.regs, paramTypes, ploc, returnTypes, rloc, rspill);

--- a/aeneas/src/x86/X86RegSet.v3
+++ b/aeneas/src/x86/X86RegSet.v3
@@ -20,12 +20,14 @@ component X86MachRegs {
 	def EBP = '\x0f';
 	def GPR = '\x10';
 	def BYTE = '\x11';
-	def SSE = '\x12';
-	def EAX_EDX = '\x13';
-	def NOT_EDX = '\x14';
-	def NOT_ECX = '\x15';
-	def ALL = '\x16';
+	def EAX_EDX = '\x12';
+	def NOT_EDX = '\x13';
+	def NOT_ECX = '\x14';
+	def GPR_CLASS = '\x15';
+	def SSE_CLASS = '\x16';
+	def ALL = '\x1d';
 	def SCRATCH = X86Regs.EBP;
+	def SSE_SCRATCH = X86Regs.XMM7;
 
 	// a billion spill slots ought to be enough...
 	def CALLER_SPILL_START = 1000000000;
@@ -52,11 +54,17 @@ component X86MachRegs {
 		rarray[EBP] = [];	// XXX: EBP is off limits because it's scratch
 		rarray[GPR] = [EAX, EBX, ECX, EDX, ESI, EDI];
 		rarray[BYTE] = [EDX, ECX, EAX, EBX];
-		rarray[SSE] = [XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7];
 		rarray[EAX_EDX] = [EAX, EDX];
 		rarray[NOT_EDX] = [EAX, EBX, ECX, ESI, EDI];
 		rarray[NOT_ECX] = [EAX, EBX, EDX, ESI, EDI];
+		rarray[GPR_CLASS] = [EAX, ECX, EDX, EBX, ESI, EDI];
+		rarray[SSE_CLASS] = [XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7];
 		rarray[ALL] = [EAX, EBX, ECX, EDX, ESI, EDI, XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7];
+
+		// TODO: workaround for unstable move insertion order
+		for (i < rarray.length) {
+			if (rarray[i] == null) rarray[i] = [];
+		}
 
 		var rnames = Array<string>.new(rarray.length);
 		rnames[EAX] = "eax";
@@ -76,15 +84,21 @@ component X86MachRegs {
 		rnames[EBP] = "ebp";
 		rnames[GPR] = "{gpr}";
 		rnames[BYTE] = "{byte}";
-		rnames[SSE] = "{sse}";
 		rnames[EAX_EDX] = "{eax,edx}";
 		rnames[NOT_EDX] = "{~edx}";
 		rnames[NOT_ECX] = "{~ecx}";
+		rnames[GPR_CLASS] = "{gpr}";
+		rnames[SSE_CLASS] = "{sse}";
 		rnames[ALL] = "{all}";
 
+		// TODO: workaround for unstable move insertion order
+		for (i < rnames.length) {
+			if (rnames[i] == null) rnames[i] = [];
+		}
+
 		var rclasses = Array<byte>.new(2);
-		rclasses[0] = GPR;
-		rclasses[1] = SSE;
+		rclasses[0] = GPR_CLASS;
+		rclasses[1] = SSE_CLASS;
 
 		// XXX: don't use EBP for scratch
 		regs = MachRegSet.new(14, rarray, rnames, rclasses, EBP, CALLER_SPILL_START, CALLEE_SPILL_START);

--- a/aeneas/src/x86/X86RegSet.v3
+++ b/aeneas/src/x86/X86RegSet.v3
@@ -119,7 +119,7 @@ component X86VirgilCallConv {
 		var pspill = 0, iprm = 0, fprm = 0;
 		for (i < ploc.length) {
 			match (Regs.toRegClass(paramTypes[i])) {
-				Ptr, I32 => {
+				REF, I32 => {
 					if (iprm < paramRegs.length) ploc[i] = paramRegs[iprm++];
 					else ploc[i] = spillStart + pspill++;
 				}
@@ -127,9 +127,10 @@ component X86VirgilCallConv {
 					if (fprm < floatParamRegs.length) ploc[i] = floatParamRegs[fprm++];
 					else ploc[i] = spillStart + pspill++;
 				}
-			} else { // I64 or F64
-				ploc[i] = spillStart + pspill;
-				pspill += 2;
+				_ => { // I64 or F64
+					ploc[i] = spillStart + pspill;
+					pspill += 2;
+				}
 			}
 		}
 		// compute locations of each return value
@@ -141,7 +142,7 @@ component X86VirgilCallConv {
 		if (returnTypes.length != 0) {	// XXX: working around the return count
 			for (i < rloc.length) {
 				match (Regs.toRegClass(returnTypes[i])) {
-					Ptr, I32 => {
+					REF, I32 => {
 						if (iprm < retRegs.length) rloc[i] = retRegs[iprm++];
 						else rloc[i] = spillStart + rspill++;
 					}
@@ -149,9 +150,10 @@ component X86VirgilCallConv {
 						if (fprm < floatRetRegs.length) rloc[i] = floatRetRegs[fprm++];
 						else rloc[i] = spillStart + rspill++;
 					}
-				} else { // I64 or F64
-					rloc[i] = spillStart + rspill;
-					rspill += 2;
+					_ => { // I64 or F64
+						ploc[i] = spillStart + pspill;
+						pspill += 2;
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
This adds register classes which can be used to discriminate against floating-point or integer registers. Have to workaround the unstable move insertion order introduced by the hashing function.

Future PRs build on the above in order to add SSE support.

~Kunal