### PR TITLE
[doc] README: add link to paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Virgil focuses on balancing these main features in a statically-typed language:
   * Type parameters - for powerful and clean abstraction over types
   * Algebraic data types - for easy building and matching of data structures
 
-For more, see the [tutorial](doc/tutorial/Overview.md).
+For more, read [this paper](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/41446.pdf).
+Or see the [tutorial](doc/tutorial/Overview.md).
 Or read up on [libraries](doc/tutorial/LibUtil.md).
 
 ## Supported Targets


### PR DESCRIPTION
The _Harmonizing Classes, Functions, Tuples, and Type Parameters in Virgil III_ paper is a great in-depth overview of Virgil's features but the link at the bottom of the README is hidden behind a paywall (this link isn't).