### PR TITLE
Refactor SSE instructions

### DIFF
--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -56,6 +56,9 @@ class X86Reg(name8: string, name16: string, name32: string, index: int) extends 
 	def plus(disp: int) -> X86Addr {
 		return X86Addr.new(null, this, 1, disp);
 	}
+	def plusSSE(disp: int) -> SSEAddr {
+		return SSEAddr.new(null, this, 1, disp);
+	}
 }
 // [base + index * scale + imm]
 class X86Addr(base: X86Reg, index: X86Reg, scale: byte, disp: int) extends X86Rm {
@@ -465,37 +468,17 @@ class X86Assembler(buffer: DataBuffer) {
 	def minsd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF2, 0x0F, 0x5D, a, b); }
 	def ucomisd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0x66, 0x0F, 0x2E, a, b); }
 
-	def cmpeqsd(a: SSEReg, b: SSERm) {
+	def cmpeqsd(a: SSEReg, b: SSERm) { cmpsd(a, b, 0x0); }
+	def cmpltsd(a: SSEReg, b: SSERm) { cmpsd(a, b, 0x1); }
+	def cmplesd(a: SSEReg, b: SSERm) { cmpsd(a, b, 0x2); }
+	def cmpunordsd(a: SSEReg, b: SSERm) { cmpsd(a, b, 0x3); }
+	def cmpneqsd(a: SSEReg, b: SSERm) { cmpsd(a, b, 0x4); }
+	def cmpnltsd(a: SSEReg, b: SSERm) { cmpsd(a, b, 0x5); }
+	def cmpnlesd(a: SSEReg, b: SSERm) { cmpsd(a, b, 0x6); }
+	def cmpordsd(a: SSEReg, b: SSERm) { cmpsd(a, b, 0x7); }
+	private def cmpsd(a: SSEReg, b: SSERm, c: byte) {
 		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
-		emitb(0x0);
-	}
-	def cmpltsd(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
-		emitb(0x1);
-	}
-	def cmplesd(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
-		emitb(0x2);
-	}
-	def cmpunordsd(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
-		emitb(0x3);
-	}
-	def cmpneqsd(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
-		emitb(0x4);
-	}
-	def cmpnltsd(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
-		emitb(0x5);
-	}
-	def cmpnlesd(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
-		emitb(0x6);
-	}
-	def cmpordsd(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF2, 0x0F, 0xC2, a, b);
-		emitb(0x7);
+		emitb(c);
 	}
 	def roundsd(a: SSEReg, b: SSERm, c: RoundingMode) {
 		emitbbbb_s_sm(0x66, 0x0F, 0x3A, 0x0B, a, b);
@@ -513,37 +496,17 @@ class X86Assembler(buffer: DataBuffer) {
 		emitbb(0x0F, 0x2E);
 		emit_sm(b, a.index);
 	}
-	def cmpeqss(a: SSEReg, b: SSERm) {
+	def cmpeqss(a: SSEReg, b: SSERm) { cmpss(a, b, 0x0); }
+	def cmpltss(a: SSEReg, b: SSERm) { cmpss(a, b, 0x1); }
+	def cmpless(a: SSEReg, b: SSERm) { cmpss(a, b, 0x2); }
+	def cmpunordss(a: SSEReg, b: SSERm) { cmpss(a, b, 0x3); }
+	def cmpneqss(a: SSEReg, b: SSERm) { cmpss(a, b, 0x4); }
+	def cmpnltss(a: SSEReg, b: SSERm) { cmpss(a, b, 0x5); }
+	def cmpnless(a: SSEReg, b: SSERm) { cmpss(a, b, 0x6); }
+	def cmpordss(a: SSEReg, b: SSERm) { cmpss(a, b, 0x7); }
+	private def cmpss(a: SSEReg, b: SSERm, c: byte) {
 		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
-		emitb(0x0);
-	}
-	def cmpltss(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
-		emitb(0x1);
-	}
-	def cmpless(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
-		emitb(0x2);
-	}
-	def cmpunordss(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
-		emitb(0x3);
-	}
-	def cmpneqss(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
-		emitb(0x4);
-	}
-	def cmpnltss(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
-		emitb(0x5);
-	}
-	def cmpnless(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
-		emitb(0x6);
-	}
-	def cmpordss(a: SSEReg, b: SSERm) {
-		emitbbb_s_sm(0xF3, 0x0F, 0xC2, a, b);
-		emitb(0x7);
+		emitb(c);
 	}
 	def roundss(a: SSEReg, b: SSERm, c: RoundingMode) {
 		emitbbbb_s_sm(0x66, 0x0F, 0x3A, 0x0A, a, b);
@@ -569,20 +532,25 @@ class X86Assembler(buffer: DataBuffer) {
 	def cvtss2sd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF3, 0x0F, 0x5A, a, b); }
 	def cvtsd2ss(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF2, 0x0F, 0x5A, a, b); }
 
-	def movss_m_s(a: X86Addr, b: SSEReg) { // store float
+	def movss_sm_s(a: SSERm, b: SSEReg) { // store float
 		emitbbb(0xF3, 0x0F, 0x11);
-		emit_rm(a, b.index);
+		emit_sm(a, b.index);
 	}
-	def movss_s_rm(a: SSEReg, b: X86Rm) { // load float
+	def movss_s_sm(a: SSEReg, b: SSERm) { // load float
 		emitbbb(0xF3, 0x0F, 0x10);
-		emit_rm(b, a.index);
+		emit_sm(b, a.index);
 	}
-	def movsd_m_s(a: X86Addr, b: SSEReg) { // store double
+	def movsd_sm_s(a: SSERm, b: SSEReg) { // store double
 		emitbbb(0xF2, 0x0F, 0x11);
-		emit_rm(a, b.index);
+		emit_sm(a, b.index);
 	}
-	def movsd_s_rm(a: SSEReg, b: X86Rm) { // load double
+	def movsd_s_sm(a: SSEReg, b: SSERm) { // load double
 		emitbbb(0xF2, 0x0F, 0x10);
+		emit_sm(b, a.index);
+	}
+
+	def movd_s_rm(a: SSEReg, b: X86Rm) {
+		emitbbb(0x66, 0x0F, 0x6E);
 		emit_rm(b, a.index);
 	}
 

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -6,10 +6,12 @@ def main(a: Array<string>) -> int {
 	var gen = X86AsmGen.new(a);
 
 	// SSE move instructions
-	gen.do_m_s("movss", gen.asm.movss_m_s);
-	gen.do_s_rm("movss", gen.asm.movss_s_rm);
-	gen.do_m_s("movsd", gen.asm.movsd_m_s);
-	gen.do_s_rm("movsd", gen.asm.movsd_s_rm);
+	gen.do_sm_s("movss", gen.asm.movss_sm_s);
+	gen.do_s_sm("movss", gen.asm.movss_s_sm);
+	gen.do_sm_s("movsd", gen.asm.movsd_sm_s);
+	gen.do_s_sm("movsd", gen.asm.movsd_s_sm);
+
+	gen.do_s_rm("movd", gen.asm.movd_s_rm);
 
 	gen.do_s_sm("addsd", gen.asm.addsd);
 	gen.do_s_sm("subsd", gen.asm.subsd);
@@ -160,6 +162,23 @@ class X86AsmGen(args: Array<string>) {
 				buf.puts(s.name);
 				buf.puts(", ");
 				addr.render(buf);
+				buf.puts(" ;;== ");
+				render();
+				Terminal.putbln(buf);
+			}
+		}
+	}
+
+	def do_sm_s(mnemonic: string, asm_func: (SSERm, SSEReg) -> void) {
+		if (skip(mnemonic)) return;
+		for (addr in SSE_ADDRS) {
+			for (s in [X86Regs.XMM0, X86Regs.XMM1, X86Regs.XMM7]) {
+				asm_func(addr, s);
+				buf.reset();
+				buf.puts(mnemonic).sp();
+				addr.render(buf);
+				buf.puts(", ");
+				buf.puts(s.name);
 				buf.puts(" ;;== ");
 				render();
 				Terminal.putbln(buf);


### PR DESCRIPTION
Refactors the comparison instructions to reduce repeated code. Code is more in-line with `cmov()` now. Also updates the move instructions to reflect the actual operands they can take. 