### PR TITLE
Add check for word size when calculating number of spill slots

### DIFF
--- a/aeneas/src/arm/ArmRuntime.v3
+++ b/aeneas/src/arm/ArmRuntime.v3
@@ -21,7 +21,7 @@ class ArmRuntime extends MachRuntime {
 	def genArmCode(irm: IrMethod, codegen: ArmCodeGen) {
 		context.enterMethod(irm);
 		context.graph.resetMarks(null);
-		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(context.graph));
+		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(context.graph), mach.data.addressSize);
 		codegen.generate(irm, frame);
 	}
 	def genTestInputs(main: IrMethod, asm: ArmMacroAssembler, frame: MachFrame) {
@@ -95,7 +95,7 @@ class ArmRuntime extends MachRuntime {
 		asm_exit_r(asm, asm.loc_r(frame, frame.conv.callerRet(0)));
 	}
 	def getFrame(ssa: SsaGraph) -> MachFrame {
-		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(ssa));
+		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(ssa), mach.data.addressSize);
 		frame.frameSize = mach.data.addressSize;
 		return frame;
 	}

--- a/aeneas/src/arm/ArmRuntime.v3
+++ b/aeneas/src/arm/ArmRuntime.v3
@@ -21,7 +21,7 @@ class ArmRuntime extends MachRuntime {
 	def genArmCode(irm: IrMethod, codegen: ArmCodeGen) {
 		context.enterMethod(irm);
 		context.graph.resetMarks(null);
-		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(context.graph), mach.data.addressSize);
+		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(context.graph), mach.data.addrAlign);
 		codegen.generate(irm, frame);
 	}
 	def genTestInputs(main: IrMethod, asm: ArmMacroAssembler, frame: MachFrame) {
@@ -95,7 +95,7 @@ class ArmRuntime extends MachRuntime {
 		asm_exit_r(asm, asm.loc_r(frame, frame.conv.callerRet(0)));
 	}
 	def getFrame(ssa: SsaGraph) -> MachFrame {
-		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(ssa), mach.data.addressSize);
+		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(ssa), mach.data.addrAlign);
 		frame.frameSize = mach.data.addressSize;
 		return frame;
 	}

--- a/aeneas/src/arm/ArmRuntime.v3
+++ b/aeneas/src/arm/ArmRuntime.v3
@@ -21,7 +21,7 @@ class ArmRuntime extends MachRuntime {
 	def genArmCode(irm: IrMethod, codegen: ArmCodeGen) {
 		context.enterMethod(irm);
 		context.graph.resetMarks(null);
-		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(context.graph), mach.data.addrAlign);
+		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(context.graph), mach.data.addrAlign, mach.refSize);
 		codegen.generate(irm, frame);
 	}
 	def genTestInputs(main: IrMethod, asm: ArmMacroAssembler, frame: MachFrame) {
@@ -95,7 +95,7 @@ class ArmRuntime extends MachRuntime {
 		asm_exit_r(asm, asm.loc_r(frame, frame.conv.callerRet(0)));
 	}
 	def getFrame(ssa: SsaGraph) -> MachFrame {
-		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(ssa), mach.data.addrAlign);
+		var frame = MachFrame.new(ArmVirgilCallConv.getForGraph(ssa), mach.data.addrAlign, mach.refSize);
 		frame.frameSize = mach.data.addressSize;
 		return frame;
 	}

--- a/aeneas/src/mach/MachBackend.v3
+++ b/aeneas/src/mach/MachBackend.v3
@@ -91,8 +91,7 @@ class MachFrame(conv: MachCallConv, wordSize: int) {
 	def allocSpill(regClass: RegClass) -> int {
 		match (regClass) {
 			I64, F64 => {
-				var numSpill = 64 / wordSize;
-				if (numSpill == 0) numSpill = 1; // in case word size is larger than 64-bit XXX: is it required?
+				var numSpill = if(wordSize >= 64, 1, 2); // XXX: assumes at least 32-bit word size
 				var spill = conv.regSet.spillStart + spillVars;
 				spillVars += numSpill;
 				return spill | IS_64;

--- a/aeneas/src/mach/MachBackend.v3
+++ b/aeneas/src/mach/MachBackend.v3
@@ -81,7 +81,7 @@ class VReg {
 	}
 }
 // Representation of a machine frame, including spill slots and space for outgoing params
-class MachFrame(conv: MachCallConv) {
+class MachFrame(conv: MachCallConv, wordSize: int) {
 	var spillVars: int;		// spilled variables
 	var spillArgs: int;		// space for outgoing spilled arguments
 	var frameSize: int = -1;	// architecture-specific total frame size
@@ -91,8 +91,10 @@ class MachFrame(conv: MachCallConv) {
 	def allocSpill(regClass: RegClass) -> int {
 		match (regClass) {
 			I64, F64 => {
+				var numSpill = 64 / wordSize;
+				if (numSpill == 0) numSpill = 1; // in case word size is larger than 64-bit XXX: is it required?
 				var spill = conv.regSet.spillStart + spillVars;
-				spillVars += 2; // XXX: wasteful on 64-bit
+				spillVars += numSpill;
 				return spill | IS_64;
 			}
 			_ => return conv.regSet.spillStart + spillVars++;

--- a/aeneas/src/mach/MachBackend.v3
+++ b/aeneas/src/mach/MachBackend.v3
@@ -29,6 +29,14 @@ enum RegClass {
 }
 // Conversion functions from V3 Types to RegClasses
 component RegClasses {
+	// size in bytes
+	def size(t: RegClass, align: Alignment) -> int {
+		match (t) {
+			I64, F64 => return 8;
+			REF => return align.size;
+			_ => return 4;
+		}
+	}
 	def fromType(t: Type) -> RegClass {
 		match (t.typeCon.kind) {
 			V3Kind.INT => return fromIntType(IntType.!(t));
@@ -81,7 +89,7 @@ class VReg {
 	}
 }
 // Representation of a machine frame, including spill slots and space for outgoing params
-class MachFrame(conv: MachCallConv, wordSize: int) {
+class MachFrame(conv: MachCallConv, align: Alignment) {
 	var spillVars: int;		// spilled variables
 	var spillArgs: int;		// space for outgoing spilled arguments
 	var frameSize: int = -1;	// architecture-specific total frame size
@@ -89,15 +97,11 @@ class MachFrame(conv: MachCallConv, wordSize: int) {
 	def IS_64: int = 0x40000000;	// if the spilled value is 64 bits
 
 	def allocSpill(regClass: RegClass) -> int {
-		match (regClass) {
-			I64, F64 => {
-				var numSpill = if(wordSize >= 64, 1, 2); // XXX: assumes at least 32-bit word size
-				var spill = conv.regSet.spillStart + spillVars;
-				spillVars += numSpill;
-				return spill | IS_64;
-			}
-			_ => return conv.regSet.spillStart + spillVars++;
-		}
+		var is64 = if(regClass == RegClass.I64 || regClass == RegClass.F64, IS_64);
+		var numSpill = align.alignUp(RegClasses.size(regClass, align)) >> align.shift;
+		var spill = conv.regSet.spillStart + spillVars;
+		spillVars += numSpill;
+		return spill | is64;
 	}
 	def getTmpSpill(regClass: RegClass) -> int {
 		var is64 = if(regClass == RegClass.I64 || regClass == RegClass.F64, IS_64);

--- a/aeneas/src/mach/MachBackend.v3
+++ b/aeneas/src/mach/MachBackend.v3
@@ -30,10 +30,10 @@ enum RegClass {
 // Conversion functions from V3 Types to RegClasses
 component RegClasses {
 	// size in bytes
-	def size(t: RegClass, align: Alignment) -> int {
+	def size(t: RegClass, refSize: int) -> int {
 		match (t) {
 			I64, F64 => return 8;
-			REF => return align.size;
+			REF => return refSize;
 			_ => return 4;
 		}
 	}
@@ -89,7 +89,7 @@ class VReg {
 	}
 }
 // Representation of a machine frame, including spill slots and space for outgoing params
-class MachFrame(conv: MachCallConv, align: Alignment) {
+class MachFrame(conv: MachCallConv, align: Alignment, refSize: int) {
 	var spillVars: int;		// spilled variables
 	var spillArgs: int;		// space for outgoing spilled arguments
 	var frameSize: int = -1;	// architecture-specific total frame size
@@ -98,7 +98,7 @@ class MachFrame(conv: MachCallConv, align: Alignment) {
 
 	def allocSpill(regClass: RegClass) -> int {
 		var is64 = if(regClass == RegClass.I64 || regClass == RegClass.F64, IS_64);
-		var numSpill = align.alignUp(RegClasses.size(regClass, align)) >> align.shift;
+		var numSpill = align.alignUp(RegClasses.size(regClass, refSize)) >> align.shift;
 		var spill = conv.regSet.spillStart + spillVars;
 		spillVars += numSpill;
 		return spill | is64;

--- a/aeneas/src/x86-64/X86_64Backend.v3
+++ b/aeneas/src/x86-64/X86_64Backend.v3
@@ -220,7 +220,7 @@ class X86_64Backend extends MachBackend {
 		asm.xaddq_m_r(addr, reg);
 	}
 	def getFrame(ssa: SsaGraph) -> MachFrame {
-		return MachFrame.new(X86_64VirgilCallConv.getForGraph(ssa), mach.code.addressSize);
+		return MachFrame.new(X86_64VirgilCallConv.getForGraph(ssa), mach.data.addrAlign);
 	}
 	def computeFrameSize(frame: MachFrame) -> MachFrame {
 		frame.frameSize = mach.alignTo(frame.slots() * mach.refSize + mach.code.addressSize, mach.stackAlign);

--- a/aeneas/src/x86-64/X86_64Backend.v3
+++ b/aeneas/src/x86-64/X86_64Backend.v3
@@ -220,7 +220,7 @@ class X86_64Backend extends MachBackend {
 		asm.xaddq_m_r(addr, reg);
 	}
 	def getFrame(ssa: SsaGraph) -> MachFrame {
-		return MachFrame.new(X86_64VirgilCallConv.getForGraph(ssa), mach.data.addrAlign);
+		return MachFrame.new(X86_64VirgilCallConv.getForGraph(ssa), mach.data.addrAlign, mach.refSize);
 	}
 	def computeFrameSize(frame: MachFrame) -> MachFrame {
 		frame.frameSize = mach.alignTo(frame.slots() * mach.refSize + mach.code.addressSize, mach.stackAlign);

--- a/aeneas/src/x86-64/X86_64Backend.v3
+++ b/aeneas/src/x86-64/X86_64Backend.v3
@@ -220,7 +220,7 @@ class X86_64Backend extends MachBackend {
 		asm.xaddq_m_r(addr, reg);
 	}
 	def getFrame(ssa: SsaGraph) -> MachFrame {
-		return MachFrame.new(X86_64VirgilCallConv.getForGraph(ssa));
+		return MachFrame.new(X86_64VirgilCallConv.getForGraph(ssa), mach.code.addressSize);
 	}
 	def computeFrameSize(frame: MachFrame) -> MachFrame {
 		frame.frameSize = mach.alignTo(frame.slots() * mach.refSize + mach.code.addressSize, mach.stackAlign);

--- a/aeneas/src/x86/X86Backend.v3
+++ b/aeneas/src/x86/X86Backend.v3
@@ -259,7 +259,7 @@ class X86Backend extends MachBackend {
 		MachDataWriter.!(asm.w).recordPatch(addr, asm.pos() - 4);
 	}
 	def getFrame(ssa: SsaGraph) -> MachFrame {
-		var frame = MachFrame.new(X86VirgilCallConv.getForGraph(ssa), mach.data.addressSize);
+		var frame = MachFrame.new(X86VirgilCallConv.getForGraph(ssa), mach.data.addrAlign);
 		frame.frameSize = mach.data.addressSize;
 		return frame;
 	}

--- a/aeneas/src/x86/X86Backend.v3
+++ b/aeneas/src/x86/X86Backend.v3
@@ -259,7 +259,7 @@ class X86Backend extends MachBackend {
 		MachDataWriter.!(asm.w).recordPatch(addr, asm.pos() - 4);
 	}
 	def getFrame(ssa: SsaGraph) -> MachFrame {
-		var frame = MachFrame.new(X86VirgilCallConv.getForGraph(ssa));
+		var frame = MachFrame.new(X86VirgilCallConv.getForGraph(ssa), mach.data.addressSize);
 		frame.frameSize = mach.data.addressSize;
 		return frame;
 	}

--- a/aeneas/src/x86/X86Backend.v3
+++ b/aeneas/src/x86/X86Backend.v3
@@ -259,7 +259,7 @@ class X86Backend extends MachBackend {
 		MachDataWriter.!(asm.w).recordPatch(addr, asm.pos() - 4);
 	}
 	def getFrame(ssa: SsaGraph) -> MachFrame {
-		var frame = MachFrame.new(X86VirgilCallConv.getForGraph(ssa), mach.data.addrAlign);
+		var frame = MachFrame.new(X86VirgilCallConv.getForGraph(ssa), mach.data.addrAlign, mach.refSize);
 		frame.frameSize = mach.data.addressSize;
 		return frame;
 	}

--- a/aeneas/src/x86/X86CodeGen.v3
+++ b/aeneas/src/x86/X86CodeGen.v3
@@ -55,7 +55,7 @@ class X86CodeGen extends OldCodeGen {
 	var kernel: Kernel;
 
 	new(mach: MachProgram, context: SsaContext) super(mach, context) {
-		frame = MachFrame.new(X86VirgilCallConv.getForGraph(context.graph), mach.code.addressSize);
+		frame = MachFrame.new(X86VirgilCallConv.getForGraph(context.graph), mach.data.addrAlign);
 	}
 	def genCode(asm: X86MacroAssembler) {
 		this.asm = asm;

--- a/aeneas/src/x86/X86CodeGen.v3
+++ b/aeneas/src/x86/X86CodeGen.v3
@@ -55,7 +55,7 @@ class X86CodeGen extends OldCodeGen {
 	var kernel: Kernel;
 
 	new(mach: MachProgram, context: SsaContext) super(mach, context) {
-		frame = MachFrame.new(X86VirgilCallConv.getForGraph(context.graph), mach.data.addrAlign);
+		frame = MachFrame.new(X86VirgilCallConv.getForGraph(context.graph), mach.data.addrAlign, mach.refSize);
 	}
 	def genCode(asm: X86MacroAssembler) {
 		this.asm = asm;

--- a/aeneas/src/x86/X86CodeGen.v3
+++ b/aeneas/src/x86/X86CodeGen.v3
@@ -55,7 +55,7 @@ class X86CodeGen extends OldCodeGen {
 	var kernel: Kernel;
 
 	new(mach: MachProgram, context: SsaContext) super(mach, context) {
-		frame = MachFrame.new(X86VirgilCallConv.getForGraph(context.graph));
+		frame = MachFrame.new(X86VirgilCallConv.getForGraph(context.graph), mach.code.addressSize);
 	}
 	def genCode(asm: X86MacroAssembler) {
 		this.asm = asm;

--- a/aeneas/src/x86/X86MacroAssembler.v3
+++ b/aeneas/src/x86/X86MacroAssembler.v3
@@ -475,7 +475,7 @@ class X86MacroAssembler extends X86Assembler {
 	def u64_divmod_small_divisor(op: WideDivision, source: Source, stub: bool) {
 		var start = codeOffset(), frame: MachFrame;
 		if (op.zeroCheck && stub && mach.runtime.src != null) {
-			var frame = MachFrame.new(null);
+			var frame = MachFrame.new(null, 0);
 			frame.frameSize = 0;
 			mach.runtime.src.recordStubStart(start, op.name, frame);
 		}

--- a/aeneas/src/x86/X86MacroAssembler.v3
+++ b/aeneas/src/x86/X86MacroAssembler.v3
@@ -475,7 +475,7 @@ class X86MacroAssembler extends X86Assembler {
 	def u64_divmod_small_divisor(op: WideDivision, source: Source, stub: bool) {
 		var start = codeOffset(), frame: MachFrame;
 		if (op.zeroCheck && stub && mach.runtime.src != null) {
-			var frame = MachFrame.new(null, null);
+			var frame = MachFrame.new(null, null, 0);
 			frame.frameSize = 0;
 			mach.runtime.src.recordStubStart(start, op.name, frame);
 		}

--- a/aeneas/src/x86/X86MacroAssembler.v3
+++ b/aeneas/src/x86/X86MacroAssembler.v3
@@ -475,7 +475,7 @@ class X86MacroAssembler extends X86Assembler {
 	def u64_divmod_small_divisor(op: WideDivision, source: Source, stub: bool) {
 		var start = codeOffset(), frame: MachFrame;
 		if (op.zeroCheck && stub && mach.runtime.src != null) {
-			var frame = MachFrame.new(null, 0);
+			var frame = MachFrame.new(null, null);
 			frame.frameSize = 0;
 			mach.runtime.src.recordStubStart(start, op.name, frame);
 		}


### PR DESCRIPTION
Quick change that I noticed. Makes it so that 64-bit only uses one spill slot. Does make assumptions that at least 32-bit word size.