### PR TITLE
Fix wave.node.js exit code

### DIFF
--- a/rt/wave/wave.node.js
+++ b/rt/wave/wave.node.js
@@ -88,4 +88,4 @@ memory = new Uint8Array(memory.buffer);
 var main = instance.exports[".entry"];
 if (main == undefined) main = instance.exports["entry"];
 if (main == undefined) main = instance.exports["main"];
-main(args.length);
+process.exitCode = main(args.length);


### PR DESCRIPTION
`wave.node.js` does not return an exit code causing `aeneas test` to fail at test `test/system/exit_main0.v3`:

```
(/tmp/srackham/virgil-test/aeneas/bootstrap/x86-linux/Aeneas) system
  Running       int           | 35 of 35 passed
  Running       int-ra        | 35 of 35 passed
  Compiling     jar           | 35 of 35 passed
  Running       jar           | 35 of 35 passed
  Compiling     wave          | 35 of 35 passed
  Running       wave@node     |
exit_main0.v3: fail: /tmp/srackham/virgil-test/system/wave/exit_main0.v3.exit.diff
34 of 35 passed 1 failed
```