### PR TITLE
Add move from xmm to r/m32

### DIFF
--- a/aeneas/src/main/Version.v3
+++ b/aeneas/src/main/Version.v3
@@ -3,6 +3,6 @@
 
 // Updated by VCS scripts. DO NOT EDIT.
 component Version {
-	def version: string = "III-5.1160";
+	def version: string = "III-5.1161";
 	var buildData: string;
 }

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -553,6 +553,10 @@ class X86Assembler(buffer: DataBuffer) {
 		emitbbb(0x66, 0x0F, 0x6E);
 		emit_rm(b, a.index);
 	}
+	def movd_rm_s(a: X86Rm, b: SSEReg) {
+		emitbbb(0x66, 0x0F, 0x7E);
+		emit_rm(a, b.index);
+	}
 
 	def emitbbb_s_sm(b1: byte, b2: byte, b3: byte, a: SSEReg, b: SSERm) {
 		emitbbb(b1, b2, b3);

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -12,6 +12,7 @@ def main(a: Array<string>) -> int {
 	gen.do_s_sm("movsd", gen.asm.movsd_s_sm);
 
 	gen.do_s_rm("movd", gen.asm.movd_s_rm);
+	gen.do_rm_s("movd", gen.asm.movd_rm_s);
 
 	gen.do_s_sm("addsd", gen.asm.addsd);
 	gen.do_s_sm("subsd", gen.asm.subsd);
@@ -94,12 +95,18 @@ class X86AsmGen(args: Array<string>) {
 
 	def do_rm_s(mnemonic: string, asm_func: (X86Rm, SSEReg) -> void) {
 		if (skip(mnemonic)) return;
-		var addr = X86Regs.EAX.indirect();
-		for (s in [X86Regs.XMM0, X86Regs.XMM1, X86Regs.XMM7]) {
-			asm_func(addr, s);
-			buf.reset();
-			render();
-			Terminal.putbln(buf);
+		for (addr in ADDRS) {
+			for (s in [X86Regs.XMM0, X86Regs.XMM1, X86Regs.XMM7]) {
+				asm_func(addr, s);
+				buf.reset();
+				buf.puts(mnemonic).sp();
+				addr.render(buf);
+				buf.puts(", ");
+				buf.puts(s.name);
+				buf.puts(" ;;== ");
+				render();
+				Terminal.putbln(buf);
+			}
 		}
 	}
 	def do_m_s(mnemonic: string, asm_func: (X86Addr, SSEReg) -> void) {


### PR DESCRIPTION
Adds `movd r/m32, xmm` instruction. This will be used to implement the `int.view(float)` functionality.

~Kunal