### PR TITLE
[lang] escaped apostrophes in string literals are optional

### DIFF
--- a/aeneas/src/main/Version.v3
+++ b/aeneas/src/main/Version.v3
@@ -3,6 +3,6 @@
 
 // Updated by VCS scripts. DO NOT EDIT.
 component Version {
-	def version: string = "III-7.1536";
+	def version: string = "III-7.1537";
 	var buildData: string;
 }

--- a/lib/util/Strings.v3
+++ b/lib/util/Strings.v3
@@ -115,9 +115,7 @@ component Strings {
 		while (i < max) {
 			var ch = a[i];
 			if (ch < ' ' || ch > 127) return (pos - i, null);
-			if (ch == '\'') return (pos - i, null);
 			if (ch == '\"') return (1 + i - pos, buf.toString());
-			var end = i + 2;
 			if (ch == '\\') {
 				var p = Chars.parseEscape(a, i + 1);
 				if (p.0 <= 0) return (pos - i + p.0, null);

--- a/test/core/parser/str02.v3
+++ b/test/core/parser/str02.v3
@@ -4,6 +4,7 @@ class A {
 	var g: string = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 	var h: string = "abcdefghijklmnopqrstuvwxyz";
 	var i: string = "1234567890";
-	var j: string = "`~!@#$%^&*()-_=+";
-	var j: string = "[{]}|;:,<.>/?";
+	var j: string = "`~!@#$%^&'*()-_=+";
+	var k: string = "[{]}|;:,<.>/?";
+	var l: string = "\r\t\n\"\'\\\x4C";
 }

--- a/test/core/string12.v3
+++ b/test/core/string12.v3
@@ -1,0 +1,18 @@
+//@execute 0=true
+def tests: Array<(string, string)> = [
+	("'","\'"),
+	("'a'","\'a\'"),
+	("a'b'c","a\'b\'c")
+];
+
+component string12 {
+	def main(arg: int) -> bool {
+		for (t in tests) {
+			if (t.0.length != t.1.length) return false;
+			for (i < t.0.length) {
+				if (t.0[i] != t.1[i]) return false;
+			}
+		}
+		return true;
+	}
+}

--- a/test/lib/StringsTest.v3
+++ b/test/lib/StringsTest.v3
@@ -22,6 +22,10 @@ def test_parseLiteral(t: LibTest) {
 
 	ok(0, null, "");
 	ok(2, "", "\"\"");
+	ok(3, "'", "\"\'\"");
+	ok(3, "'", "\"'\"");
+	ok(4, "a'", "\"a\'\"");
+	ok(4, "a'", "\"a'\"");
 	okP(2, "", "..\"\"..", 2);
 	okP(4, "xA", "..\"xA\"..", 2);
 	ok(28, "abcdefghijklmnopqrstuvwxyz", "\"abcdefghijklmnopqrstuvwxyz\"");
@@ -62,7 +66,7 @@ def test_parseLiteralErr(t: LibTest) {
 	err(-2, "\"a");
 	err(-4, "\"a\\\'");
 
-	err(-1, "\"\'");
+	err(-2, "\"\'");
 	err(-2, "\"\\xZ\"");
 	err(-3, "\"\\xF\"");
 


### PR DESCRIPTION
See #87.