### PR TITLE
Improve support for SSE instruction generation

### DIFF
--- a/aeneas/src/main/Version.v3
+++ b/aeneas/src/main/Version.v3
@@ -3,6 +3,6 @@
 
 // Updated by VCS scripts. DO NOT EDIT.
 component Version {
-	def version: string = "III-5.1176";
+	def version: string = "III-5.1177";
 	var buildData: string;
 }

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -579,6 +579,16 @@ class X86Assembler(buffer: DataBuffer) {
 	def pslld_i(a: SSEReg, imm: byte) { emitbbb_si_b(0x66, 0x0F, 0x72, a, 0x6, imm); }
 	def psllq_i(a: SSEReg, imm: byte) { emitbbb_si_b(0x66, 0x0F, 0x73, a, 0x6, imm); }
 
+	// x87 FPU instructions
+	def fld_d(a: SSEAddr) {
+		emitb(0xD9);
+		emit_sm(a, 0x0);
+	}
+	def fisttp_q(a: SSEAddr) {
+		emitb(0xDD);
+		emit_sm(a, 0x1);
+	}
+
 	def emitbbb_s_sm(b1: byte, b2: byte, b3: byte, a: SSEReg, b: SSERm) {
 		emitbbb(b1, b2, b3);
 		emit_sm(b, a.index);

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -569,8 +569,27 @@ class X86Assembler(buffer: DataBuffer) {
 		emit_rm(a, b.index);
 	}
 
+	def andps(a: SSEReg, b: SSERm) { emitbb_s_sm(0x0F, 0x54, a, b); }
+	def andpd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0x66, 0x0F, 0x54, a, b); }
+	def xorps(a: SSEReg, b: SSERm) { emitbb_s_sm(0x0F, 0x57, a, b); }
+	def xorpd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0x66, 0x0F, 0x57, a, b); }
+
+	def psrld_i(a: SSEReg, imm: byte) { emitbbb_si_b(0x66, 0x0F, 0x72, a, 0x2, imm); }
+	def psrlq_i(a: SSEReg, imm: byte) { emitbbb_si_b(0x66, 0x0F, 0x73, a, 0x2, imm); }
+	def pslld_i(a: SSEReg, imm: byte) { emitbbb_si_b(0x66, 0x0F, 0x72, a, 0x6, imm); }
+	def psllq_i(a: SSEReg, imm: byte) { emitbbb_si_b(0x66, 0x0F, 0x73, a, 0x6, imm); }
+
 	def emitbbb_s_sm(b1: byte, b2: byte, b3: byte, a: SSEReg, b: SSERm) {
 		emitbbb(b1, b2, b3);
+		emit_sm(b, a.index);
+	}
+	def emitbbb_si_b(b1: byte, b2: byte, b3: byte, a: SSEReg, b: int, c: byte) {
+		emitbbb(b1, b2, b3);
+		emit_sm(a, b);
+		emitb(c);
+	}
+	def emitbb_s_sm(b1: byte, b2: byte, a: SSEReg, b: SSERm) {
+		emitbb(b1, b2);
 		emit_sm(b, a.index);
 	}
 

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -68,6 +68,7 @@ class X86Addr(base: X86Reg, index: X86Reg, scale: byte, disp: int) extends X86Rm
 		}
 	}
 	def absolute() -> bool { return base == null && index == null; }
+	def toSSEAddr() -> SSEAddr { return SSEAddr.new(base, index, scale, disp); }
 }
 class SSERm {
 	def render(buf: StringBuffer) -> StringBuffer {
@@ -86,6 +87,7 @@ class SSEAddr(base: X86Reg, index: X86Reg, scale: byte, disp: int) extends SSERm
 		}
 	}
 	def absolute() -> bool { return base == null && index == null; }
+	def toX86Addr() -> X86Addr { return X86Addr.new(base, index, scale, disp); }
 }
 // global constants representing registers
 component X86Regs {

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -579,6 +579,9 @@ class X86Assembler(buffer: DataBuffer) {
 	def pslld_i(a: SSEReg, imm: byte) { emitbbb_si_b(0x66, 0x0F, 0x72, a, 0x6, imm); }
 	def psllq_i(a: SSEReg, imm: byte) { emitbbb_si_b(0x66, 0x0F, 0x73, a, 0x6, imm); }
 
+	def pcmpeqd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0x66, 0x0F, 0x76, a, b); }
+	def pcmpeqq(a: SSEReg, b: SSERm) { emitbbbb_s_sm(0x66, 0x0F, 0x38, 0x29, a, b); }
+
 	// x87 FPU instructions
 	def fld_d(a: SSEAddr) {
 		emitb(0xD9);

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -534,6 +534,14 @@ class X86Assembler(buffer: DataBuffer) {
 	}
 	def cvtss2sd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF3, 0x0F, 0x5A, a, b); }
 	def cvtsd2ss(a: SSEReg, b: SSERm) { emitbbb_s_sm(0xF2, 0x0F, 0x5A, a, b); }
+	def cvttss2si(a: X86Reg, b: SSERm) {
+		emitbbb(0xF3, 0x0F, 0x2C);
+		emit_sm(b, a.index);
+	}
+	def cvttsd2si(a: X86Reg, b: SSERm) {
+		emitbbb(0xF2, 0x0F, 0x2C);
+		emit_sm(b, a.index);
+	}
 
 	def movss_sm_s(a: SSERm, b: SSEReg) { // store float
 		emitbbb(0xF3, 0x0F, 0x11);

--- a/aeneas/src/x86/X86MacroAssembler.v3
+++ b/aeneas/src/x86/X86MacroAssembler.v3
@@ -78,26 +78,22 @@ class X86MacroAssembler extends X86Assembler {
 		if (s == d) return;
 		if (SSEReg.?(d)) return movsd_s_sm(SSEReg.!(d), s);
 		if (SSEReg.?(s)) return movsd_sm_s(d, SSEReg.!(s));
-		if (scratch != null) {
-			movsd_s_sm(scratch, s);
-			movsd_sm_s(d, scratch);
-		}
-		// push(s);            // push value from source memory onto the stack
-		// pop(SSEAddr.!(d));  // pop value off stack into destination memory
+		movsd_s_sm(scratch, s);
+		movsd_sm_s(d, scratch);
 	}
 	// a macro to move a value into a location
 	def movd_l_val(frame: MachFrame, loc: int, val: Val) {
-		if (loc >= X86MachRegs.XMM0 && loc <= X86MachRegs.XMM7
-				|| Float32Val.?(val)) {
+		if (loc >= X86MachRegs.XMM0 && loc <= X86MachRegs.XMM7) {
 			movd_l_fval(frame, loc, val);
 		} else {
 			var d = loc_rm(frame, loc);
 			match (val) {
 				x: Addr => {
-						 var pos = buffer.pos;
-						 movd_rm_i(d, X86Addrs.ABS_CONST);
-						 recordPatch(pos, x);
+					var pos = buffer.pos;
+					movd_rm_i(d, X86Addrs.ABS_CONST);
+					recordPatch(pos, x);
 				}
+				x: Float32Val => movd_l_fval(frame, loc, x); // TODO: Float64Val case
 				_ => movd_rm_i(d, V3.unboxIntegral(val));
 			}
 		}
@@ -109,7 +105,7 @@ class X86MacroAssembler extends X86Assembler {
 		if (val != null) {
 			match (val) {
 				x: Float32Val => f = int.view(x.bits);
-				x: Float64Val => f = int.view(x.bits);
+				x: Float64Val => f = int.view(x.bits); // TODO: fix Float64Val case
 			}
 		}
 		movd_rm_i(X86Regs.EBP, f);
@@ -140,11 +136,7 @@ class X86MacroAssembler extends X86Assembler {
 			X86MachRegs.EDI => return edi;
 			X86MachRegs.EBP => return ebp;
 		}
-		var regSet = frame.conv.regSet, wordSize = mach.data.addressSize, offset: int;
-		if (loc >= regSet.calleeStart) offset = wordSize * (loc - regSet.calleeStart);
-		else if (loc >= regSet.callerStart) offset = frame.size() + (wordSize * (loc - regSet.callerStart));
-		else if (loc >= regSet.spillStart) offset = wordSize * (loc - regSet.spillStart + frame.spillArgs);
-		else return failLocation("invalid spill location", loc, frame.conv.regSet);
+		var offset = calc_offset(frame, loc, false);
 		return esp.plus(offset);
 	}
 	def failLocation(msg: string, loc: int, regSet: MachRegSet) -> X86Reg {
@@ -178,16 +170,26 @@ class X86MacroAssembler extends X86Assembler {
 			X86MachRegs.XMM6 => return xmm6;
 			X86MachRegs.XMM7 => return xmm7;
 		}
-		var regSet = frame.conv.regSet, wordSize = mach.data.addressSize, offset: int;
-		if (loc >= regSet.calleeStart) offset = wordSize * (loc - regSet.calleeStart);
-		else if (loc >= regSet.callerStart) offset = frame.size() + (wordSize * (loc - regSet.callerStart));
-		else if (loc >= regSet.spillStart) offset = wordSize * (loc - regSet.spillStart + frame.spillArgs);
-		else return failSSELocation("invalid spill location", loc, frame.conv.regSet);
+		var offset = calc_offset(frame, loc, true);
 		return esp.plusSSE(offset);
 	}
 	def failSSELocation(msg: string, loc: int, regSet: MachRegSet) -> SSEReg {
 		mach.fail(Strings.format2("%1: %2", msg, regSet.identify(loc)));
 		return X86MachRegs.SSE_SCRATCH;
+	}
+	def calc_offset(frame: MachFrame, loc: int, isSSE: bool) -> int {
+		var regSet = frame.conv.regSet, wordSize = mach.data.addressSize;
+		if (loc >= regSet.calleeStart) {
+			return wordSize * (loc - regSet.calleeStart);
+		} else if (loc >= regSet.callerStart) {
+			return frame.size() + (wordSize * (loc - regSet.callerStart));
+		} else if (loc >= regSet.spillStart) {
+			return wordSize * (loc - regSet.spillStart + frame.spillArgs);
+		} else {
+			if (isSSE) failSSELocation("invalid spill location", loc, regSet);
+			else failLocation("invalid spill location", loc, regSet);
+			return 0;
+		}
 	}
 	// patch an absolute address, scanning backwards up to "start"
 	def recordPatch(start: int, target: Addr) {

--- a/aeneas/src/x86/X86MacroAssembler.v3
+++ b/aeneas/src/x86/X86MacroAssembler.v3
@@ -9,6 +9,14 @@ def edi = X86Regs.EDI;
 def esi = X86Regs.ESI;
 def ebp = X86Regs.EBP;
 def esp = X86Regs.ESP;
+def xmm0 = X86Regs.XMM0;
+def xmm1 = X86Regs.XMM1;
+def xmm2 = X86Regs.XMM2;
+def xmm3 = X86Regs.XMM3;
+def xmm4 = X86Regs.XMM4;
+def xmm5 = X86Regs.XMM5;
+def xmm6 = X86Regs.XMM6;
+def xmm7 = X86Regs.XMM7;
 
 def gen_i64_divmod_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int, op: WideDivision) {
 	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
@@ -51,22 +59,51 @@ class X86MacroAssembler extends X86Assembler {
 		push(s);            // push value from source memory onto the stack
 		pop(X86Addr.!(d));  // pop value off stack into destination memory
 	}
+	// a macro to move between any two SSE register/memory operands
+	def movsd_sm_sm(d: SSERm, s: SSERm, scratch: SSEReg) {
+		if (s == d) return;
+		if (SSEReg.?(d)) return movsd_s_sm(SSEReg.!(d), s);
+		if (SSEReg.?(s)) return movsd_sm_s(d, SSEReg.!(s));
+		if (scratch != null) {
+			movsd_s_sm(scratch, s);
+			movsd_sm_s(d, scratch);
+		}
+		// push(s);            // push value from source memory onto the stack
+		// pop(SSEAddr.!(d));  // pop value off stack into destination memory
+	}
 	// a macro to move a value into a location
 	def movd_l_val(frame: MachFrame, loc: int, val: Val) {
-		var d = loc_rm(frame, loc);
-		if (val == null) {
-			movd_rm_i(d, 0);
-		} else if (Addr.?(val)) {
-			var pos = buffer.pos;
-			movd_rm_i(d, X86Addrs.ABS_CONST);
-			recordPatch(pos, Addr.!(val));
+		if (loc >= X86MachRegs.XMM0 && loc <= X86MachRegs.XMM7
+				|| Float32Val.?(val)) {
+			movd_l_fval(frame, loc, val);
 		} else {
-			movd_rm_i(d, V3.unboxIntegral(val));
+			var d = loc_rm(frame, loc);
+			match (val) {
+				x: Addr => {
+						 var pos = buffer.pos;
+						 movd_rm_i(d, X86Addrs.ABS_CONST);
+						 recordPatch(pos, x);
+				}
+				_ => movd_rm_i(d, V3.unboxIntegral(val));
+			}
 		}
+	}
+	// a macro to move a value into an SSE location
+	def movd_l_fval(frame: MachFrame, loc: int, val: Val) {
+		var f = 0;
+		var d = loc_sm(frame, loc);
+		if (val != null) {
+			match (val) {
+				x: Float32Val => f = int.view(x.bits);
+				x: Float64Val => f = int.view(x.bits);
+			}
+		}
+		movd_rm_i(X86Regs.EBP, f);
+		movd_s_rm(SSEReg.!(d), X86Regs.EBP); // cast will never fail since we know d is an SSEReg from loc
 	}
 	// convert a location into an x86 register
 	def loc_r(frame: MachFrame, loc: int) -> X86Reg {
-		match(loc) {
+		match (loc) {
 			X86MachRegs.EAX => return eax;
 			X86MachRegs.EBX => return ebx;
 			X86MachRegs.ECX => return ecx;
@@ -79,7 +116,7 @@ class X86MacroAssembler extends X86Assembler {
 	}
 	// convert a location into an x86 register/memory reference
 	def loc_rm(frame: MachFrame, loc: int) -> X86Rm {
-		match(loc) {
+		match (loc) {
 			0 => return failLocation("unassigned location", loc, frame.conv.regSet);
 			X86MachRegs.EAX => return eax;
 			X86MachRegs.EBX => return ebx;
@@ -99,6 +136,44 @@ class X86MacroAssembler extends X86Assembler {
 	def failLocation(msg: string, loc: int, regSet: MachRegSet) -> X86Reg {
 		mach.fail(Strings.format2("%1: %2", msg, regSet.identify(loc)));
 		return X86MachRegs.SCRATCH;
+	}
+	// convert a location into an SSE register
+	def loc_s(frame: MachFrame, loc: int) -> SSEReg {
+		match (loc) {
+			X86MachRegs.XMM0 => return xmm0;
+			X86MachRegs.XMM1 => return xmm1;
+			X86MachRegs.XMM2 => return xmm2;
+			X86MachRegs.XMM3 => return xmm3;
+			X86MachRegs.XMM4 => return xmm4;
+			X86MachRegs.XMM5 => return xmm5;
+			X86MachRegs.XMM6 => return xmm6;
+			X86MachRegs.XMM7 => return xmm7;
+		}
+		return failSSELocation("required SSE register", loc, frame.conv.regSet);
+	}
+	// convert a location into an SSE register/memory reference
+	def loc_sm(frame: MachFrame, loc: int) -> SSERm {
+		match (loc) {
+			0 => return failSSELocation("unassigned location", loc, frame.conv.regSet);
+			X86MachRegs.XMM0 => return xmm0;
+			X86MachRegs.XMM1 => return xmm1;
+			X86MachRegs.XMM2 => return xmm2;
+			X86MachRegs.XMM3 => return xmm3;
+			X86MachRegs.XMM4 => return xmm4;
+			X86MachRegs.XMM5 => return xmm5;
+			X86MachRegs.XMM6 => return xmm6;
+			X86MachRegs.XMM7 => return xmm7;
+		}
+		var regSet = frame.conv.regSet, wordSize = mach.data.addressSize, offset: int;
+		if (loc >= regSet.calleeStart) offset = wordSize * (loc - regSet.calleeStart);
+		else if (loc >= regSet.callerStart) offset = frame.size() + (wordSize * (loc - regSet.callerStart));
+		else if (loc >= regSet.spillStart) offset = wordSize * (loc - regSet.spillStart + frame.spillArgs);
+		else return failSSELocation("invalid spill location", loc, frame.conv.regSet);
+		return esp.plusSSE(offset);
+	}
+	def failSSELocation(msg: string, loc: int, regSet: MachRegSet) -> SSEReg {
+		mach.fail(Strings.format2("%1: %2", msg, regSet.identify(loc)));
+		return X86MachRegs.SSE_SCRATCH;
 	}
 	// patch an absolute address, scanning backwards up to "start"
 	def recordPatch(start: int, target: Addr) {

--- a/aeneas/src/x86/X86MacroAssembler.v3
+++ b/aeneas/src/x86/X86MacroAssembler.v3
@@ -574,6 +574,27 @@ class X86MacroAssembler extends X86Assembler {
 	def int_truncd(a: X86Reg, b: SSERm) {
 		cvttsd2si(a, b);
 	}
+	def cmp_fp(cond: X86Cond, dest: X86Reg, a: SSEReg, b: SSERm, isDouble: bool) {
+		if (cond == X86Conds.NZ) movd_rm_i(dest, 0x1); // XXX: if unordered result, then default for != is true
+		else movd_rm_i(dest, 0x0);
+		if (isDouble) ucomisd(a, b);
+		else ucomiss(a, b);
+		var label = Label.new();
+		jmpl_near(X86Conds.P, label);
+		setx(cond, dest);
+		bind(label);
+	}
+	def fabs(dest: SSEReg, a: SSERm, isDouble: bool) {
+		if (isDouble) {
+			if (dest != a) movsd_s_sm(dest, a);
+			psllq_i(dest, 0x1); // lsl followed by lsr to zero out sign bit
+			psrlq_i(dest, 0x1);
+		} else {
+			if (dest != a) movss_s_sm(dest, a);
+			pslld_i(dest, 0x1);
+			psrld_i(dest, 0x1);
+		}
+	}
 }
 // A helper for generating shift operations for a given V3 opcode.
 class X86Shifter(opcode: Opcode) {

--- a/aeneas/src/x86/X86MacroAssembler.v3
+++ b/aeneas/src/x86/X86MacroAssembler.v3
@@ -574,6 +574,18 @@ class X86MacroAssembler extends X86Assembler {
 	def int_truncd(a: X86Reg, b: SSERm) {
 		cvttsd2si(a, b);
 	}
+	def fp_bit_eq(dest: X86Reg, a: SSEReg, b: SSERm, isDouble: bool) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		if (isDouble) {
+			if (a != sse_scratch) movsd_s_sm(sse_scratch, a);
+			pcmpeqq(sse_scratch, b);
+		} else {
+			if (a != sse_scratch) movss_s_sm(sse_scratch, a);
+			pcmpeqd(sse_scratch, b);
+		}
+		movd_rm_s(dest, sse_scratch);
+		and.rm_i(dest, 0x1);
+	}
 	def cmp_fp(cond: X86Cond, dest: X86Reg, a: SSEReg, b: SSERm, isDouble: bool) {
 		if (cond == X86Conds.NZ) movd_rm_i(dest, 0x1); // XXX: if unordered result, then default for != is true
 		else movd_rm_i(dest, 0x0);

--- a/aeneas/src/x86/X86MacroAssembler.v3
+++ b/aeneas/src/x86/X86MacroAssembler.v3
@@ -23,6 +23,20 @@ def gen_i64_divmod_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeSt
 	asm.wdiv_full(op, null, true);
 	asm.ret();
 }
+def gen_f2i_fixup_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int) {
+	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
+	asm.f2i_fixup();
+	asm.ret();
+}
+def gen_ui2f_fixup_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int) {
+	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
+	asm.ui2f_fixup();
+	asm.ret();
+}
+def gen_f2ui_fixup_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int) {
+	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
+	asm.f2ui_fixup();
+}
 
 // An extended X86Assembler that has additional machine-level utilities, such as
 // recording patch locations and translating between regset locations and x86
@@ -394,6 +408,171 @@ class X86MacroAssembler extends X86Assembler {
 			movd_rm_r(edx, esi);
 		}
 		if (frame != null) mach.runtime.src.recordFrameEnd(codeOffset());
+	}
+
+	def cast_f2ui(dest: X86Reg, a: SSERm) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plusSSE(0x0);
+		sub.rm_i(esp, 0x8);
+		if (SSEAddr.?(a)) {
+			fld_d(SSEAddr.!(a));
+		} else {
+			movss_sm_s(save, SSEReg.!(a));
+			fld_d(save);
+		}
+		fisttp_q(save);
+		movd_r_rm(dest, save.toX86Addr());
+		add.rm_i(esp, 0x8);
+	}
+	def cast_d2ui(dest: X86Reg, a: SSERm) {
+		// TODO: convert double to unsigned int
+	}
+	def f2ui_fixup() {
+		var scratch = X86MachRegs.SCRATCH;
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var inout = esp.plus(4 * 0x4); // return address + 3 saves
+		var inout_sse = inout.toSSEAddr();
+		var xmm0_save = esp.plusSSE(2 * 0x4);
+		var save = esp.plusSSE(0x0);
+		var L1 = Label.new(), L2 = Label.new();
+		sub.rm_i(esp, 0xC);
+		movss_sm_s(xmm0_save, xmm0);
+		movss_s_sm(xmm0, inout_sse);
+		xorps(sse_scratch, sse_scratch);
+		ucomiss(sse_scratch, xmm0); // if (f <= 0) return 0
+		jmpl_near(X86Conds.NC, L1);
+		movd_rm_i(scratch, 0x4f800000); // if (f >= 4294967296) return MAX_U32_INT
+		movd_s_rm(sse_scratch, scratch);
+		ucomiss(xmm0, sse_scratch);
+		jmpl_near(X86Conds.C, L2);
+		movd_rm_i(inout, 0xffffffff);
+		movss_s_sm(xmm0, xmm0_save);
+		add.rm_i(esp, 0xC);
+		ret();
+		bind(L2); // else return (unsigned int)f
+		movss_sm_s(save, xmm0);
+		fld_d(save);
+		fisttp_q(save);
+		movd_r_rm(scratch, save.toX86Addr());
+		movd_rm_r(inout, scratch);
+		movss_s_sm(xmm0, xmm0_save);
+		add.rm_i(esp, 0xC);
+		ret();
+		bind(L1);
+		movd_rm_i(inout, 0x0);
+		movss_s_sm(xmm0, xmm0_save);
+		add.rm_i(esp, 0xC);
+		ret();
+	}
+	def uint_truncf(dest: X86Reg, a: SSERm) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plusSSE(0x0);
+		sub.rm_i(esp, 0x4);
+		if (SSEReg.?(a)) {
+			movss_sm_s(save, SSEReg.!(a));
+		} else {
+			movss_s_sm(sse_scratch, a);
+			movss_sm_s(save, sse_scratch);
+		}
+		var name = "f2ui_fixup";
+		var addr = mach.stubMap[name].0;
+		if (addr == null) {
+			addr = Address.new(mach.codeRegion, name);
+			mach.stubMap[name] = (addr, gen_f2ui_fixup_stub(mach, _, _, codeStartOffset));
+		}
+		call_addr(addr);
+		pop(dest);
+	}
+	def uint_truncd(dest: X86Reg, a: SSERm) {
+		// TODO: convert double to unsigned int with truncation
+	}
+	def ui2f_fixup() {
+		var scratch = X86MachRegs.SCRATCH;
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plus(2 * 0x4); // return address + 1 save
+		var done = Label.new();
+		push(eax);
+		movd_r_rm(scratch, save);
+		cvtsi2ss(sse_scratch, scratch);
+		test_rm_r(scratch, scratch);
+		jmpl_near(X86Conds.GE, done);
+		movd_r_rm(eax, scratch);
+		shr_i(scratch, 0x1);
+		and.rm_i(eax, 0x1);
+		or.r_rm(eax, scratch);
+		cvtsi2ss(sse_scratch, eax);
+		addss(sse_scratch, sse_scratch); // return value in sse_scratch
+		bind(done);
+		pop(eax);
+	}
+	def cast_ui2f(dest: SSEReg, a: X86Rm) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plusSSE(0x0);
+		push(a);
+		var name = "ui2f_fixup";
+		var addr = mach.stubMap[name].0;
+		if (addr == null) {
+			addr = Address.new(mach.codeRegion, name);
+			mach.stubMap[name] = (addr, gen_ui2f_fixup_stub(mach, _, _, codeStartOffset));
+		}
+		call_addr(addr);
+		add.rm_i(esp, 0x4);
+		movss_s_sm(dest, sse_scratch); // return value in sse_scratch
+	}
+	def cast_ui2d(dest: SSEReg, a: X86Rm) {
+		// TODO: convert unsigned int to double
+	}
+	def f2i_fixup() {
+		var scratch = X86MachRegs.SCRATCH;
+		var inout = esp.plus(4 * 0x4); // return address + 3 saves
+		var done = Label.new();
+		push(eax);
+		push(ecx);
+		push(edx);
+		movd_rm_i(eax, 0x7f800000);
+		xor.r_rm(ecx, ecx);
+		movd_r_rm(scratch, inout);
+		movd_r_rm(edx, scratch);
+		and.rm_i(edx, 0x7fffffff);
+		cmp.r_rm(eax, edx); // if NaN -> 0
+		jmpl_near(X86Conds.S, done); // if negative
+		test_rm_r(scratch, scratch); // signed ? MIN_INT : MAX_INT
+		movd_rm_i(ecx, 0x80000000);
+		movd_rm_i(eax, 0x7fffffff);
+		cmovns(ecx, eax);
+		bind(done);
+		movd_rm_r(inout, ecx);
+		pop(edx);
+		pop(ecx);
+		pop(eax);
+	}
+	def int_truncf(a: X86Reg, b: SSERm) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plus(0x0);
+		var label = Label.new();
+		cvttss2si(a, b);
+		cmp.rm_i(a, 0x80000000); // XXX: float sign flip
+		jmpl_near(X86Conds.NZ, label);
+		sub.rm_i(esp, 0x4);
+		if (SSEReg.?(b)) {
+			movd_rm_s(save, SSEReg.!(b));
+		} else {
+			movss_s_sm(sse_scratch, b);
+			movd_rm_s(save, sse_scratch);
+		}
+		var name = "f2i_fixup";
+		var addr = mach.stubMap[name].0;
+		if (addr == null) {
+			addr = Address.new(mach.codeRegion, name);
+			mach.stubMap[name] = (addr, gen_f2i_fixup_stub(mach, _, _, codeStartOffset));
+		}
+		call_addr(addr);
+		pop(a);
+		bind(label);
+	}
+	// TODO: truncate double
+	def int_truncd(a: X86Reg, b: SSERm) {
+		cvttsd2si(a, b);
 	}
 }
 // A helper for generating shift operations for a given V3 opcode.

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -66,6 +66,9 @@ def main(a: Array<string>) -> int {
 	gen.do_s_i("pslld", gen.asm.pslld_i);
 	gen.do_s_i("psllq", gen.asm.psllq_i);
 
+	gen.do_s_sm("pcmpeqd", gen.asm.pcmpeqd);
+	gen.do_s_sm("pcmpeqq", gen.asm.pcmpeqq);
+
 	gen.do_sm("fld DWORD", gen.asm.fld_d);
 	gen.do_sm("fisttp QWORD", gen.asm.fisttp_q);
 

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -56,6 +56,16 @@ def main(a: Array<string>) -> int {
 	gen.do_r_sm("cvttsd2si", gen.asm.cvttsd2si);
 	gen.do_r_sm("cvttss2si", gen.asm.cvttss2si);
 
+	gen.do_s_sm("andps", gen.asm.andps);
+	gen.do_s_sm("andpd", gen.asm.andpd);
+	gen.do_s_sm("xorps", gen.asm.xorps);
+	gen.do_s_sm("xorpd", gen.asm.xorpd);
+
+	gen.do_s_i("psrld", gen.asm.psrld_i);
+	gen.do_s_i("psrlq", gen.asm.psrlq_i);
+	gen.do_s_i("pslld", gen.asm.pslld_i);
+	gen.do_s_i("psllq", gen.asm.psllq_i);
+
 	Terminal.put(";; passed\n");
 	return 0;
 }
@@ -212,6 +222,23 @@ class X86AsmGen(args: Array<string>) {
 					render();
 					Terminal.putbln(buf);
 				}
+			}
+		}
+	}
+
+	def do_s_i(mnemonic: string, asm_func: (SSEReg, byte) -> void) {
+		if (skip(mnemonic)) return;
+		for (s in [X86Regs.XMM0, X86Regs.XMM1, X86Regs.XMM7]) {
+			for (imm in ['\x01', '\x02', '\x03']) {
+				asm_func(s, imm);
+				buf.reset();
+				buf.puts(mnemonic).sp();
+				buf.puts(s.name);
+				buf.puts(", ");
+				buf.puti(imm);
+				buf.puts(" ;;== ");
+				render();
+				Terminal.putbln(buf);
 			}
 		}
 	}

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -66,6 +66,9 @@ def main(a: Array<string>) -> int {
 	gen.do_s_i("pslld", gen.asm.pslld_i);
 	gen.do_s_i("psllq", gen.asm.psllq_i);
 
+	gen.do_sm("fld DWORD", gen.asm.fld_d);
+	gen.do_sm("fisttp QWORD", gen.asm.fisttp_q);
+
 	Terminal.put(";; passed\n");
 	return 0;
 }
@@ -135,6 +138,18 @@ class X86AsmGen(args: Array<string>) {
 				render();
 				Terminal.putbln(buf);
 			}
+		}
+	}
+	def do_sm(mnemonic: string, asm_func: (SSEAddr) -> void) {
+		if (skip(mnemonic)) return;
+		for (addr in SSE_ADDRS) {
+			asm_func(addr);
+			buf.reset();
+			buf.puts(mnemonic).sp();
+			addr.render(buf);
+			buf.puts(" ;;== ");
+			render();
+			Terminal.putbln(buf);
 		}
 	}
 	def do_s_rm(mnemonic: string, asm_func: (SSEReg, X86Rm) -> void) {

--- a/test/x86/asm/X86AssemblerTestGen.v3
+++ b/test/x86/asm/X86AssemblerTestGen.v3
@@ -53,6 +53,8 @@ def main(a: Array<string>) -> int {
 	gen.do_s_rm("cvtsi2ss", gen.asm.cvtsi2ss);
 	gen.do_s_sm("cvtss2sd", gen.asm.cvtss2sd);
 	gen.do_s_sm("cvtsd2ss", gen.asm.cvtsd2ss);
+	gen.do_r_sm("cvttsd2si", gen.asm.cvttsd2si);
+	gen.do_r_sm("cvttss2si", gen.asm.cvttss2si);
 
 	Terminal.put(";; passed\n");
 	return 0;


### PR DESCRIPTION
This is a fairly big patch. I've tried to make each commit small-ish so that reviewing it is more digestible. The meat of the patch is the implementation of conversion and truncation between floats and (unsigned) ints. 

A few things to note:
- The conversion and truncation functions added in the MacroAssembler were either implemented in C first and compiled with `icc` using `-msse4.2 -m32 -O3` or they were based on how the JVM implements them.
- The two x87 FPU instructions were what `icc` spat out for the conversion between a `float` and `unsigned int`. The conversion is quite simple to do with these instructions. It's a bit of a nightmare in just SSE instructions (although technically, the `fisttp` instruction was added in SSE3).
- I was not so sure how to respect calling convention when dealing with stub functions, so I opted to use the stack for passing values around. I was a bit stingy some places and directly return value in the SSE scratch register (`xmm7`). Please do tell me if I should change either of the above.
- Originally I had opted to have function names similar to Intel instructions, such as `cvtsui2ss` instead of `cast_ui2f` for converting a single unsigned integer to a single-precision float (sort of similar to what `v8` does). I have opted to have the simpler naming scheme over the alphabet soup. Do you have any preference?

I have completed support for single-precision floating point, passing all relevant tests. I'll send the patch for that as soon as this supporting patch is merged.

~Kunal