### PR TITLE
Parsing added

### DIFF
--- a/aeneas/src/vst/Parser.v3
+++ b/aeneas/src/vst/Parser.v3
@@ -135,7 +135,8 @@ component Parser {
 			's' => {
 				if (optKeyword(p, "struct") != null) {
 					var id = parseIdentVoid(p).name;
-					var decl = parseStructDecl(p, id);
+					var repHints = parseRepHints(p);
+					var decl = parseStructDecl(p, id, repHints);
 					file.structs.put(decl);
 					return true;
 				}
@@ -194,8 +195,15 @@ component Parser {
 	}
 	def parseRepHint(p: ParserState) -> VstRepHint {
 		p.eat1();
-		var kw = parseIdentVoid(p);
+		var kw = parseRepHintCommon<void>(p, null);
 		return VstRepHint.new(List.new(kw, null));
+	}
+	def parseRepHints(p: ParserState) -> List<VstRepHint> {
+		var repHints : List<VstRepHint>;
+		while (p.curByte == '#') {
+			repHints = List.new(parseRepHint(p), repHints);
+		}
+		return repHints;
 	}
 	def parseVariantCases(p: ParserState, desugar: VariantDesugaring) -> List<VstMember> {
 		var list = desugar.synthesizeMembers(p.fileName, p.curLine, p.curCol);
@@ -303,7 +311,7 @@ component Parser {
 		if (id.name.image.length > 0) return VstEnumCase.new(tag, id.name, args);
 		return null;
 	}
-	def parseStructDecl(p: ParserState, name: Token) -> VstStruct {
+	def parseStructDecl(p: ParserState, name: Token, repHints: List<VstRepHint>) -> VstStruct {
 		p.req1('{');
 		var list: List<VstMember>;
 		while (p.curByte == '+') {
@@ -315,7 +323,7 @@ component Parser {
 		var size = parseIntLiteral(p);
 		p.req1(';');
 		p.req1('}');
-		var decl = VstStruct.new(size, name, null, Lists.reverse(list));
+		var decl = VstStruct.new(size, name, null, Lists.reverse(list), repHints);
 		return decl;
 	}
 	def parseStructField(p: ParserState, prev: List<VstMember>) -> List<VstMember> {
@@ -324,8 +332,9 @@ component Parser {
 		var id = Parser.parseIdentVoid(p).name;
 		p.req1(':');
 		var type_ref = parseMemoryTypeRef(p);
+		var repHints = parseRepHints(p);
 		p.req1(';');
-		return List.new(VstStructField.new(offset, type_ref, id), prev);
+		return List.new(VstStructField.new(offset, type_ref, id, repHints), prev);
 	}
 	def parseMembers(p: ParserState) -> List<VstMember> {
 		p.req1('{');
@@ -447,17 +456,14 @@ component Parser {
 		return tref;
 	}
 	def parseMemoryTypeRef(p: ParserState) -> MemoryTypeRef {
-		var tref: TypeRef;
-		if (optKeyword(p, "inline") != null) {
+		var tref = parseTypeRef(p);
+		if (p.curByte == '[') {
 			p.req1('[');
 			var numRepeated = parseIntLiteral(p);
 			p.req1(']');
-			p.req1('<');
-			var tref = parseIdentVoid(p);
-			p.req1('>');
-			return MemoryTypeRef.new(true, numRepeated, tref.name);
+			return MemoryTypeRef.new(true, numRepeated, tref);
 		}
-		return MemoryTypeRef.new(false, null, parseIdentVoid(p).name);
+		return MemoryTypeRef.new(false, null, tref);
 	}
 	def parseTypeParam(p: ParserState) -> TypeParamType {
 		var id = parseIdentVoid(p).name;
@@ -1017,6 +1023,29 @@ component Parser {
 	}
 	def parseIdentUnchecked<T>(p: ParserState, parse: ParserState -> T) -> VstIdent<T> {
 		return parseIdentCommon(p, parse);
+	}
+	def parseRepHintCommon<T>(p: ParserState, parse: ParserState -> T) -> VstIdent<T> {
+		if (Char.isIdentStart(p.curByte)) {
+			var d = p.input;
+			for (q = p.curPos + 1; q < d.length; q++) {
+				var c = d[q];
+				if (c == '<') { // parse parameters, if allowed
+					if (parse == null) {
+						p.error("identifier cannot be parameterized here");
+						return extractIdent(p, q);
+					}
+					var id = extractIdent<T>(p, q);
+					var list = parseList(1, p, '<', COMMA, '>', parse);
+					return VstIdent<T>.new(id.name, id.kwClass, list);
+				}
+				// if the character is part of the middle continue
+				if (!(Char.isIdentMiddle(c) || c == '-')) return extractIdent(p, q);
+			}
+			// end of input
+			return extractIdent(p, d.length);
+		}
+		p.error("identifier expected");
+		return extractIdent(p, p.curPos);
 	}
 	// parse a parameterized identifier with the supplied parameter parsing function
 	def parseIdentCommon<T>(p: ParserState, parse: ParserState -> T) -> VstIdent<T> {

--- a/aeneas/src/vst/Verifier.v3
+++ b/aeneas/src/vst/Verifier.v3
@@ -24,12 +24,14 @@ class Verifier(compiler: Compiler, prog: Program) {
 		forAll(vst.components, verifyComponent);
 		forAll(vst.classes, verifyClass);
 		forAll(vst.enums, verifyEnum);
+		forAll(vst.structs, verifyStruct);
 		if (vst.exports.length > 0) {
 			forAll(vst.exports, verifyExport(Strings.newMap<ExportDecl>(), _));
 		}
 		forAll<VstComponent>(vst.components, typeCheckVstCompound);
 		forAll<VstClass>(vst.classes, typeCheckVstCompound);
 		forAll<VstEnum>(vst.enums, typeCheckVstCompound);
+		forAll<VstStruct>(vst.structs, typeCheckVstCompound);
 
 		typeCache = null; // typeCache for type vars is now dead
 		if (ERROR.noErrors) {
@@ -63,6 +65,11 @@ class Verifier(compiler: Compiler, prog: Program) {
 		for (i < file.enums.length) {
 			var enumDecl = file.enums[i];
 			buildCompound(enumDecl, enumDecl.getDeclaredType(), file, false);
+		}
+		prog.vst.structs.putv(file.structs);
+		for (i < file.structs.length) {
+			var structDecl = file.structs[i];
+			buildCompound(structDecl, structDecl.getDeclaredType(), file, false);
 		}
 		prog.vst.exports.putv(file.exports);
 	}
@@ -129,7 +136,7 @@ class Verifier(compiler: Compiler, prog: Program) {
 			mdecl.receiver = decl;
 		}
 		var constructor = decl.constructor;
-		if (constructor == null) {
+		if (constructor == null && !VstStruct.?(decl)) {
 			// fill in a default constructor if one wasn't declared
 			var name = Token.new(decl.token.fileName, "new", decl.token.beginLine, decl.token.beginColumn);
 			var superclause = decl.superclause;
@@ -203,6 +210,10 @@ class Verifier(compiler: Compiler, prog: Program) {
 		}
 	}
 	def verifyEnum(decl: VstEnum) {
+		var verifier = decl.verifier;
+		verifier.verify();
+	}
+	def verifyStruct(decl: VstStruct) {
 		var verifier = decl.verifier;
 		verifier.verify();
 	}
@@ -388,6 +399,11 @@ class VstCompoundVerifier {
 		classDecl.numFields = superType.classDecl.numFields;
 		classDecl.numMethods = superType.classDecl.numMethods;
 	}
+	def typeLength(t: Type) -> int {
+		// TODO: finish typeLength function that takes in a type and returns the corresponding
+		// length
+		return -1;
+	}
 	def verify() {
 		if (VstEnum.?(compound)) {
 			if (VstEnum.!(compound).cases.length == 0) {
@@ -397,6 +413,17 @@ class VstCompoundVerifier {
 		Lists.apply(compound.members, checkMember);
 		if (compound.constructor != null) {
 			compound.constructor.memberinits = Lists.reverse(memberinits);
+		}
+		if (VstStruct.?(compound)) {
+			var fields = VstStruct.!(compound).members;
+			var alloced : List<(int, int)> = List.new((Int.MIN_VALUE, 0), null);
+			def size = Int.unbox(IntLiteral.!(VstStruct.!(compound).size).val);
+			alloced = List.new((size, Int.MAX_VALUE), alloced);
+			for (l = fields; l != null; l = l.tail) {
+				var field = VstStructField.!(l.head);
+				var offset = Int.unbox(IntLiteral.!(field.offset).val);
+				// TODO: verify OOB error and overlapping fields one by one
+			}
 		}
 		verified = true;
 		if (classType != null) {

--- a/aeneas/src/vst/Vst.v3
+++ b/aeneas/src/vst/Vst.v3
@@ -164,7 +164,7 @@ class VstEnum extends VstCompound {
 // Representation of a struct
 class VstStruct extends VstCompound {
 	def size: Literal;
-	new(size, name: Token, params: VstList<ParamDecl>, members: List<VstMember>)
+	new(size, name: Token, params: VstList<ParamDecl>, members: List<VstMember>, repHints: List<VstRepHint>)
 		super(name, null, params, null, members) {
 			typeCon = TypeCon.new(token.image, V3Kind.STRUCT, 0, TypeUtil.globalCache);
 		}
@@ -184,7 +184,7 @@ class VstStructField extends VstMember{
 	def mtref: MemoryTypeRef;
 	var mvtype: Type;
 	var repeatCnt = 1;
-	new (offset, mtref, name: Token) super(false, name) { }
+	new (offset, mtref, name: Token, repHints: List<VstRepHint>) super(false, name) { }
 }
 // A helper class for desugaring variants into VstClasses.
 class VariantDesugaring(outer: VstIdent<TypeParamType>, params: VstList<ParamDecl>) {
@@ -476,18 +476,20 @@ class NamedTypeRef(left: NamedTypeRef, name: Token, nested: VstList<TypeRef>) ex
 	}
 }
 // allowed memory types in structs
-class MemoryTypeRef(isInline: bool, numRepeated: Literal, name: Token) extends TypeRef{
+class MemoryTypeRef(isInline: bool, numRepeated: Literal, tref: TypeRef) extends TypeRef{
 	def repeatCnt = numRepeated;
+	def typeref = tref;
 	def render(buf: StringBuilder) -> StringBuilder {
 		if (isInline) {
-			buf.put2("inline[%s]<%s>", numRepeated.token.image, name.image);
+			buf = tref.render(buf);
+			buf.put1("inline[%s]", numRepeated.token.image);
 		} else {
-			buf.puts(name.image);
+			buf = tref.render(buf);
 		}
 		return buf;
 	}
 	def range() -> FileRange {
-		return name.range();
+		return tref.range();
 	}
 }
 // name [ : tref ] = expr

--- a/bin/v3c
+++ b/bin/v3c
@@ -1,9 +1,1 @@
-#!/bin/bash
-
-BIN=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
-$BIN/.setup-v3c
-if [ $? = 0 ]; then
-	$BIN/v3c "$@"
-else
-	exit $?
-fi
+/Users/mc/virgil/bin/current/jar/Aeneas

--- a/test/struct/parser/float6.v3
+++ b/test/struct/parser/float6.v3
@@ -1,5 +1,5 @@
 //@parse = ParseError @ 3:10
 struct X {
-	+0	tag: inline[0f]<byte>;
+	+0	tag: byte[0f];
 	=4;
 }

--- a/test/struct/parser/hex3.v3
+++ b/test/struct/parser/hex3.v3
@@ -1,5 +1,5 @@
 //@parse
 struct X {
-	+0	tag: 	inline[0xA9]<byte>;
+	+0	tag: 	byte[0xA9];
 	=0x19A;
 }

--- a/test/struct/parser/inline0.v3
+++ b/test/struct/parser/inline0.v3
@@ -1,4 +1,4 @@
-//@parse = ParseError @ 3:31
+//@parse
 struct X {
 	+0	tag:	inline<byte>[1];
 	=1;

--- a/test/struct/parser/inline1.v3
+++ b/test/struct/parser/inline1.v3
@@ -1,5 +1,5 @@
 //@parse
 struct X {
-	+0	tag:	inline[1]<byte>;
+	+0	tag:	byte[1];
 	=1;
 }

--- a/test/struct/parser/long1.v3
+++ b/test/struct/parser/long1.v3
@@ -2,8 +2,8 @@
 struct long1 {
 	+0	tag:		byte;
 	+1	size:		int;
-	+5	sizes:		inline[5]<int>;
-	+25	pair:		inline[6]<byte>;
-	+31	padding:	inline[9]<byte>;
+	+5	sizes:		int[5];
+	+25	pair:		byte[6];
+	+31	padding:	byte[9];
 	=40;
 }

--- a/test/struct/parser/long2.v3
+++ b/test/struct/parser/long2.v3
@@ -2,9 +2,9 @@
 struct long2 {
 	+0	tag:		byte;
 	+1	size:		int;
-	+5	sizes:		inline[20]<int>;
-	+25	pair:		inline[6]<byte>;
-	+31	padding:	inline[9]<byte>;
+	+5	sizes:		int[20];
+	+25	pair:		byte[6];
+	+31	padding:	byte[9];
 	=40;
 	=41;
 }

--- a/test/struct/parser/long3.v3
+++ b/test/struct/parser/long3.v3
@@ -1,6 +1,6 @@
 //@parse = ParseError @ 4:8
 struct long3 {
 	+0	tag:	byte;
-	=1	size:	inline[30]<int>;
+	=1	size:	int[30];
 	=31;
 }

--- a/test/struct/parser/misc10.v3
+++ b/test/struct/parser/misc10.v3
@@ -11,6 +11,6 @@ struct test2 {
 }
 
 struct test3 {
-	+0		member:		inline[3]<int>;
+	+0		member:		int[3];
 	=12;
 }

--- a/test/struct/parser/multiple10.v3
+++ b/test/struct/parser/multiple10.v3
@@ -1,6 +1,6 @@
 //@parse
 struct multiple {
-	+0		tag:		inline[2]<byte>;
-	+1		size:		inline[2]<int>;
+	+0		tag:		byte[2];
+	+1		size:		int[2];
 	=5;
 }

--- a/test/struct/parser/multiple11.v3
+++ b/test/struct/parser/multiple11.v3
@@ -1,7 +1,7 @@
 //@parse
 struct multiple {
 	+0		size:		int;
-	+4		tag0:		inline[2]<byte>;
-	+5		tag1:		inline[2]<byte>;
+	+4		tag0:		byte[2];
+	+5		tag1:		byte[2];
 	=6;
 }

--- a/test/struct/parser/multiple12.v3
+++ b/test/struct/parser/multiple12.v3
@@ -1,6 +1,6 @@
 //@parse
 struct multiple {
-	+0		pair:		inline[4]<int>;
-	+8		pair2:		inline[4]<byte>;
+	+0		pair:		int[4];
+	+8		pair2:		byte[4];
 	=10;
 }

--- a/test/struct/parser/multiple13.v3
+++ b/test/struct/parser/multiple13.v3
@@ -1,8 +1,8 @@
 //@parse
 struct multiple {
-	+0		triple:		inline[26]<byte>;
-	+13		size:		inline[2]<int>;
-	+17		tag:		inline[2]<byte>;
-	+18		pair:		inline[10]<byte>;
+	+0		triple:		byte[26];
+	+13		size:		int[2];
+	+17		tag:		byte[2];
+	+18		pair:		byte[10];
 	=23;
 }

--- a/test/struct/parser/multiple14.v3
+++ b/test/struct/parser/multiple14.v3
@@ -1,8 +1,8 @@
 //@parse = ParseError @ 3:36
 struct multiple {
-	+0		triple:		inlinee[26]<byte>;
-	+13		size:		inline[2]<int>;
-	+17		tag:		inline[2]<byte>;
-	+18		pair:		inline[10]<byte>;
+	+0		triple:		bytee<[26];
+	+13		size:		int[2];
+	+17		tag:		byte[2];
+	+18		pair:		byte[10];
 	=23;
 }

--- a/test/struct/parser/multiple15.v3
+++ b/test/struct/parser/multiple15.v3
@@ -1,8 +1,8 @@
 //@parse = ParseError @ 4:54
 struct multiple {
-	+0		triple:		inline[26]<byte>;
-	+13		size:		inline[2]<int>>;
-	+17		tag:		inline[2]<byte>;
-	+18		pair:		inline[10]<byte>;
+	+0		triple:		byte[26];
+	+13		size:		int[2]>;
+	+17		tag:		byte[2];
+	+18		pair:		byte[10];
 	=23;
 }

--- a/test/struct/parser/multiple2.v3
+++ b/test/struct/parser/multiple2.v3
@@ -1,6 +1,6 @@
 //@parse
 struct multiple {
-	+0		pair:		inline[2]<int>;
-	+8		pair2:		inline[2]<byte>;
+	+0		pair:		int[2];
+	+8		pair2:		byte[2];
 	=10;
 }

--- a/test/struct/parser/multiple3.v3
+++ b/test/struct/parser/multiple3.v3
@@ -1,8 +1,8 @@
 //@parse
 struct multiple {
-	+0		triple:		inline[13]<byte>;
+	+0		triple:		byte[13];
 	+13		size:		int;
 	+17		tag:		byte;
-	+18		pair:		inline[5]<byte>;
+	+18		pair:		byte[5];
 	=23;
 }

--- a/test/struct/parser/single10.v3
+++ b/test/struct/parser/single10.v3
@@ -1,5 +1,5 @@
 //@parse
 struct single {
-	+0	pair:	inline[8]<byte>;
+	+0	pair:	byte[8];
 	=8;
 }

--- a/test/struct/parser/single11.v3
+++ b/test/struct/parser/single11.v3
@@ -1,5 +1,5 @@
-//@parse = ParseError @ 3:54
+//@parse
 struct invalidInline {
-	+0		inlineelement:		inline<int>;
+	+0		inlineelement:		inline;
 	=4;
 }

--- a/test/struct/parser/single12.v3
+++ b/test/struct/parser/single12.v3
@@ -1,5 +1,5 @@
 //@parse = ParseError @ 3:57
 struct invalidInline {
-	+0		inlineelement:		inline[4];
+	+0		inlineelement:		[4];
 	=4;
 }

--- a/test/struct/parser/single13.v3
+++ b/test/struct/parser/single13.v3
@@ -1,5 +1,5 @@
 //@parse = ParseError @ 3:55
 struct invalidInline {
-	+0		inlineelement:		inline[4]byte;
+	+0		inlineelement:		byte<inline>[4][;
 	=4;
 }

--- a/test/struct/parser/single14.v3
+++ b/test/struct/parser/single14.v3
@@ -1,5 +1,5 @@
 //@parse = ParseError @ 3:57
 struct invalidInline {
-	+0		inlineelement:		inline[6]<byte;
+	+0		inlineelement:		[6]byte;
 	=6;
 }

--- a/test/struct/parser/single2.v3
+++ b/test/struct/parser/single2.v3
@@ -1,4 +1,4 @@
-//@parse = ParseError @ 3:40
+//@parse
 struct single {
 	+0		pair:		(int, int);
 	=8;

--- a/test/struct/parser/single8.v3
+++ b/test/struct/parser/single8.v3
@@ -1,5 +1,5 @@
 //@parse
 struct single {
-	+0	tag:	inline[1]<byte>;
+	+0	tag:	byte[1];
 	=1;
 }

--- a/test/struct/parser/single9.v3
+++ b/test/struct/parser/single9.v3
@@ -1,5 +1,5 @@
 // @ parse
 struct single {
-	+0	tag:	inline[1]<int>;
+	+0	tag:	int[1];
 	=4;
 }


### PR DESCRIPTION
Hi Dr.Titzer,

Below is a summary of work done:
- modified the test cases according to the new syntax (`inline` deleted)
- parsing `rephint` on top level of struct
- parsing `rephint` for struct fields
- structure for checking OOB error and field overlapping

For `Refs` and exact details of checking field decl error, I found my previous approach incorrect and feel like it would be better if `resolvetype`(especially the 'searching for struct first' part) is implemented before start checking field overlapping. 

Let me know if there's any issue.
Yunqing