### PR TITLE
Improve floating point support for x86 target

### DIFF
--- a/aeneas/src/arm/ArmRegSet.v3
+++ b/aeneas/src/arm/ArmRegSet.v3
@@ -24,9 +24,9 @@ component ArmMachRegs {
 	def LR = ArmReg.R14;
 	def IP = ArmReg.R15;
 
-	// a billion spill slots ought to be enough...
-	def CALLER_SPILL_START = 1000000000;
-	def CALLEE_SPILL_START = 2000000000;
+	// XXX: enough spill slots to not use the 31st bit
+	def CALLER_SPILL_START = 100000000;
+	def CALLEE_SPILL_START = 200000000;
 
 	var regs: MachRegSet;
 
@@ -65,7 +65,8 @@ component ArmMachRegs {
 		rnames[GPR] = "{gpr}";
 		rnames[ALL] = "{all}";
 
-		regs = MachRegSet.new(12, rarray, rnames, [GPR], R12, CALLER_SPILL_START, CALLEE_SPILL_START);
+		// XXX: fpScratch = 0 as no floating point support for arm currently
+		regs = MachRegSet.new(12, rarray, rnames, [GPR], R12, 0, CALLER_SPILL_START, CALLEE_SPILL_START);
 	}
 }
 // Defines the standard parameter and return registers for Arm calls between Virgil methods.

--- a/aeneas/src/mach/MachBackend.v3
+++ b/aeneas/src/mach/MachBackend.v3
@@ -38,7 +38,7 @@ component Regs {
 			}
 			V3Kind.ENUM => return toRegIntClass(V3.getVariantTagType(t));
 			V3Kind.ENUM_SET => return toRegIntClass(V3.getEnumSetType(t));
-			_ => return RegClass.I32;
+			_ => return RegClass.REF;
 		}
 	}
 
@@ -84,13 +84,14 @@ class MachFrame(conv: MachCallConv) {
 	var spillVars: int;		// spilled variables
 	var spillArgs: int;		// space for outgoing spilled arguments
 	var frameSize: int = -1;	// architecture-specific total frame size
+	def IS_64: int = 0x40000000;	// if the spilled value is 64 bits
 
 	def allocSpill(regClass: RegClass) -> int {
 		match (regClass) {
-			I64, F64 => { // TODO: alloc double spill for F32 as well
+			I64, F64 => {
 				var spill = conv.regSet.spillStart + spillVars;
 				spillVars += 2;
-				return spill;
+				return spill | IS_64;
 			}
 			_ => return conv.regSet.spillStart + spillVars++;
 		}
@@ -122,11 +123,12 @@ class MachRegSet {
 	def names: Array<string>;		// names of each register and set
 	def regClasses: Array<byte>;	// registers in each class
 	def scratch: int;
+	def fpScratch: int;
 	def spillStart: int = regSets.length;
 	def callerStart: int;
 	def calleeStart: int;
 	def matrix = BitMatrix.new(physRegs + 1, regSets.length);
-	new(physRegs, regSets, names, regClasses, scratch, callerStart, calleeStart) {
+	new(physRegs, regSets, names, regClasses, scratch, fpScratch, callerStart, calleeStart) {
 		// compute the matrix of physical register / register set membership
 		for (i < regSets.length) {
 			var rs = regSets[i];
@@ -235,14 +237,23 @@ class MachCodeGen(mach: MachProgram, context: SsaContext) {
 		var max = context.graph.markGen;
 		if (i.mark >= max) return vars[i.mark - max]; // already has a variable
 		var isConst = SsaConst.?(i);
+		var varNum = vars.length;
 		var t = i.getType();
-		var num = Tuple.length(t);
-		var vreg = VReg.new(i, vars.length, num, isConst);
-		vreg.regClass = Regs.toRegClass(t);
-		vars.put(vreg);
-		while (--num > 0) vars.put(VReg.new(i, vars.length, 1, isConst));
-		i.mark = vreg.varNum + max; // maps instruction to var
-		return vreg;
+		if (V3.isTuple(t)) {
+			var size = Tuple.length(t);
+			for (l = t.nested; l != null; l = l.tail) {
+				var vreg = VReg.new(i, vars.length, size, isConst);
+				vreg.regClass = Regs.toRegClass(l.head);
+				vars.put(vreg);
+				size = 1;
+			}
+		} else {
+			var vreg = VReg.new(i, varNum, 1, isConst);
+			vreg.regClass = Regs.toRegClass(t);
+			vars.put(vreg);
+		}
+		i.mark = varNum + max; // maps instruction to var
+		return vars[varNum];
 	}
 	def val(i: SsaInstr) -> Val {
 		return SsaConst.!(i).val;

--- a/aeneas/src/mach/MachLowering.v3
+++ b/aeneas/src/mach/MachLowering.v3
@@ -935,7 +935,7 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		var ft = oi.op.typeArgs[0];
 		var ftc = Float_TypeCon.!(ft.typeCon);
 		var itt = IntType.!(oi.op.typeArgs[1]);
-		var ett = Int.getType(itt.signed, if(itt.width < 32, 32, 64)), tn = normIntType(ett);
+		var ett = Int.getType(itt.signed, if(itt.width <= 32, 32, 64)), tn = normIntType(ett);
 		var x = oi.input0();
 		var ni: SsaInstr;
 		match (itt.rank) {

--- a/aeneas/src/mach/MoveResolver.v3
+++ b/aeneas/src/mach/MoveResolver.v3
@@ -2,7 +2,7 @@
 // See LICENSE for details of Apache 2.0 license.
 
 // Resolves a list of parallel moves, e.g. to resolve the value of each phi at
-// a control flow predecessor, or to rearrange values into correct registers 
+// a control flow predecessor, or to rearrange values into correct registers
 // according to a specific calling convention.
 // Uses a custom map from int -> MoveNode internally for performance.
 // Note: most move graphs will be tiny, with just 2 or 3 nodes
@@ -70,7 +70,7 @@ class MoveResolver(ERROR: ErrorGen) {
 		return node;
 	}
 	// generate moves in appropriate order
-	def genMoves(alloc: void -> int, move: (int, int) -> void) {
+	def genMoves(alloc: int -> int, move: (int, int) -> void) {
 		if (size == 0) return;
 		for (i < map.length) {
 			var node = map[i];
@@ -95,13 +95,13 @@ class MoveResolver(ERROR: ErrorGen) {
 		return node != null && node.src != null;
 	}
 	// traverse the move graph, inserting moves in post-order
-	private def orderMove(alloc: void -> int, move: (int, int) -> void, node: MoveNode) {
+	private def orderMove(alloc: int -> int, move: (int, int) -> void, node: MoveNode) {
 		if (node.color == BLACK) return;
 		node.color = GRAY;
 		for (l = node.dstList; l != null; l = l.dstNext) {
 			if (l.color == GRAY) {
 				// cycle detected; break it with a temporary
-				var tmp = alloc();    // allocate a temporary
+				var tmp = alloc(l.loc);    // allocate a temporary
 				move(l.loc, tmp);	// save
 				move(node.loc, l.loc);	// overwrite
 				l.loc = tmp;		// on-stack uses will use tmp

--- a/aeneas/src/mach/RegAlloc.v3
+++ b/aeneas/src/mach/RegAlloc.v3
@@ -356,7 +356,7 @@ class LinearScanRegAlloc {
 		var u = uses[usepos], result: int;
 		if ((u & gen.ASSIGNED_MASK) == 0) result = gen.varOfUse(usepos).loc();
 		else result = uses[usepos + 1];
-		if (result <= 0) gen.mach.prog.ERROR.fail(Strings.format1("invalid location @ usepos: %1", usepos));
+		if (result <= 0) gen.mach.prog.ERROR.fail(Strings.format3("invalid location: %1 @ usepos: %2 @ uuid: %3", result, usepos, gen.varOfUse(usepos).ssa.uid));
 		return result;
 	}
 	def print() {

--- a/aeneas/src/main/Version.v3
+++ b/aeneas/src/main/Version.v3
@@ -3,6 +3,6 @@
 
 // Updated by VCS scripts. DO NOT EDIT.
 component Version {
-	def version: string = "III-5.1180";
+	def version: string = "III-5.1181";
 	var buildData: string;
 }

--- a/aeneas/src/x86/X86Assembler.v3
+++ b/aeneas/src/x86/X86Assembler.v3
@@ -568,6 +568,14 @@ class X86Assembler(buffer: DataBuffer) {
 		emitbbb(0x66, 0x0F, 0x7E);
 		emit_rm(a, b.index);
 	}
+	def movq_s_sm(a: SSEReg, b: SSERm) {
+		emitbbb(0xF3, 0x0F, 0x7E);
+		emit_sm(b, a.index);
+	}
+	def movq_sm_s(a: SSERm, b: SSEReg) {
+		emitbbb(0x66, 0x0F, 0xD6);
+		emit_sm(a, b.index);
+	}
 
 	def andps(a: SSEReg, b: SSERm) { emitbb_s_sm(0x0F, 0x54, a, b); }
 	def andpd(a: SSEReg, b: SSERm) { emitbbb_s_sm(0x66, 0x0F, 0x54, a, b); }
@@ -583,9 +591,29 @@ class X86Assembler(buffer: DataBuffer) {
 	def pcmpeqq(a: SSEReg, b: SSERm) { emitbbbb_s_sm(0x66, 0x0F, 0x38, 0x29, a, b); }
 
 	// x87 FPU instructions
+	def fadd_d(a: SSEAddr) {
+		emitb(0xD8);
+		emit_sm(a, 0x0);
+	}
 	def fld_d(a: SSEAddr) {
 		emitb(0xD9);
 		emit_sm(a, 0x0);
+	}
+	def fld_q(a: SSEAddr) {
+		emitb(0xDD);
+		emit_sm(a, 0x0);
+	}
+	def fild_q(a: SSEAddr) {
+		emitb(0xDF);
+		emit_sm(a, 0x5);
+	}
+	def fstp_d(a: SSEAddr) {
+		emitb(0xD9);
+		emit_sm(a, 0x3);
+	}
+	def fstp_q(a: SSEAddr) {
+		emitb(0xDD);
+		emit_sm(a, 0x3);
 	}
 	def fisttp_q(a: SSEAddr) {
 		emitb(0xDD);

--- a/aeneas/src/x86/X86CodeGen.v3
+++ b/aeneas/src/x86/X86CodeGen.v3
@@ -1083,7 +1083,8 @@ class X86CodeGen extends MachCodeGen {
 	def frameAdjust() -> int {
 		return frame.size() - mach.code.addressSize; // assumes return address already pushed
 	}
-	def allocMoveTmp() -> int {
+	def allocMoveTmp(loc: int) -> int {
+		if (X86MachRegs.isSSEReg(loc)) return X86MachRegs.XMM7;
 		return frame.conv.regSet.scratch;
 	}
 	def loc_r(loc: int) -> X86Reg {

--- a/aeneas/src/x86/X86MacroAssembler.v3
+++ b/aeneas/src/x86/X86MacroAssembler.v3
@@ -28,14 +28,45 @@ def gen_f2i_fixup_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeSta
 	asm.f2i_fixup();
 	asm.ret();
 }
+def gen_d2i_fixup_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int) {
+	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
+	asm.d2i_fixup();
+	asm.ret();
+}
+def gen_d2l_fixup_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int) {
+	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
+	asm.d2l_fixup();
+	asm.ret();
+}
 def gen_ui2f_fixup_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int) {
 	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
 	asm.ui2f_fixup();
 	asm.ret();
 }
+def gen_ui2d_fixup_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int) {
+	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
+	asm.ui2d_fixup();
+	asm.ret();
+}
 def gen_f2ui_fixup_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int) {
 	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
 	asm.f2ui_fixup();
+	asm.ret();
+}
+def gen_d2ui_fixup_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int) {
+	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
+	asm.d2ui_fixup();
+	asm.ret();
+}
+def gen_d2ul_fixup_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int) {
+	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
+	asm.d2ul_fixup();
+	asm.ret();
+}
+def gen_d2ul_stub(mach: MachProgram, addr: Addr, u: MachDataBuffer, codeStartOffset: int) {
+	var asm = X86MacroAssembler.new(mach, u, codeStartOffset);
+	asm.d2ul();
+	asm.ret();
 }
 
 // An extended X86Assembler that has additional machine-level utilities, such as
@@ -62,6 +93,7 @@ class X86MacroAssembler extends X86Assembler {
 	}
 	// a macro to move between any two register/memory operands
 	def movd_rm_rm(d: X86Rm, s: X86Rm, scratch: X86Reg) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
 		if (s == d) return;
 		if (X86Reg.?(d)) return movd_r_rm(X86Reg.!(d), s);
 		if (X86Reg.?(s)) return movd_rm_r(d, X86Reg.!(s));
@@ -69,21 +101,36 @@ class X86MacroAssembler extends X86Assembler {
 			movd_r_rm(scratch, s);
 			movd_rm_r(d, scratch);
 		}
-		// XXX: use XMM register for memory-memory move instead of stack
-		push(s);            // push value from source memory onto the stack
-		pop(X86Addr.!(d));  // pop value off stack into destination memory
+		movd_s_rm(sse_scratch, s);
+		movd_rm_s(d, sse_scratch);
 	}
-	// a macro to move between any two SSE register/memory operands
-	def movsd_sm_sm(d: SSERm, s: SSERm, scratch: SSEReg) {
+	// a macro to move between two 64-bit memory operands
+	def movq_m_m(d: X86Rm, s: X86Rm) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		movq_s_sm(sse_scratch, X86Addr.!(s).toSSEAddr());
+		movq_sm_s(X86Addr.!(d).toSSEAddr(), sse_scratch);
+	}
+	// a macro to move between any two double-precision SSE register/memory operands
+	def movsd_sm_sm(d: SSERm, s: SSERm) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
 		if (s == d) return;
 		if (SSEReg.?(d)) return movsd_s_sm(SSEReg.!(d), s);
 		if (SSEReg.?(s)) return movsd_sm_s(d, SSEReg.!(s));
-		movsd_s_sm(scratch, s);
-		movsd_sm_s(d, scratch);
+		movsd_s_sm(sse_scratch, s);
+		movsd_sm_s(d, sse_scratch);
+	}
+	// a macro to move between any two single-precision SSE register/memory operands
+	def movss_sm_sm(d: SSERm, s: SSERm) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		if (s == d) return;
+		if (SSEReg.?(d)) return movss_s_sm(SSEReg.!(d), s);
+		if (SSEReg.?(s)) return movss_sm_s(d, SSEReg.!(s));
+		movss_s_sm(sse_scratch, s);
+		movss_sm_s(d, sse_scratch);
 	}
 	// a macro to move a value into a location
 	def movd_l_val(frame: MachFrame, loc: int, val: Val) {
-		if (loc >= X86MachRegs.XMM0 && loc <= X86MachRegs.XMM7) {
+		if (X86MachRegs.isSSEReg(loc)) {
 			movd_l_fval(frame, loc, val);
 		} else {
 			var d = loc_rm(frame, loc);
@@ -93,23 +140,51 @@ class X86MacroAssembler extends X86Assembler {
 					movd_rm_i(d, X86Addrs.ABS_CONST);
 					recordPatch(pos, x);
 				}
-				x: Float32Val => movd_l_fval(frame, loc, x); // TODO: Float64Val case
+				x: Float32Val => movd_l_fval(frame, loc, x);
+				x: Float64Val => movd_l_fval(frame, loc, x);
 				_ => movd_rm_i(d, V3.unboxIntegral(val));
 			}
 		}
 	}
-	// a macro to move a value into an SSE location
+	// a macro to move a floating point value into an SSE location
 	def movd_l_fval(frame: MachFrame, loc: int, val: Val) {
-		var f = 0;
 		var d = loc_sm(frame, loc);
 		if (val != null) {
 			match (val) {
-				x: Float32Val => f = int.view(x.bits);
-				x: Float64Val => f = int.view(x.bits); // TODO: fix Float64Val case
+				x: Float32Val => {
+					var f = int.view(x.bits);
+					movd_rm_i(ebp, f);
+					if (SSEReg.?(d)) movd_s_rm(SSEReg.!(d), ebp);
+					else movd_rm_r(SSEAddr.!(d).toX86Addr(), ebp);
+				}
+				x: Float64Val => { // XXX: load constants into data section instead of using stack
+					var fl = int.view(x.bits);
+					var fh = int.view(x.bits >> 32);
+					if (SSEReg.?(d)) {
+						if (fl == 0x0 && fh == 0x0) {
+							xorpd(SSEReg.!(d), SSEReg.!(d));
+						} else {
+							push_i(fh);
+							push_i(fl);
+							movq_s_sm(SSEReg.!(d), esp.plusSSE(0x0));
+							add.rm_i(esp, 0x8);
+						}
+					} else {
+						var addr_low = SSEAddr.!(d).toX86Addr();
+						var addr_high = X86Addr.new(addr_low.base, addr_low.index, addr_low.scale, addr_low.disp + 0x4);
+						movd_rm_i(addr_low, fl);
+						movd_rm_i(addr_high, fh);
+					}
+			  }
+			}
+		} else { // default value is 0
+			if (SSEReg.?(d)) xorpd(SSEReg.!(d), SSEReg.!(d));
+			else {
+				var sse_scratch = X86MachRegs.SSE_SCRATCH;
+				xorpd(sse_scratch, sse_scratch);
+				movsd_sm_s(SSEAddr.!(d), sse_scratch);
 			}
 		}
-		movd_rm_i(X86Regs.EBP, f);
-		movd_s_rm(SSEReg.!(d), X86Regs.EBP); // cast will never fail since we know d is an SSEReg from loc
 	}
 	// convert a location into an x86 register
 	def loc_r(frame: MachFrame, loc: int) -> X86Reg {
@@ -136,6 +211,7 @@ class X86MacroAssembler extends X86Assembler {
 			X86MachRegs.EDI => return edi;
 			X86MachRegs.EBP => return ebp;
 		}
+		if (loc > 0) loc &= ~(frame.IS_64);
 		var offset = calc_offset(frame, loc, false);
 		return esp.plus(offset);
 	}
@@ -170,6 +246,7 @@ class X86MacroAssembler extends X86Assembler {
 			X86MachRegs.XMM6 => return xmm6;
 			X86MachRegs.XMM7 => return xmm7;
 		}
+		if (loc > 0) loc &= ~(frame.IS_64);
 		var offset = calc_offset(frame, loc, true);
 		return esp.plusSSE(offset);
 	}
@@ -186,7 +263,7 @@ class X86MacroAssembler extends X86Assembler {
 		} else if (loc >= regSet.spillStart) {
 			return wordSize * (loc - regSet.spillStart + frame.spillArgs);
 		} else {
-			if (isSSE) failSSELocation("invalid spill location", loc, regSet);
+			if (isSSE) failSSELocation("invalid SSE spill location", loc, regSet);
 			else failLocation("invalid spill location", loc, regSet);
 			return 0;
 		}
@@ -412,7 +489,8 @@ class X86MacroAssembler extends X86Assembler {
 		if (frame != null) mach.runtime.src.recordFrameEnd(codeOffset());
 	}
 
-	def cast_f2ui(dest: X86Reg, a: SSERm) {
+	// a macro to convert from a single-precision float to an unsigned int
+	def cvt_f2ui(dest: X86Reg, a: SSERm) {
 		var sse_scratch = X86MachRegs.SSE_SCRATCH;
 		var save = esp.plusSSE(0x0);
 		sub.rm_i(esp, 0x8);
@@ -426,46 +504,22 @@ class X86MacroAssembler extends X86Assembler {
 		movd_r_rm(dest, save.toX86Addr());
 		add.rm_i(esp, 0x8);
 	}
-	def cast_d2ui(dest: X86Reg, a: SSERm) {
-		// TODO: convert double to unsigned int
-	}
-	def f2ui_fixup() {
-		var scratch = X86MachRegs.SCRATCH;
+	// a macro to convert from a double-precision float to an unsigned int
+	def cvt_d2ui(dest: X86Reg, a: SSERm) {
 		var sse_scratch = X86MachRegs.SSE_SCRATCH;
-		var inout = esp.plus(4 * 0x4); // return address + 3 saves
-		var inout_sse = inout.toSSEAddr();
-		var xmm0_save = esp.plusSSE(2 * 0x4);
 		var save = esp.plusSSE(0x0);
-		var L1 = Label.new(), L2 = Label.new();
-		sub.rm_i(esp, 0xC);
-		movss_sm_s(xmm0_save, xmm0);
-		movss_s_sm(xmm0, inout_sse);
-		xorps(sse_scratch, sse_scratch);
-		ucomiss(sse_scratch, xmm0); // if (f <= 0) return 0
-		jmpl_near(X86Conds.NC, L1);
-		movd_rm_i(scratch, 0x4f800000); // if (f >= 4294967296) return MAX_U32_INT
-		movd_s_rm(sse_scratch, scratch);
-		ucomiss(xmm0, sse_scratch);
-		jmpl_near(X86Conds.C, L2);
-		movd_rm_i(inout, 0xffffffff);
-		movss_s_sm(xmm0, xmm0_save);
-		add.rm_i(esp, 0xC);
-		ret();
-		bind(L2); // else return (unsigned int)f
-		movss_sm_s(save, xmm0);
-		fld_d(save);
+		sub.rm_i(esp, 0x8);
+		if (SSEAddr.?(a)) {
+			fld_q(SSEAddr.!(a));
+		} else {
+			movsd_sm_s(save, SSEReg.!(a));
+			fld_q(save);
+		}
 		fisttp_q(save);
-		movd_r_rm(scratch, save.toX86Addr());
-		movd_rm_r(inout, scratch);
-		movss_s_sm(xmm0, xmm0_save);
-		add.rm_i(esp, 0xC);
-		ret();
-		bind(L1);
-		movd_rm_i(inout, 0x0);
-		movss_s_sm(xmm0, xmm0_save);
-		add.rm_i(esp, 0xC);
-		ret();
+		movd_r_rm(dest, save.toX86Addr());
+		add.rm_i(esp, 0x8);
 	}
+	// macro to truncate a single-precision float to an unsigned integer
 	def uint_truncf(dest: X86Reg, a: SSERm) {
 		var sse_scratch = X86MachRegs.SSE_SCRATCH;
 		var save = esp.plusSSE(0x0);
@@ -485,9 +539,133 @@ class X86MacroAssembler extends X86Assembler {
 		call_addr(addr);
 		pop(dest);
 	}
+	// macro to truncate a double-precision float to an unsigned integer
 	def uint_truncd(dest: X86Reg, a: SSERm) {
-		// TODO: convert double to unsigned int with truncation
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plusSSE(0x0);
+		sub.rm_i(esp, 0x8);
+		if (SSEReg.?(a)) {
+			movsd_sm_s(save, SSEReg.!(a));
+		} else {
+			movsd_s_sm(sse_scratch, a);
+			movsd_sm_s(save, sse_scratch);
+		}
+		var name = "d2ui_fixup";
+		var addr = mach.stubMap[name].0;
+		if (addr == null) {
+			addr = Address.new(mach.codeRegion, name);
+			mach.stubMap[name] = (addr, gen_d2ui_fixup_stub(mach, _, _, codeStartOffset));
+		}
+		call_addr(addr);
+		pop(dest);
+		add.rm_i(esp, 0x4);
 	}
+	/** stub that converts a single-precision float to an unsigned int with
+	 *  virgil truncation semantics
+	 *  @input: 32-bit floating point value on stack
+	 *  @output: 32-bit unsigned integer on stack
+	 */
+	def f2ui_fixup() {
+		var scratch = X86MachRegs.SCRATCH;
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var inout = esp.plus(4 * 0x4); // return address + 3 saves
+		var xmm0_save = esp.plusSSE(2 * 0x4);
+		var save = esp.plusSSE(0x0);
+		var L1 = Label.new(), L2 = Label.new(), done = Label.new();
+		sub.rm_i(esp, 0xc);
+		movss_sm_s(xmm0_save, xmm0);
+		movss_s_sm(xmm0, inout.toSSEAddr());
+		xorps(sse_scratch, sse_scratch);
+		ucomiss(sse_scratch, xmm0); // if (f <= 0) return 0;
+		jmpl_near(X86Conds.NC, L1);
+		movd_rm_i(scratch, 0x4f800000);
+		movd_s_rm(sse_scratch, scratch);
+		ucomiss(xmm0, sse_scratch); // if (f >= 4294967296) return MAX_U32_INT;
+		jmpl_near(X86Conds.C, L2);
+		movd_rm_i(inout, 0xffffffff);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L2); // else return (unsigned int)f;
+		movss_sm_s(save, xmm0);
+		fld_d(save);
+		fisttp_q(save);
+		movd_r_rm(scratch, save.toX86Addr());
+		movd_rm_r(inout, scratch);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L1);
+		movd_rm_i(inout, 0x0);
+		bind(done);
+		movss_s_sm(xmm0, xmm0_save);
+		add.rm_i(esp, 0xc);
+	}
+	/** stub that converts a double-precision float to an unsigned int with
+	 *  virgil truncation semantics
+	 *  @input: 64-bit floating point value on stack
+	 *  @output: 32-bit unsigned integer on stack
+	 */
+	def d2ui_fixup() {
+		var scratch = X86MachRegs.SCRATCH;
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var inout = esp.plus(5 * 0x4); // return address + 4 saves
+		var xmm0_save = esp.plusSSE(2 * 0x4);
+		var save = esp.plusSSE(0x0);
+		var L1 = Label.new(), L2 = Label.new(), done = Label.new();
+		sub.rm_i(esp, 4 * 0x4);
+		movsd_sm_s(xmm0_save, xmm0);
+		movsd_s_sm(xmm0, inout.toSSEAddr());
+		xorpd(sse_scratch, sse_scratch);
+		ucomisd(sse_scratch, xmm0);
+		jmpl_near(X86Conds.NC, L1); // if (d <= 0) return 0;
+		movd_rm_i(esp.plus(0x0), 0x00000000);
+		movd_rm_i(esp.plus(0x4), 0x41f00000);
+		ucomisd(xmm0, esp.plusSSE(0x0)); // if (d >= 4294967296) return MAX_U32_INT;
+		jmpl_near(X86Conds.C, L2);
+		movd_rm_i(inout, 0xffffffff);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L1);
+		movd_rm_i(inout, 0x0);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L2); // else return (unsigned int)d;
+		movsd_sm_s(save, xmm0);
+		fld_q(save);
+		fisttp_q(save);
+		movd_r_rm(scratch, save.toX86Addr());
+		movd_rm_r(inout, scratch);
+		bind(done);
+		movsd_s_sm(xmm0, xmm0_save);
+		add.rm_i(esp, 4 * 0x4);
+	}
+	// a macro to convert an unsigned integer to a single-precision float
+	def cvt_ui2f(dest: SSEReg, a: X86Rm) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		push(a);
+		var name = "ui2f_fixup";
+		var addr = mach.stubMap[name].0;
+		if (addr == null) {
+			addr = Address.new(mach.codeRegion, name);
+			mach.stubMap[name] = (addr, gen_ui2f_fixup_stub(mach, _, _, codeStartOffset));
+		}
+		call_addr(addr);
+		add.rm_i(esp, 0x4);
+		movss_s_sm(dest, sse_scratch); // XXX: return value in sse_scratch
+	}
+	// a macro to convert an unsigned integer to a double-precision float
+	def cvt_ui2d(dest: SSEReg, a: X86Rm) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		push(a);
+		var name = "ui2d_fixup";
+		var addr = mach.stubMap[name].0;
+		if (addr == null) {
+			addr = Address.new(mach.codeRegion, name);
+			mach.stubMap[name] = (addr, gen_ui2d_fixup_stub(mach, _, _, codeStartOffset));
+		}
+		call_addr(addr);
+		add.rm_i(esp, 0x4);
+		movsd_s_sm(dest, sse_scratch); // XXX: return value in sse_scratch
+	}
+	/** stub that converts an unsigned integer to a single-precision float
+	 *  @input: 32-bit unsigned integer on stack
+	 *  @output: 32-bit floating point value in SSE_SCRATCH
+	 */
 	def ui2f_fixup() {
 		var scratch = X86MachRegs.SCRATCH;
 		var sse_scratch = X86MachRegs.SSE_SCRATCH;
@@ -503,51 +681,28 @@ class X86MacroAssembler extends X86Assembler {
 		and.rm_i(eax, 0x1);
 		or.r_rm(eax, scratch);
 		cvtsi2ss(sse_scratch, eax);
-		addss(sse_scratch, sse_scratch); // return value in sse_scratch
+		addss(sse_scratch, sse_scratch); // XXX: return value in sse_scratch
 		bind(done);
 		pop(eax);
 	}
-	def cast_ui2f(dest: SSEReg, a: X86Rm) {
-		var sse_scratch = X86MachRegs.SSE_SCRATCH;
-		var save = esp.plusSSE(0x0);
-		push(a);
-		var name = "ui2f_fixup";
-		var addr = mach.stubMap[name].0;
-		if (addr == null) {
-			addr = Address.new(mach.codeRegion, name);
-			mach.stubMap[name] = (addr, gen_ui2f_fixup_stub(mach, _, _, codeStartOffset));
-		}
-		call_addr(addr);
-		add.rm_i(esp, 0x4);
-		movss_s_sm(dest, sse_scratch); // return value in sse_scratch
-	}
-	def cast_ui2d(dest: SSEReg, a: X86Rm) {
-		// TODO: convert unsigned int to double
-	}
-	def f2i_fixup() {
+	/** stub that converts an unsigned integer to a double-precision float
+	 *  @input: 32-bit unsigned integer on stack
+	 *  @output: 32-bit floating point value in SSE_SCRATCH
+	 */
+	def ui2d_fixup() {
 		var scratch = X86MachRegs.SCRATCH;
-		var inout = esp.plus(4 * 0x4); // return address + 3 saves
-		var done = Label.new();
-		push(eax);
-		push(ecx);
-		push(edx);
-		movd_rm_i(eax, 0x7f800000);
-		xor.r_rm(ecx, ecx);
-		movd_r_rm(scratch, inout);
-		movd_r_rm(edx, scratch);
-		and.rm_i(edx, 0x7fffffff);
-		cmp.r_rm(eax, edx); // if NaN -> 0
-		jmpl_near(X86Conds.S, done); // if negative
-		test_rm_r(scratch, scratch); // signed ? MIN_INT : MAX_INT
-		movd_rm_i(ecx, 0x80000000);
-		movd_rm_i(eax, 0x7fffffff);
-		cmovns(ecx, eax);
-		bind(done);
-		movd_rm_r(inout, ecx);
-		pop(edx);
-		pop(ecx);
-		pop(eax);
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plus(0x4);
+		xorpd(sse_scratch, sse_scratch);
+		movd_r_rm(scratch, save);
+		add.rm_i(scratch, 0x80000000);
+		cvtsi2sd(sse_scratch, scratch);
+		push_i(0x41e00000);
+		push_i(0x00000000);
+		addsd(sse_scratch, esp.plusSSE(0x0)); // XXX: return value in sse_scratch
+		add.rm_i(esp, 0x8);
 	}
+	// a macro to convert an integer to a single-precision float
 	def int_truncf(a: X86Reg, b: SSERm) {
 		var sse_scratch = X86MachRegs.SSE_SCRATCH;
 		var save = esp.plus(0x0);
@@ -572,10 +727,347 @@ class X86MacroAssembler extends X86Assembler {
 		pop(a);
 		bind(label);
 	}
-	// TODO: truncate double
+	// a macro to convert an integer to a double-precision float
 	def int_truncd(a: X86Reg, b: SSERm) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plusSSE(0x0);
+		var label = Label.new();
 		cvttsd2si(a, b);
+		cmp.rm_i(a, 0x80000000); // XXX: float sign flip
+		jmpl_near(X86Conds.NZ, label);
+		sub.rm_i(esp, 2 * 0x4);
+		if (SSEReg.?(b)) {
+			movsd_sm_s(save, SSEReg.!(b));
+		} else {
+			movsd_s_sm(sse_scratch, b);
+			movsd_sm_s(save, sse_scratch);
+		}
+		var name = "d2i_fixup";
+		var addr = mach.stubMap[name].0;
+		if (addr == null) {
+			addr = Address.new(mach.codeRegion, name);
+			mach.stubMap[name] = (addr, gen_d2i_fixup_stub(mach, _, _, codeStartOffset));
+		}
+		call_addr(addr);
+		pop(a);
+		add.rm_i(esp, 0x4);
+		bind(label);
 	}
+	/** stub that converts a single-precision float to an int with virgil
+	 *  truncation semantics
+	 *  @input: 32-bit floating point value on stack
+	 *  @output: 32-bit integer on stack
+	 */
+	def f2i_fixup() {
+		var scratch = X86MachRegs.SCRATCH;
+		var inout = esp.plus(4 * 0x4); // return address + 3 saves
+		var done = Label.new();
+		push(eax);
+		push(ecx);
+		push(edx);
+		movd_rm_i(eax, 0x7f800000);
+		xor.r_rm(ecx, ecx);
+		movd_r_rm(scratch, inout);
+		movd_r_rm(edx, scratch);
+		and.rm_i(edx, 0x7fffffff);
+		cmp.r_rm(eax, edx); // if NaN -> 0
+		jmpl_near(X86Conds.S, done); // if negative;
+		test_rm_r(scratch, scratch); // signed ? MIN_INT : MAX_INT;
+		movd_rm_i(ecx, 0x80000000);
+		movd_rm_i(eax, 0x7fffffff);
+		cmovns(ecx, eax);
+		bind(done);
+		movd_rm_r(inout, ecx);
+		pop(edx);
+		pop(ecx);
+		pop(eax);
+	}
+	/** stub that converts a double-precision float to an int with virgil
+	 *  truncation semantics
+	 *  @input: 64-bit floating point value on stack
+	 *  @output: 32-bit integer on stack
+	 */
+	def d2i_fixup() {
+		var scratch = X86MachRegs.SCRATCH;
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var inout = esp.plus(5 * 0x4); // return address + 4 saves
+		var xmm0_save = esp.plusSSE(0x8);
+		var L1 = Label.new(), L2 = Label.new(), done = Label.new();
+		sub.rm_i(esp, 0x8);
+		push_i(0x41e00000);
+		push_i(0x00000000);
+		movsd_sm_s(xmm0_save, xmm0);
+		movsd_s_sm(sse_scratch, inout.toSSEAddr());
+		ucomisd(sse_scratch, sse_scratch); // if (d == NaN) return 0;
+		jmpl_near(X86Conds.P, L1);
+		ucomisd(sse_scratch, esp.plusSSE(0x0)); // if (d >= 2**31 - 1) return MAX_I32_INT;
+		jmpl_near(X86Conds.C, L2);
+		movd_rm_i(inout, 0x7fffffff);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L2);
+		movd_rm_i(esp.plus(0x4), 0xc1e00000);
+		movsd_s_sm(xmm0, esp.plusSSE(0x0));
+		ucomisd(xmm0, sse_scratch); // if (d <= -2**31) return MIN_I32_INT;
+		jmpl_near(X86Conds.C, L1);
+		movd_rm_i(inout, 0x80000000);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L1);
+		movd_rm_i(inout, 0x0);
+		bind(done);
+		movsd_s_sm(xmm0, xmm0_save);
+		add.rm_i(esp, 4 * 0x4);
+	}
+	// a macro to convert an unsigned long to a floating point value
+	def cvt_ul2fp(dest: SSEReg, a: X86Rm, b: X86Rm, isDouble: bool) {
+		var scratch = X86MachRegs.SCRATCH;
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plusSSE(0x0);
+		var L1 = Label.new();
+		push(b);
+		push(a);
+		fild_q(save);
+		movd_r_rm(scratch, b);
+		test_rm_r(scratch, scratch);
+		jmpl_near(X86Conds.NS, L1);
+		push_i(0x5f800000);
+		fadd_d(save);
+		add.rm_i(esp, 0x4);
+		bind(L1);
+		if (isDouble) {
+			fstp_q(save);
+			movsd_s_sm(dest, save);
+		} else {
+			fstp_d(save);
+			movss_s_sm(dest, save);
+		}
+		add.rm_i(esp, 0x8);
+	}
+	// a macro to convert a long to a floating point value
+	def cvt_l2fp(dest: SSEReg, a: X86Rm, b: X86Rm, isDouble: bool) {
+		var save = esp.plusSSE(0x0);
+		push(b);
+		push(a);
+		fild_q(save);
+		if (isDouble) {
+			fstp_q(save);
+			movsd_s_sm(dest, save);
+		} else {
+			fstp_d(save);
+			movss_s_sm(dest, save);
+		}
+		add.rm_i(esp, 0x8);
+	}
+	// a macro to convert a floating point value to a long
+	def cvt_fp2l(il: X86Rm, ih: X86Rm, a: SSERm, isDouble: bool) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plusSSE(0x0);
+		var ih_save = esp.plus(0x4);
+		var il_save = esp.plus(0x0);
+		sub.rm_i(esp, 0x8);
+		if (!isDouble) cvtss2sd(sse_scratch, a); // if single-precision float
+		else if (SSEReg.?(a)) sse_scratch = SSEReg.!(a); // XXX: cheeky way to save SSEReg
+		else if (SSEAddr.?(a)) movsd_s_sm(sse_scratch, a);
+		movsd_sm_s(save, sse_scratch);
+		fld_q(save);
+		fisttp_q(save);
+		movd_rm_rm(il, il_save, null);
+		movd_rm_rm(ih, ih_save, null);
+		add.rm_i(esp, 0x8);
+	}
+	// a macro to convert a floating point value to an unsigned long
+	def cvt_fp2ul(il: X86Rm, ih: X86Rm, a: SSERm, isDouble: bool) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plusSSE(0x0);
+		sub.rm_i(esp, 0x8);
+		if (!isDouble) cvtss2sd(sse_scratch, a); // if single-precision float
+		else if (SSEReg.?(a)) sse_scratch = SSEReg.!(a); // XXX: cheeky way to save SSEReg
+		else if (SSEAddr.?(a)) movsd_s_sm(sse_scratch, a);
+		movsd_sm_s(save, sse_scratch);
+		var name = "d2ul";
+		var addr = mach.stubMap[name].0;
+		if (addr == null) {
+			addr = Address.new(mach.codeRegion, name);
+			mach.stubMap[name] = (addr, gen_d2ul_stub(mach, _, _, codeStartOffset));
+		}
+		call_addr(addr);
+		pop(il);
+		pop(ih);
+	}
+	/** stub that converts a double-precision float to a long
+	 *  @input: 64-bit floating point value on stack
+	 *  @output: 64-bit long on stack
+	 */
+	def d2ul() {
+		var scratch = X86MachRegs.SCRATCH;
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var inout = esp.plusSSE(3 * 0x4); // return address + 2 saves
+		var inout_ih = esp.plus(4 * 0x4); // return address + 3 saves
+		var xmm0_save = esp.plusSSE(0x0);
+		var L1 = Label.new(), done = Label.new();
+		sub.rm_i(esp, 0x8);
+		movsd_sm_s(xmm0_save, xmm0);
+		movsd_s_sm(xmm0, inout);
+		push_i(0x43e00000);
+		push_i(0x00000000);
+		movsd_s_sm(sse_scratch, esp.plusSSE(0x0));
+		add.rm_i(esp, 0x8);
+		ucomisd(xmm0, sse_scratch); // if (d >= 2**63) return ((unsigned long) (d - 2**63)) + MIN_I64_INT;
+		jmpl_near(X86Conds.NC, L1);
+		movsd_sm_s(inout, xmm0); // else return (unsigned long)d;
+		fld_q(inout);
+		fisttp_q(inout);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L1);
+		subsd(xmm0, sse_scratch);
+		movsd_sm_s(inout, xmm0);
+		fld_q(inout);
+		fisttp_q(inout);
+		add.rm_i(inout_ih, 0x80000000);
+		bind(done);
+		movsd_s_sm(xmm0, xmm0_save);
+		add.rm_i(esp, 0x8);
+	}
+	def ulong_truncfp(il: X86Rm, ih: X86Rm, a: SSERm, isDouble: bool) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plusSSE(0x0);
+		sub.rm_i(esp, 0x8);
+		if (!isDouble) cvtss2sd(sse_scratch, a); // if single-precision float
+		else if (SSEReg.?(a)) sse_scratch = SSEReg.!(a); // XXX: cheeky way to save SSEReg
+		else if (SSEAddr.?(a)) movsd_s_sm(sse_scratch, a);
+		movsd_sm_s(save, sse_scratch);
+		var name = "d2ul_fixup";
+		var addr = mach.stubMap[name].0;
+		if (addr == null) {
+			addr = Address.new(mach.codeRegion, name);
+			mach.stubMap[name] = (addr, gen_d2ul_fixup_stub(mach, _, _, codeStartOffset));
+		}
+		call_addr(addr);
+		pop(il);
+		pop(ih);
+	}
+	/** stub that converts a double-precision float to an unsigned long with
+	 *  virgil truncation semantics
+	 *  @input: 64-bit floating point value on stack
+	 *  @output: 64-bit unsigned long on stack
+	 */
+	def d2ul_fixup() {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var inout = esp.plusSSE(5 * 0x4); // return value + 4 saves
+		var inout_il = inout.toX86Addr();
+		var inout_ih = esp.plus(6 * 0x4); // return value + 5 saves
+		var ih_save = esp.plus(0x4);
+		var il_save = esp.plus(0x0);
+		var xmm0_save = esp.plusSSE(0x8);
+		var L1 = Label.new(), L2 = Label.new();
+		var L3 = Label.new(), done = Label.new();
+		sub.rm_i(esp, 2 * 0x8);
+		movsd_sm_s(xmm0_save, xmm0);
+		movsd_s_sm(xmm0, inout);
+		ucomisd(xmm0, xmm0); // if (d == NaN) return 0;
+		jmpl_near(X86Conds.P, L1);
+		xorpd(sse_scratch, sse_scratch);
+		ucomisd(sse_scratch, xmm0); // if (d <= 0) return 0;
+		jmpl_near(X86Conds.NC, L1);
+		movd_rm_i(il_save, 0x00000000);
+		movd_rm_i(ih_save, 0x43f00000);
+		movsd_s_sm(sse_scratch, esp.plusSSE(0x0));
+		ucomisd(xmm0, sse_scratch); // if (d >= 2**64) return MAX_U64_INT;
+		jmpl_near(X86Conds.NC, L2);
+		movd_rm_i(ih_save, 0x43e00000);
+		movsd_s_sm(sse_scratch, esp.plusSSE(0x0));
+		ucomisd(xmm0, sse_scratch); // if (d >= 2**63) return ((unsigned long) (d - 2**63)) + MIN_I64_INT;
+		jmpl_near(X86Conds.NC, L3);
+		movsd_sm_s(inout, xmm0); // else return (unsigned long) d;
+		fld_q(inout);
+		fisttp_q(inout);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L2);
+		movd_rm_i(inout_il, 0xffffffff);
+		movd_rm_i(inout_ih, 0xffffffff);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L3);
+		subsd(xmm0, sse_scratch);
+		movsd_sm_s(inout, xmm0);
+		fld_q(inout);
+		fisttp_q(inout);
+		add.rm_i(inout_ih, 0x80000000);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L1);
+		xorpd(xmm0, xmm0);
+		movsd_sm_s(inout, xmm0);
+		bind(done);
+		movsd_s_sm(xmm0, xmm0_save);
+		add.rm_i(esp, 2 * 0x8);
+	}
+	// a macro to convert a floating point value to a long
+	def long_truncfp(il: X86Rm, ih: X86Rm, a: SSERm, isDouble: bool) {
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var save = esp.plusSSE(0x0);
+		sub.rm_i(esp, 0x8);
+		if (!isDouble) cvtss2sd(sse_scratch, a); // if single-precision float
+		else if (SSEReg.?(a)) sse_scratch = SSEReg.!(a); // XXX: cheeky way to save SSEReg
+		else if (SSEAddr.?(a)) movsd_s_sm(sse_scratch, a);
+		movsd_sm_s(save, sse_scratch);
+		var name = "d2l_fixup";
+		var addr = mach.stubMap[name].0;
+		if (addr == null) {
+			addr = Address.new(mach.codeRegion, name);
+			mach.stubMap[name] = (addr, gen_d2l_fixup_stub(mach, _, _, codeStartOffset));
+		}
+		call_addr(addr);
+		pop(il);
+		pop(ih);
+	}
+	/** stub that converts a double-precision float to a long with virgil
+	 *  truncation semantics
+	 *  @input: 64-bit floating point value on stack
+	 *  @output: 64-bit long on stack
+	 */
+	def d2l_fixup() {
+		var scratch = X86MachRegs.SCRATCH;
+		var sse_scratch = X86MachRegs.SSE_SCRATCH;
+		var inout = esp.plusSSE(5 * 0x4); // return value + 4 saves
+		var inout_il = inout.toX86Addr();
+		var inout_ih = esp.plus(6 * 0x4); // return value + 5 saves
+		var ih_save = esp.plus(0x4);
+		var il_save = esp.plus(0x0);
+		var xmm0_save = esp.plusSSE(0x8);
+		var L1 = Label.new(), L2 = Label.new();
+		var L3 = Label.new(), done = Label.new();
+		sub.rm_i(esp, 2 * 0x8);
+		movsd_sm_s(xmm0_save, xmm0);
+		movsd_s_sm(xmm0, inout);
+		ucomisd(xmm0, xmm0);
+		jmpl_near(X86Conds.P, L1); // if (d == NaN) return 0;
+		movd_rm_i(ih_save, 0xc3e00000);
+		movd_rm_i(il_save, 0x00000000);
+		movsd_s_sm(sse_scratch, esp.plusSSE(0x0));
+		ucomisd(sse_scratch, xmm0); // if (d <= -2**63) return MIN_I64_INT;
+		jmpl_near(X86Conds.NC, L2);
+		movd_rm_i(ih_save, 0x43e00000);
+		movsd_s_sm(sse_scratch, esp.plusSSE(0x0));
+		ucomisd(xmm0, sse_scratch); // if (d >= 2**63) return MAX_I64_INT;
+		jmpl_near(X86Conds.NC, L3);
+		movsd_sm_s(inout, xmm0); // else return (long)d;
+		fld_q(inout);
+		fisttp_q(inout);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L3);
+		movd_rm_i(inout_il, 0xffffffff);
+		movd_rm_i(inout_ih, 0x7fffffff);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L2);
+		movd_rm_i(inout_il, 0x0);
+		movd_rm_i(inout_ih, 0x80000000);
+		jmpl_near(X86Conds.ALWAYS, done);
+		bind(L1);
+		xorpd(xmm0, xmm0);
+		movsd_sm_s(inout, xmm0);
+		bind(done);
+		movsd_s_sm(xmm0, xmm0_save);
+		add.rm_i(esp, 2 * 0x8);
+	}
+	// a macro to perform bit equality for floating point values
 	def fp_bit_eq(dest: X86Reg, a: SSEReg, b: SSERm, isDouble: bool) {
 		var sse_scratch = X86MachRegs.SSE_SCRATCH;
 		if (isDouble) {
@@ -588,6 +1080,7 @@ class X86MacroAssembler extends X86Assembler {
 		movd_rm_s(dest, sse_scratch);
 		and.rm_i(dest, 0x1);
 	}
+	// a macro to generate a boolean after comparing two floating point values
 	def cmp_fp(cond: X86Cond, dest: X86Reg, a: SSEReg, b: SSERm, isDouble: bool) {
 		if (cond == X86Conds.NZ) movd_rm_i(dest, 0x1); // XXX: if unordered result, then default for != is true
 		else movd_rm_i(dest, 0x0);
@@ -598,6 +1091,7 @@ class X86MacroAssembler extends X86Assembler {
 		setx(cond, dest);
 		bind(label);
 	}
+	// a macro to compute the absolute value of a float
 	def fabs(dest: SSEReg, a: SSERm, isDouble: bool) {
 		if (isDouble) {
 			if (dest != a) movsd_s_sm(dest, a);

--- a/aeneas/src/x86/X86RegSet.v3
+++ b/aeneas/src/x86/X86RegSet.v3
@@ -29,9 +29,9 @@ component X86MachRegs {
 	def SCRATCH = X86Regs.EBP;
 	def SSE_SCRATCH = X86Regs.XMM7;
 
-	// a billion spill slots ought to be enough...
-	def CALLER_SPILL_START = 1000000000;
-	def CALLEE_SPILL_START = 2000000000;
+	// XXX: enough spill slots to not use the 31st bit
+	def CALLER_SPILL_START = 100000000;
+	def CALLEE_SPILL_START = 200000000;
 
 	var regs: MachRegSet;
 
@@ -50,16 +50,16 @@ component X86MachRegs {
 		rarray[XMM4] = [XMM4];
 		rarray[XMM5] = [XMM5];
 		rarray[XMM6] = [XMM6];
-		rarray[XMM7] = [XMM7];
-		rarray[EBP] = [];	// XXX: EBP is off limits because it's scratch
+		rarray[XMM7] = []; // XXX: EBP and XMM7 are off limits because they're scratch
+		rarray[EBP] = [];
 		rarray[GPR] = [EAX, EBX, ECX, EDX, ESI, EDI];
 		rarray[BYTE] = [EDX, ECX, EAX, EBX];
 		rarray[EAX_EDX] = [EAX, EDX];
 		rarray[NOT_EDX] = [EAX, EBX, ECX, ESI, EDI];
 		rarray[NOT_ECX] = [EAX, EBX, EDX, ESI, EDI];
 		rarray[GPR_CLASS] = [EAX, ECX, EDX, EBX, ESI, EDI];
-		rarray[SSE_CLASS] = [XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7];
-		rarray[ALL] = [EAX, EBX, ECX, EDX, ESI, EDI, XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7];
+		rarray[SSE_CLASS] = [XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6];
+		rarray[ALL] = [EAX, EBX, ECX, EDX, ESI, EDI, XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6];
 
 		var rnames = Array<string>.new(rarray.length);
 		rnames[EAX] = "eax";
@@ -91,7 +91,11 @@ component X86MachRegs {
 		rclasses[1] = SSE_CLASS;
 
 		// XXX: don't use EBP for scratch
-		regs = MachRegSet.new(14, rarray, rnames, rclasses, EBP, CALLER_SPILL_START, CALLEE_SPILL_START);
+		regs = MachRegSet.new(14, rarray, rnames, rclasses, EBP, XMM7, CALLER_SPILL_START, CALLEE_SPILL_START);
+	}
+
+	def isSSEReg(loc: int) -> bool {
+		return loc >= X86MachRegs.XMM0 && loc <= X86MachRegs.XMM7;
 	}
 }
 // Defines the standard parameter and return registers for X86 calls between Virgil methods.
@@ -113,11 +117,18 @@ component X86VirgilCallConv {
 					if (iprm < paramRegs.length) ploc[i] = paramRegs[iprm++];
 					else ploc[i] = spillStart + pspill++;
 				}
-				F32 => { // TODO: make F32 also spill 2 slots
+				F32 => {
 					if (fprm < floatParamRegs.length) ploc[i] = floatParamRegs[fprm++];
 					else ploc[i] = spillStart + pspill++;
 				}
-				_ => { // I64 or F64
+				F64 => {
+					if (fprm < floatParamRegs.length) ploc[i] = floatParamRegs[fprm++];
+					else {
+						ploc[i] = spillStart + pspill;
+						pspill += 2;
+					}
+				}
+				I64 => {
 					ploc[i] = spillStart + pspill;
 					pspill += 2;
 				}
@@ -127,8 +138,7 @@ component X86VirgilCallConv {
 		var len = returnTypes.length;
 		if (len == 0) len = 1;  // TODO: fix return count
 		var rloc = Array<int>.new(len), rspill = 0;
-		iprm = 0;
-		fprm = 0;
+		iprm = 0; fprm = 0;
 		if (returnTypes.length != 0) {	// XXX: working around the return count
 			for (i < rloc.length) {
 				match (Regs.toRegClass(returnTypes[i])) {
@@ -136,13 +146,20 @@ component X86VirgilCallConv {
 						if (iprm < retRegs.length) rloc[i] = retRegs[iprm++];
 						else rloc[i] = spillStart + rspill++;
 					}
-					F32 => { // TODO: make F32 also spill 2 slots
+					F32 => {
 						if (fprm < floatRetRegs.length) rloc[i] = floatRetRegs[fprm++];
 						else rloc[i] = spillStart + rspill++;
 					}
-					_ => { // I64 or F64
-						ploc[i] = spillStart + pspill;
-						pspill += 2;
+					F64 => {
+						if (fprm < floatRetRegs.length) rloc[i] = floatRetRegs[fprm++];
+						else {
+							rloc[i] = spillStart + rspill;
+							rspill += 2;
+						}
+					}
+					I64 => {
+						rloc[i] = spillStart + rspill;
+						rspill += 2;
 					}
 				}
 			}

--- a/aeneas/test/MoveResolverTest.v3
+++ b/aeneas/test/MoveResolverTest.v3
@@ -42,7 +42,7 @@ def move(src: int, dst: int) {
 	input[dst] = val;
 }
 
-def alloc() -> int {
+def alloc(loc: int) -> int {
 	return 0; // always use register 0 for a temporary
 }
 

--- a/test/float/ret_tuple03.v3
+++ b/test/float/ret_tuple03.v3
@@ -1,0 +1,10 @@
+//@execute =61
+def check(a: float, b: float) -> (float, int) {
+	if (a > b) return (a + b, 61);
+	else return (b - a, 100);
+}
+def main() -> int {
+	var t = check(105.5f, -222.5f);
+	if (t.1 > int.truncf(t.0)) return t.1;
+	else return 500;
+}

--- a/test/float/ret_tuple04.v3
+++ b/test/float/ret_tuple04.v3
@@ -1,0 +1,15 @@
+//@execute =61
+def f(a: float, b: float) -> (float, float) {
+	return (a, b);
+}
+def g(a: float, b: float) -> (float, float) {
+	return (b, a);
+}
+def check(a: float, b: float) -> int {
+	if (f(a, b) != (a, b)) return -1;
+	if (g(a, b) != (b, a)) return -3;
+	return 61;
+}
+def main() -> int {
+	return check(105.5f, -222.5f);
+}


### PR DESCRIPTION
This patch basically condenses every change *except* the actual isel for floating point support on x86. Unfortunately, I looked into it and the x87 FPU dependencies will be necessary until we move to x64.

I've heavily commented the stubs and macros in the X86MacroAssembler to make it clear what every function does. I'll create a new PR for the isel when this one is approved.

~Kunal