### PR TITLE
Add simple test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - testing-ci
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Build and Test
         run: bash ./ci/jvm/build-test-jvm.sh
-  # wasm:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #     - name: Build and Test
-  #       run: bash ./ci/wasm/build-test-wasm.sh
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: bash ./ci/wasm/build-test-wasm.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - master
+      - testing-ci
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - master
+
+concurrency:
+  # Cancels pending runs when a PR gets updated.
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  x86-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: bash ./ci/linux/build-test-x86_64.sh
+  x86_64-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: bash ./ci/linux/build-test-x86.sh
+  x86_64-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: bash ./ci/macos/build-test-x86_64.sh
+  jvm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: bash ./ci/jvm/build-test-jvm.sh
+  # wasm:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - name: Build and Test
+  #       run: bash ./ci/wasm/build-test-wasm.sh
+

--- a/ci/jvm/build-test-jvm.sh
+++ b/ci/jvm/build-test-jvm.sh
@@ -3,9 +3,10 @@
 SOURCE="${BASH_SOURCE[0]}"
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
-source "${DIR}/../../test/common.bash"
+VIRGIL_LOC="${DIR}/../.."
+TEST_DIR="${VIRGIL_LOC}/test"
 
-${VIRGIL_LOC}/test/configure
+"${TEST_DIR}"/configure
 export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-PROGRESS_ARGS=l TEST_TARGETS="jvm" aeneas test
+PROGRESS_ARGS=l TEST_TARGETS="jvm" "${TEST_DIR}"/all.bash

--- a/ci/jvm/build-test-jvm.sh
+++ b/ci/jvm/build-test-jvm.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+source "${DIR}/../../test/common.bash"
+
+${VIRGIL_LOC}/test/configure
+
+TEST_TARGETS="jvm"
+aeneas test

--- a/ci/jvm/build-test-jvm.sh
+++ b/ci/jvm/build-test-jvm.sh
@@ -6,6 +6,6 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}/../../test/common.bash"
 
 ${VIRGIL_LOC}/test/configure
+export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-TEST_TARGETS="jvm"
-aeneas test
+TEST_TARGETS="jvm" aeneas test

--- a/ci/jvm/build-test-jvm.sh
+++ b/ci/jvm/build-test-jvm.sh
@@ -8,4 +8,4 @@ source "${DIR}/../../test/common.bash"
 ${VIRGIL_LOC}/test/configure
 export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-TEST_TARGETS="jvm" aeneas test
+PROGRESS_ARGS=l TEST_TARGETS="jvm" aeneas test

--- a/ci/jvm/build-test-jvm.sh
+++ b/ci/jvm/build-test-jvm.sh
@@ -7,6 +7,5 @@ VIRGIL_LOC="${DIR}/../.."
 TEST_DIR="${VIRGIL_LOC}/test"
 
 "${TEST_DIR}"/configure
-export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
 PROGRESS_ARGS=l TEST_TARGETS="jvm" "${TEST_DIR}"/all.bash

--- a/ci/linux/build-test-x86.sh
+++ b/ci/linux/build-test-x86.sh
@@ -6,6 +6,6 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}/../../test/common.bash"
 
 ${VIRGIL_LOC}/test/configure
+export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-TEST_TARGETS="int x86-linux"
-aeneas test
+TEST_TARGETS="int x86-linux" aeneas test

--- a/ci/linux/build-test-x86.sh
+++ b/ci/linux/build-test-x86.sh
@@ -7,6 +7,5 @@ VIRGIL_LOC="${DIR}/../.."
 TEST_DIR="${VIRGIL_LOC}/test"
 
 "${TEST_DIR}"/configure
-export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
 PROGRESS_ARGS=l TEST_TARGETS="int x86-linux" "${TEST_DIR}"/all.bash

--- a/ci/linux/build-test-x86.sh
+++ b/ci/linux/build-test-x86.sh
@@ -8,4 +8,4 @@ source "${DIR}/../../test/common.bash"
 ${VIRGIL_LOC}/test/configure
 export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-TEST_TARGETS="int x86-linux" aeneas test
+PROGRESS_ARGS=l TEST_TARGETS="int x86-linux" aeneas test

--- a/ci/linux/build-test-x86.sh
+++ b/ci/linux/build-test-x86.sh
@@ -3,9 +3,10 @@
 SOURCE="${BASH_SOURCE[0]}"
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
-source "${DIR}/../../test/common.bash"
+VIRGIL_LOC="${DIR}/../.."
+TEST_DIR="${VIRGIL_LOC}/test"
 
-${VIRGIL_LOC}/test/configure
+"${TEST_DIR}"/configure
 export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-PROGRESS_ARGS=l TEST_TARGETS="int x86-linux" aeneas test
+PROGRESS_ARGS=l TEST_TARGETS="int x86-linux" "${TEST_DIR}"/all.bash

--- a/ci/linux/build-test-x86.sh
+++ b/ci/linux/build-test-x86.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+source "${DIR}/../../test/common.bash"
+
+${VIRGIL_LOC}/test/configure
+
+TEST_TARGETS="int x86-linux"
+aeneas test

--- a/ci/linux/build-test-x86.sh
+++ b/ci/linux/build-test-x86.sh
@@ -6,6 +6,9 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 VIRGIL_LOC="${DIR}/../.."
 TEST_DIR="${VIRGIL_LOC}/test"
 
+echo "Install nasm"
+sudo apt -y install nasm
+
 "${TEST_DIR}"/configure
 
 PROGRESS_ARGS=l TEST_TARGETS="int x86-linux" "${TEST_DIR}"/all.bash

--- a/ci/linux/build-test-x86_64.sh
+++ b/ci/linux/build-test-x86_64.sh
@@ -7,6 +7,5 @@ VIRGIL_LOC="${DIR}/../.."
 TEST_DIR="${VIRGIL_LOC}/test"
 
 "${TEST_DIR}"/configure
-export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
 PROGRESS_ARGS=l TEST_TARGETS="int x86-64-linux" "${TEST_DIR}"/all.bash

--- a/ci/linux/build-test-x86_64.sh
+++ b/ci/linux/build-test-x86_64.sh
@@ -6,6 +6,9 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 VIRGIL_LOC="${DIR}/../.."
 TEST_DIR="${VIRGIL_LOC}/test"
 
+echo "Install nasm"
+sudo apt -y install nasm
+
 "${TEST_DIR}"/configure
 
 PROGRESS_ARGS=l TEST_TARGETS="int x86-64-linux" "${TEST_DIR}"/all.bash

--- a/ci/linux/build-test-x86_64.sh
+++ b/ci/linux/build-test-x86_64.sh
@@ -8,4 +8,4 @@ source "${DIR}/../../test/common.bash"
 ${VIRGIL_LOC}/test/configure
 export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-TEST_TARGETS="int x86-64-linux" aeneas test
+PROGRESS_ARGS=l TEST_TARGETS="int x86-64-linux" aeneas test

--- a/ci/linux/build-test-x86_64.sh
+++ b/ci/linux/build-test-x86_64.sh
@@ -6,6 +6,6 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}/../../test/common.bash"
 
 ${VIRGIL_LOC}/test/configure
+export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-TEST_TARGETS="int x86-64-linux"
-aeneas test
+TEST_TARGETS="int x86-64-linux" aeneas test

--- a/ci/linux/build-test-x86_64.sh
+++ b/ci/linux/build-test-x86_64.sh
@@ -3,9 +3,10 @@
 SOURCE="${BASH_SOURCE[0]}"
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
-source "${DIR}/../../test/common.bash"
+VIRGIL_LOC="${DIR}/../.."
+TEST_DIR="${VIRGIL_LOC}/test"
 
-${VIRGIL_LOC}/test/configure
+"${TEST_DIR}"/configure
 export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-PROGRESS_ARGS=l TEST_TARGETS="int x86-64-linux" aeneas test
+PROGRESS_ARGS=l TEST_TARGETS="int x86-64-linux" "${TEST_DIR}"/all.bash

--- a/ci/linux/build-test-x86_64.sh
+++ b/ci/linux/build-test-x86_64.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+source "${DIR}/../../test/common.bash"
+
+${VIRGIL_LOC}/test/configure
+
+TEST_TARGETS="int x86-64-linux"
+aeneas test

--- a/ci/macos/build-test-x86_64.sh
+++ b/ci/macos/build-test-x86_64.sh
@@ -3,9 +3,10 @@
 SOURCE="${BASH_SOURCE[0]}"
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
-source "${DIR}/../../test/common.bash"
+VIRGIL_LOC="${DIR}/../.."
+TEST_DIR="${VIRGIL_LOC}/test"
 
-${VIRGIL_LOC}/test/configure
+"${TEST_DIR}"/configure
 export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-PROGRESS_ARGS=l TEST_TARGETS="int x86-64-macos" aeneas test
+PROGRESS_ARGS=l TEST_TARGETS="int x86-64-macos" "${TEST_DIR}"/all.bash

--- a/ci/macos/build-test-x86_64.sh
+++ b/ci/macos/build-test-x86_64.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+source "${DIR}/../../test/common.bash"
+
+${VIRGIL_LOC}/test/configure
+
+TEST_TARGETS="int x86-64-macos"
+aeneas test

--- a/ci/macos/build-test-x86_64.sh
+++ b/ci/macos/build-test-x86_64.sh
@@ -8,4 +8,4 @@ TEST_DIR="${VIRGIL_LOC}/test"
 
 "${TEST_DIR}"/configure
 
-PROGRESS_ARGS=l TEST_TARGETS="int x86-64-macos" "${TEST_DIR}"/all.bash
+PROGRESS_ARGS=l TEST_TARGETS="int x86-64-darwin" "${TEST_DIR}"/all.bash

--- a/ci/macos/build-test-x86_64.sh
+++ b/ci/macos/build-test-x86_64.sh
@@ -8,4 +8,4 @@ source "${DIR}/../../test/common.bash"
 ${VIRGIL_LOC}/test/configure
 export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-TEST_TARGETS="int x86-64-macos" aeneas test
+PROGRESS_ARGS=l TEST_TARGETS="int x86-64-macos" aeneas test

--- a/ci/macos/build-test-x86_64.sh
+++ b/ci/macos/build-test-x86_64.sh
@@ -6,6 +6,6 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}/../../test/common.bash"
 
 ${VIRGIL_LOC}/test/configure
+export PATH=$PATH:"${VIRGIL_LOC}/bin:${VIRGIL_LOC}/bin/dev"
 
-TEST_TARGETS="int x86-64-macos"
-aeneas test
+TEST_TARGETS="int x86-64-macos" aeneas test

--- a/ci/wasm/build-test-wasm.sh
+++ b/ci/wasm/build-test-wasm.sh
@@ -8,4 +8,4 @@ TEST_DIR="${VIRGIL_LOC}/test"
 
 "${TEST_DIR}"/configure
 
-PROGRESS_ARGS=l TEST_TARGETS="wasm" "${TEST_DIR}"/all.bash
+PROGRESS_ARGS=l TEST_TARGETS="wasm-js" "${TEST_DIR}"/all.bash

--- a/ci/wasm/build-test-wasm.sh
+++ b/ci/wasm/build-test-wasm.sh
@@ -8,4 +8,4 @@ TEST_DIR="${VIRGIL_LOC}/test"
 
 "${TEST_DIR}"/configure
 
-PROGRESS_ARGS=l TEST_TARGETS="int x86-64-macos" "${TEST_DIR}"/all.bash
+PROGRESS_ARGS=l TEST_TARGETS="wasm" "${TEST_DIR}"/all.bash

--- a/test/all.bash
+++ b/test/all.bash
@@ -165,6 +165,8 @@ if [ $? = 0 ]; then
     echo "  bin/current == bin/bootstrap ${GREEN}ok${NORM}"
     exit $SCRIPT_EXIT_CODE
 else
+    # if the bootstrap check fails, we exit with an exit failure even if no
+    # tests have failed
     update_exit_code_if_non_zero 1
     printf $YELLOW
     cat $OUT/bootstrap.diff

--- a/test/all.bash
+++ b/test/all.bash
@@ -17,7 +17,7 @@ if [ "$?" != 0 ]; then
     echo $HOSTS
     exit 1
 fi
-    
+
 if [ "$V3C_STABLE" = "" ]; then
     for h in $HOSTS; do
 	STABLE_DIR=$(cd $DIR/../bin/stable/ && pwd)/$h
@@ -69,6 +69,10 @@ else
     BOOTSTRAP=$AENEAS_TEST
 fi
 
+# progress parameters -- by default the inline (`i`) mode is used, while the CI
+# uses line (`l`) mode
+PROGRESS_ARGS=${PROGRESS_ARGS:=i}
+
 #######################################################################
 # Init test framework
 #######################################################################
@@ -84,6 +88,7 @@ if [ "$QUIET_SETUP" != 1 ]; then
     echo "TEST_CACHE=$TEST_CACHE"
     echo "V3C_STABLE=$V3C_STABLE"
     echo "V3C_OPTS=\"$V3C_OPTS\""
+    echo "PROGRESS_ARGS=\"$PROGRESS_ARGS\""
     echo "AENEAS_TEST=\"$AENEAS_TEST\""
 fi
 
@@ -111,7 +116,7 @@ for dir in unit lib; do
     td=$VIRGIL_LOC/test/$dir
     print_line
     echo "${CYAN}($V3C_STABLE) $dir${NORM}"
-    (cd $td && AENEAS_TEST=$V3C_STABLE $td/test.bash)
+    (cd $td && AENEAS_TEST=$V3C_STABLE PROGRESS_ARGS=$PROGRESS_ARGS $td/test.bash)
 done
 
 #######################################################################
@@ -132,7 +137,7 @@ for dir in $TEST_DIRS; do
     td=$VIRGIL_LOC/test/$dir
     print_line
     echo "${CYAN}($AENEAS_TEST) $dir${NORM}"
-    (cd $td && $td/test.bash)
+    (cd $td && PROGRESS_ARGS=$PROGRESS_ARGS $td/test.bash)
 done
 
 if [ "$SKIP_BOOTSTRAP" = 1 ]; then
@@ -161,5 +166,5 @@ for dir in $TEST_DIRS; do
     td=$VIRGIL_LOC/test/$dir
     print_line
     echo "${CYAN}($CURRENT) $dir${NORM}"
-    (cd $td && AENEAS_TEST=$CURRENT $td/test.bash)
+    (cd $td && AENEAS_TEST=$CURRENT PROGRESS_ARGS=$PROGRESS_ARGS $td/test.bash)
 done

--- a/test/all.bash
+++ b/test/all.bash
@@ -69,10 +69,6 @@ else
     BOOTSTRAP=$AENEAS_TEST
 fi
 
-# progress parameters -- by default the inline (`i`) mode is used, while the CI
-# uses line (`l`) mode
-PROGRESS_ARGS=${PROGRESS_ARGS:=i}
-
 #######################################################################
 # Init test framework
 #######################################################################
@@ -116,7 +112,7 @@ for dir in unit lib; do
     td=$VIRGIL_LOC/test/$dir
     print_line
     echo "${CYAN}($V3C_STABLE) $dir${NORM}"
-    (cd $td && AENEAS_TEST=$V3C_STABLE PROGRESS_ARGS=$PROGRESS_ARGS $td/test.bash)
+    (cd $td && AENEAS_TEST=$V3C_STABLE $td/test.bash)
 done
 
 #######################################################################
@@ -137,7 +133,7 @@ for dir in $TEST_DIRS; do
     td=$VIRGIL_LOC/test/$dir
     print_line
     echo "${CYAN}($AENEAS_TEST) $dir${NORM}"
-    (cd $td && PROGRESS_ARGS=$PROGRESS_ARGS $td/test.bash)
+    (cd $td && $td/test.bash)
 done
 
 if [ "$SKIP_BOOTSTRAP" = 1 ]; then
@@ -166,5 +162,5 @@ for dir in $TEST_DIRS; do
     td=$VIRGIL_LOC/test/$dir
     print_line
     echo "${CYAN}($CURRENT) $dir${NORM}"
-    (cd $td && AENEAS_TEST=$CURRENT PROGRESS_ARGS=$PROGRESS_ARGS $td/test.bash)
+    (cd $td && AENEAS_TEST=$CURRENT $td/test.bash)
 done

--- a/test/apps/test.bash
+++ b/test/apps/test.bash
@@ -42,5 +42,5 @@ for target in $TEST_TARGETS; do
     T=$OUT/$target
     mkdir -p $T
     print_status Compiling $target
-    compile_apps $APPS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
+    compile_apps $APPS | tee $T/compile.out | $PROGRESS
 done

--- a/test/apps/test.bash
+++ b/test/apps/test.bash
@@ -38,9 +38,9 @@ for target in $TEST_TARGETS; do
 	continue
     fi
     target=$(convert_to_io_target $target)
-    
+
     T=$OUT/$target
     mkdir -p $T
     print_status Compiling $target
-    compile_apps $APPS | tee $T/compile.out | $PROGRESS i
+    compile_apps $APPS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
 done

--- a/test/bench/test.bash
+++ b/test/bench/test.bash
@@ -49,12 +49,12 @@ for target in $TEST_TARGETS; do
     mkdir -p $T
 
     print_compiling $target
-    compile_benchmarks $BENCHMARKS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
+    compile_benchmarks $BENCHMARKS | tee $T/compile.out | $PROGRESS
 
     print_status Running $target
     if [ ! -x $CONFIG/run-$target ]; then
 	echo "${YELLOW}skipped${NORM}"
     else
-	run_benchmarks $BENCHMARKS | tee $T/run.out | $PROGRESS $PROGRESS_ARGS
+	run_benchmarks $BENCHMARKS | tee $T/run.out | $PROGRESS
     fi
 done

--- a/test/bench/test.bash
+++ b/test/bench/test.bash
@@ -49,12 +49,12 @@ for target in $TEST_TARGETS; do
     mkdir -p $T
 
     print_compiling $target
-    compile_benchmarks $BENCHMARKS | tee $T/compile.out | $PROGRESS i
+    compile_benchmarks $BENCHMARKS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
 
     print_status Running $target
     if [ ! -x $CONFIG/run-$target ]; then
 	echo "${YELLOW}skipped${NORM}"
     else
-	run_benchmarks $BENCHMARKS | tee $T/run.out | $PROGRESS i
+	run_benchmarks $BENCHMARKS | tee $T/run.out | $PROGRESS $PROGRESS_ARGS
     fi
 done

--- a/test/bin/test-wasm-js-node
+++ b/test/bin/test-wasm-js-node
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+EXE_DIR=$1
+shift
+(cd $EXE_DIR && $DIR/../config/node $DIR/wasm-js-node-tester.js $@)

--- a/test/bin/wasm-js-node-tester.js
+++ b/test/bin/wasm-js-node-tester.js
@@ -1,0 +1,87 @@
+const cmdLineArgs = process.argv.slice(2);
+
+var color = true;
+var GREEN=color ? '[0;32m' : '';
+var YELLOW=color ? '[0;33m' : '';
+var RED=color ? '[0;31m' : '';
+var NORM=color ? '[0;00m' : '';
+var verbose = 2;
+var globalTestRuns = undefined;
+var outputDir = "";
+
+function fail(testname, msg) {
+    console.log("##-fail: " + msg);
+}
+
+function begin(testname) {
+    console.log("##+" + testname);
+}
+
+function pass(testname) {
+    console.log("##-ok");
+}
+
+function runTest(testname) {
+    begin(testname);
+    const fs = require("fs");
+    // 1. Read WASM buffer
+    var wasmfile = testname + ".wasm";
+    try {
+        buffer = fs.readFileSync(wasmfile);
+    } catch (e) {
+        return fail(testname, wasmfile + " file not found");
+    }
+
+    // 2. Create WASM module and instance
+    var module;
+    var instance;
+    var main;
+    try {
+        module = new WebAssembly.Module(buffer);
+        instance = new WebAssembly.Instance(module);
+        main = instance.exports.main;
+    } catch (e) {
+        return fail(testname, "" + e);
+    }
+
+    // 3. Load test expectations
+    globalTestRuns = undefined;  // by convention, overwritten by loaded script
+    var expectfile = testname + ".expect.js";
+    try {
+        eval(fs.readFileSync(expectfile) + "");
+    } catch (e) {
+        return fail(testname, expectfile + " file not found");
+    }
+
+    // 4. Perform the runs
+    var i = 0;
+    for (run of globalTestRuns) {
+        let expect = run[0];
+        try  {
+            let result = main(...run[1]);
+            if (result != expect) throw new Error("expected " + expect + ", but got " + result);
+        } catch (e) {
+            if (expect == WebAssembly.RuntimeError && e instanceof WebAssembly.RuntimeError) {
+                // Successfully caught exception expected to be thrown.
+                // TODO: check the specific error thrown.
+            } else {
+                return fail(testname, "Run " + i + " failed: " + e);
+            }
+        }
+        i++;
+    }
+    pass(testname);
+}
+
+(function mainLoop() {
+    var tests = [];
+    cmdLineArgs.forEach((arg, _) => {
+        arg = arg.replace(/[.]v3$/, "");  // strip .v3 extension
+        arg = arg.replace(/[.]wasm$/, "");  // strip .wasm extension
+        tests.push(arg);
+    });
+    console.log("##>" + tests.length);
+    for (var i = 0; i < tests.length; i++) {
+        runTest(tests[i]);
+    }
+})();

--- a/test/common.bash
+++ b/test/common.bash
@@ -30,8 +30,10 @@ NATIVE_SOURCES="$RT_LOC/native/*.v3"
 GC_SOURCES="${GC_LOC}/*.v3"
 V3C_HEAP_SIZE=${V3C_HEAP_SIZE:="-heap-size=500m"}
 
-PROGRESS=${VIRGIL_LOC}/test/config/progress
+# Progress arguments. By default the inline (i) mode is used, while the CI sets
+# it to line (l) mode
 PROGRESS_ARGS=${PROGRESS_ARGS:=i}
+PROGRESS="${VIRGIL_LOC}/test/config/progress $PROGRESS_ARGS"
 
 AENEAS_TEST=${AENEAS_TEST:=$VIRGIL_LOC/bin/v3c}
 TEST_TARGETS=${TEST_TARGETS:="int jvm wasm-js x86-linux x86-64-linux x86-darwin x86-64-darwin"}
@@ -206,7 +208,7 @@ function run_or_skip_io_tests() {
 	R=$CONFIG/run-
 	tname=${runner/$R/}
 	print_status Running $tname
-	run_io_tests $target $runner $@ | tee $OUT/$target/run-$tname.out | $PROGRESS $PROGRESS_ARGS
+	run_io_tests $target $runner $@ | tee $OUT/$target/run-$tname.out | $PROGRESS
     done
 }
 
@@ -252,7 +254,7 @@ function execute_int_tests() {
     print_status Interpreting "$2 $V3C_OPTS"
 
     P=$OUT/$1.run.out
-    run_v3c "" -test -expect=failures.txt $2 $TESTS | tee $OUT/run.out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt $2 $TESTS | tee $OUT/run.out | $PROGRESS
 }
 
 function compile_target_tests() {
@@ -263,7 +265,7 @@ function compile_target_tests() {
     mkdir -p $OUT/$target
     C=$OUT/$target/compile.out
     print_compiling $target
-    V3C_OPTS="$V3C_OPTS $opts -set-exec=false -target=$target-test -output=$OUT/$target" run_v3c_multiple 5000 ""  $TESTS | tee $C | $PROGRESS $PROGRESS_ARGS
+    V3C_OPTS="$V3C_OPTS $opts -set-exec=false -target=$target-test -output=$OUT/$target" run_v3c_multiple 5000 ""  $TESTS | tee $C | $PROGRESS
 }
 
 function check_cached_target_tests() {
@@ -300,7 +302,7 @@ function execute_target_tests() {
 	if [ "$target" = "wasm-js" ]; then
 	   ext=".wasm"
 	fi
-	check_cached_target_tests $ext | tee $OUT/$target/cached.out | $PROGRESS $PROGRESS_ARGS
+	check_cached_target_tests $ext | tee $OUT/$target/cached.out | $PROGRESS
 	TORUN=$(cat $OUT/$target/leftover)
     else
 	TORUN="$TESTS"
@@ -310,7 +312,7 @@ function execute_target_tests() {
 	print_status "  running" ""
 
 	if [ -x $CONFIG/test-$target ]; then
-	    $CONFIG/test-$target $OUT/$target $TORUN | tee $OUT/$target/run.out | $PROGRESS $PROGRESS_ARGS
+	    $CONFIG/test-$target $OUT/$target $TORUN | tee $OUT/$target/run.out | $PROGRESS
 	else
 	    count=$(echo $(echo $TORUN | wc -w))
 	    printf "$count ${YELLOW}skipped${NORM}\n"

--- a/test/common.bash
+++ b/test/common.bash
@@ -205,7 +205,7 @@ function run_or_skip_io_tests() {
 	R=$CONFIG/run-
 	tname=${runner/$R/}
 	print_status Running $tname
-	run_io_tests $target $runner $@ | tee $OUT/$target/run-$tname.out | $PROGRESS i
+	run_io_tests $target $runner $@ | tee $OUT/$target/run-$tname.out | $PROGRESS $PROGRESS_ARGS
     done
 }
 
@@ -233,7 +233,7 @@ function run_v3c_multiple() {
     while [ $i -le $# ]; do
 
 	local args=${@:$i:$SHARDING}
-	
+
 	if [ -z "$target" ]; then
 	    $AENEAS_TEST $V3C_OPTS -multiple $args
 	else
@@ -251,7 +251,7 @@ function execute_int_tests() {
     print_status Interpreting "$2 $V3C_OPTS"
 
     P=$OUT/$1.run.out
-    run_v3c "" -test -expect=failures.txt $2 $TESTS | tee $OUT/run.out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt $2 $TESTS | tee $OUT/run.out | $PROGRESS $PROGRESS_ARGS
 }
 
 function compile_target_tests() {
@@ -262,7 +262,7 @@ function compile_target_tests() {
     mkdir -p $OUT/$target
     C=$OUT/$target/compile.out
     print_compiling $target
-    V3C_OPTS="$V3C_OPTS $opts -set-exec=false -target=$target-test -output=$OUT/$target" run_v3c_multiple 5000 ""  $TESTS | tee $C | $PROGRESS i
+    V3C_OPTS="$V3C_OPTS $opts -set-exec=false -target=$target-test -output=$OUT/$target" run_v3c_multiple 5000 ""  $TESTS | tee $C | $PROGRESS $PROGRESS_ARGS
 }
 
 function check_cached_target_tests() {
@@ -299,7 +299,7 @@ function execute_target_tests() {
 	if [ "$target" = "wasm-js" ]; then
 	   ext=".wasm"
 	fi
-	check_cached_target_tests $ext | tee $OUT/$target/cached.out | $PROGRESS i
+	check_cached_target_tests $ext | tee $OUT/$target/cached.out | $PROGRESS $PROGRESS_ARGS
 	TORUN=$(cat $OUT/$target/leftover)
     else
 	TORUN="$TESTS"
@@ -309,7 +309,7 @@ function execute_target_tests() {
 	print_status "  running" ""
 
 	if [ -x $CONFIG/test-$target ]; then
-	    $CONFIG/test-$target $OUT/$target $TORUN | tee $OUT/$target/run.out | $PROGRESS i
+	    $CONFIG/test-$target $OUT/$target $TORUN | tee $OUT/$target/run.out | $PROGRESS $PROGRESS_ARGS
 	else
 	    count=$(echo $(echo $TORUN | wc -w))
 	    printf "$count ${YELLOW}skipped${NORM}\n"

--- a/test/common.bash
+++ b/test/common.bash
@@ -31,6 +31,7 @@ GC_SOURCES="${GC_LOC}/*.v3"
 V3C_HEAP_SIZE=${V3C_HEAP_SIZE:="-heap-size=500m"}
 
 PROGRESS=${VIRGIL_LOC}/test/config/progress
+PROGRESS_ARGS=${PROGRESS_ARGS:=i}
 
 AENEAS_TEST=${AENEAS_TEST:=$VIRGIL_LOC/bin/v3c}
 TEST_TARGETS=${TEST_TARGETS:="int jvm wasm-js x86-linux x86-64-linux x86-darwin x86-64-darwin"}

--- a/test/configure
+++ b/test/configure
@@ -84,7 +84,7 @@ touch $CONFIG/configged
 
 for f in $(cd $BIN; ls run-int*); do
     try_link $BIN/$f $f
-done  
+done
 
 #############################################################################
 ## target=<native>
@@ -146,7 +146,7 @@ fi
 #############################################################################
 ## target=wasm-js
 T="wasm-js"
-if [[ ! -L $CONFIG/test-$T ]]; then
+if [[ (! -L $CONFIG/test-$T) || (! -L $CONFIG/test-$T-node) ]]; then
     echo target=$T
 
     if [ -x "$D8" ]; then
@@ -155,11 +155,13 @@ if [[ ! -L $CONFIG/test-$T ]]; then
 	echo "exec $D8 \$@" >> $CONFIG/d8
 	chmod 755 $CONFIG/d8
 	link $BIN/test-$T test-$T
+    elif [[ -L $CONFIG/node ]]; then
+        link $BIN/test-$T-node test-$T
     else
 	print_skipped
     fi
 fi
-    
+
 #############################################################################
 ## target=wave
 T="wave"

--- a/test/core/test.bash
+++ b/test/core/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 

--- a/test/core/test.bash
+++ b/test/core/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 

--- a/test/darwin/test.bash
+++ b/test/darwin/test.bash
@@ -13,7 +13,7 @@ fi
 function do_test() {
     print_compiling "$target"
     mkdir -p $OUT/$target
-    run_v3c "" -multiple -set-exec=false -target=$target-test -output=$OUT/$target $TESTS | tee $OUT/compile.out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -multiple -set-exec=false -target=$target-test -output=$OUT/$target $TESTS | tee $OUT/compile.out | $PROGRESS
 
     execute_target_tests $target
 }

--- a/test/darwin/test.bash
+++ b/test/darwin/test.bash
@@ -13,7 +13,7 @@ fi
 function do_test() {
     print_compiling "$target"
     mkdir -p $OUT/$target
-    run_v3c "" -multiple -set-exec=false -target=$target-test -output=$OUT/$target $TESTS | tee $OUT/compile.out | $PROGRESS i
+    run_v3c "" -multiple -set-exec=false -target=$target-test -output=$OUT/$target $TESTS | tee $OUT/compile.out | $PROGRESS $PROGRESS_ARGS
 
     execute_target_tests $target
 }

--- a/test/enums/test.bash
+++ b/test/enums/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 

--- a/test/enums/test.bash
+++ b/test/enums/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 

--- a/test/feature/test.bash
+++ b/test/feature/test.bash
@@ -9,5 +9,5 @@ else
 fi
 
 print_status "Feature detection" ""
-run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
 exit $?

--- a/test/feature/test.bash
+++ b/test/feature/test.bash
@@ -9,5 +9,5 @@ else
 fi
 
 print_status "Feature detection" ""
-run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
 exit $?

--- a/test/float/test.bash
+++ b/test/float/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 

--- a/test/float/test.bash
+++ b/test/float/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 

--- a/test/fsi64/test.bash
+++ b/test/fsi64/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 

--- a/test/fsi64/test.bash
+++ b/test/fsi64/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 

--- a/test/funcexpr/test.bash
+++ b/test/funcexpr/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 

--- a/test/funcexpr/test.bash
+++ b/test/funcexpr/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 

--- a/test/gc/new-test.bash
+++ b/test/gc/new-test.bash
@@ -19,7 +19,7 @@ function do_test() {
 
     print_compiling "$target" ""
     RT=$(ls $OS_SOURCES $NATIVE_SOURCES $GC_SOURCES)
-    run_v3c "" -output=$T -target=$target-test -rt.gc -rt.gctables -rt.test-gc -rt.sttables -set-exec=false -heap-size=10k -multiple -rt.files="$RT" $TESTS | tee $T/compile.out | $PROGRESS i
+    run_v3c "" -output=$T -target=$target-test -rt.gc -rt.gctables -rt.test-gc -rt.sttables -set-exec=false -heap-size=10k -multiple -rt.files="$RT" $TESTS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
 
     execute_target_tests $target
 
@@ -36,7 +36,7 @@ function do_test() {
 
     print_status Testing "$target $HEAP" Aeneas
     if [ -x $CONFIG/run-$target ]; then
-	$T/$target/Aeneas -test -rma $VIRGIL_LOC/test/execute/*.v3 | tee $T/$target/Aeneas-gc.test.out | $PROGRESS i
+	$T/$target/Aeneas -test -rma $VIRGIL_LOC/test/execute/*.v3 | tee $T/$target/Aeneas-gc.test.out | $PROGRESS $PROGRESS_ARGS
     else
 	echo "${YELLOW}skipped${NORM}"
     fi

--- a/test/gc/new-test.bash
+++ b/test/gc/new-test.bash
@@ -19,7 +19,7 @@ function do_test() {
 
     print_compiling "$target" ""
     RT=$(ls $OS_SOURCES $NATIVE_SOURCES $GC_SOURCES)
-    run_v3c "" -output=$T -target=$target-test -rt.gc -rt.gctables -rt.test-gc -rt.sttables -set-exec=false -heap-size=10k -multiple -rt.files="$RT" $TESTS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -output=$T -target=$target-test -rt.gc -rt.gctables -rt.test-gc -rt.sttables -set-exec=false -heap-size=10k -multiple -rt.files="$RT" $TESTS | tee $T/compile.out | $PROGRESS
 
     execute_target_tests $target
 
@@ -36,7 +36,7 @@ function do_test() {
 
     print_status Testing "$target $HEAP" Aeneas
     if [ -x $CONFIG/run-$target ]; then
-	$T/$target/Aeneas -test -rma $VIRGIL_LOC/test/execute/*.v3 | tee $T/$target/Aeneas-gc.test.out | $PROGRESS $PROGRESS_ARGS
+	$T/$target/Aeneas -test -rma $VIRGIL_LOC/test/execute/*.v3 | tee $T/$target/Aeneas-gc.test.out | $PROGRESS
     else
 	echo "${YELLOW}skipped${NORM}"
     fi

--- a/test/gc/test.bash
+++ b/test/gc/test.bash
@@ -31,7 +31,7 @@ function do_test() {
     rm -f $ALL
 
     print_compiling "$target" ""
-    compile_gc_tests $target $TESTS | tee $T/compile.all.out | $PROGRESS $PROGRESS_ARGS
+    compile_gc_tests $target $TESTS | tee $T/compile.all.out | $PROGRESS
 
     execute_target_tests $target
 
@@ -48,7 +48,7 @@ function do_test() {
 
     print_status Testing "$target $HEAP" Aeneas
     if [ -x $CONFIG/run-$target ]; then
-	$T/$target/Aeneas -test -rma $VIRGIL_LOC/test/core/*.v3 | tee $T/$target/Aeneas-gc.test.out | $PROGRESS $PROGRESS_ARGS
+	$T/$target/Aeneas -test -rma $VIRGIL_LOC/test/core/*.v3 | tee $T/$target/Aeneas-gc.test.out | $PROGRESS
     else
 	echo "${YELLOW}skipped${NORM}"
     fi

--- a/test/gc/test.bash
+++ b/test/gc/test.bash
@@ -12,7 +12,7 @@ function compile_gc_tests() {
     local SHARDING=100
     local target=$1
     shift
-    
+
     RT_FILES="-rt.files=$(echo $OS_SOURCES $NATIVE_SOURCES $GC_SOURCES)"
     local i=1
     while [ $i -le $# ]; do
@@ -31,7 +31,7 @@ function do_test() {
     rm -f $ALL
 
     print_compiling "$target" ""
-    compile_gc_tests $target $TESTS | tee $T/compile.all.out | $PROGRESS i
+    compile_gc_tests $target $TESTS | tee $T/compile.all.out | $PROGRESS $PROGRESS_ARGS
 
     execute_target_tests $target
 
@@ -48,7 +48,7 @@ function do_test() {
 
     print_status Testing "$target $HEAP" Aeneas
     if [ -x $CONFIG/run-$target ]; then
-	$T/$target/Aeneas -test -rma $VIRGIL_LOC/test/core/*.v3 | tee $T/$target/Aeneas-gc.test.out | $PROGRESS i
+	$T/$target/Aeneas -test -rma $VIRGIL_LOC/test/core/*.v3 | tee $T/$target/Aeneas-gc.test.out | $PROGRESS $PROGRESS_ARGS
     else
 	echo "${YELLOW}skipped${NORM}"
     fi

--- a/test/lib/test.bash
+++ b/test/lib/test.bash
@@ -31,7 +31,7 @@ function do_int() {
     fi
 
     if [ "$PROGRESS_PIPE" = 1 ]; then
-	run_v3c "" -run $TESTS $VIRGIL_LOC/lib/util/*.v3 | tee $P | $PROGRESS i
+	run_v3c "" -run $TESTS $VIRGIL_LOC/lib/util/*.v3 | tee $P | $PROGRESS $PROGRESS_ARGS
     else
 	run_v3c "" -run $TESTS $VIRGIL_LOC/lib/util/*.v3 | tee $P
     fi
@@ -50,7 +50,7 @@ function do_compiled() {
 
     print_status Running $target
     if [ -x $CONFIG/run-$target ]; then
-	$OUT/$target/main $TESTS | tee $R | $PROGRESS i
+	$OUT/$target/main $TESTS | tee $R | $PROGRESS $PROGRESS_ARGS
     else
 	printf "${YELLOW}skipped${NORM}\n"
     fi

--- a/test/lib/test.bash
+++ b/test/lib/test.bash
@@ -31,7 +31,7 @@ function do_int() {
     fi
 
     if [ "$PROGRESS_PIPE" = 1 ]; then
-	run_v3c "" -run $TESTS $VIRGIL_LOC/lib/util/*.v3 | tee $P | $PROGRESS $PROGRESS_ARGS
+	run_v3c "" -run $TESTS $VIRGIL_LOC/lib/util/*.v3 | tee $P | $PROGRESS
     else
 	run_v3c "" -run $TESTS $VIRGIL_LOC/lib/util/*.v3 | tee $P
     fi
@@ -50,7 +50,7 @@ function do_compiled() {
 
     print_status Running $target
     if [ -x $CONFIG/run-$target ]; then
-	$OUT/$target/main $TESTS | tee $R | $PROGRESS $PROGRESS_ARGS
+	$OUT/$target/main $TESTS | tee $R | $PROGRESS
     else
 	printf "${YELLOW}skipped${NORM}\n"
     fi

--- a/test/linux/test.bash
+++ b/test/linux/test.bash
@@ -11,7 +11,7 @@ fi
 function do_test() {
     print_compiling $target
     mkdir -p $OUT/$target
-    run_v3c "" -multiple -set-exec=false -target=$target-test -output=$OUT/$target $TESTS | tee $OUT/compile.out | $PROGRESS i
+    run_v3c "" -multiple -set-exec=false -target=$target-test -output=$OUT/$target $TESTS | tee $OUT/compile.out | $PROGRESS $PROGRESS_ARGS
 
     execute_target_tests $target
 }

--- a/test/linux/test.bash
+++ b/test/linux/test.bash
@@ -11,7 +11,7 @@ fi
 function do_test() {
     print_compiling $target
     mkdir -p $OUT/$target
-    run_v3c "" -multiple -set-exec=false -target=$target-test -output=$OUT/$target $TESTS | tee $OUT/compile.out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -multiple -set-exec=false -target=$target-test -output=$OUT/$target $TESTS | tee $OUT/compile.out | $PROGRESS
 
     execute_target_tests $target
 }

--- a/test/range/test.bash
+++ b/test/range/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 

--- a/test/range/test.bash
+++ b/test/range/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 

--- a/test/stacktrace/test.bash
+++ b/test/stacktrace/test.bash
@@ -20,8 +20,8 @@ for target in $TEST_TARGETS; do
 
     if [[ ! "$target" =~ ^int ]]; then
         print_status Compiling $target
-        V3C_OPTS="$V3C_OPTS -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS i
+        V3C_OPTS="$V3C_OPTS -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
     fi
-    
+
     run_or_skip_io_tests $target $TESTS
 done

--- a/test/stacktrace/test.bash
+++ b/test/stacktrace/test.bash
@@ -20,7 +20,7 @@ for target in $TEST_TARGETS; do
 
     if [[ ! "$target" =~ ^int ]]; then
         print_status Compiling $target
-        V3C_OPTS="$V3C_OPTS -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
+        V3C_OPTS="$V3C_OPTS -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS
     fi
 
     run_or_skip_io_tests $target $TESTS

--- a/test/struct/test.bash
+++ b/test/struct/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 

--- a/test/struct/test.bash
+++ b/test/struct/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 

--- a/test/system/test.bash
+++ b/test/system/test.bash
@@ -16,7 +16,7 @@ for target in $TEST_TARGETS; do
 
     if [ "$target" != "int" ]; then
 	print_compiling "$target" ""
-	V3C_OPTS="$V3C_OPTS -heap-size=32k -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
+	V3C_OPTS="$V3C_OPTS -heap-size=32k -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS
     fi
 
     run_or_skip_io_tests $target $TESTS

--- a/test/system/test.bash
+++ b/test/system/test.bash
@@ -10,13 +10,13 @@ fi
 
 for target in $TEST_TARGETS; do
     target=$(convert_to_io_target $target)
-    
+
     T=$OUT/$target
     mkdir -p $T
 
     if [ "$target" != "int" ]; then
 	print_compiling "$target" ""
-	V3C_OPTS="$V3C_OPTS -heap-size=32k -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS i
+	V3C_OPTS="$V3C_OPTS -heap-size=32k -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
     fi
 
     run_or_skip_io_tests $target $TESTS

--- a/test/targets/test.bash
+++ b/test/targets/test.bash
@@ -30,8 +30,8 @@ for target in $ALL_TARGETS; do
 
     if [[ ! "$target" =~ ^int ]]; then
         print_status Compiling $target
-        V3C_OPTS="$V3C_OPTS -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS i
+        V3C_OPTS="$V3C_OPTS -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
     fi
-    
+
     run_or_skip_io_tests $target $TESTS
 done

--- a/test/targets/test.bash
+++ b/test/targets/test.bash
@@ -30,7 +30,7 @@ for target in $ALL_TARGETS; do
 
     if [[ ! "$target" =~ ^int ]]; then
         print_status Compiling $target
-        V3C_OPTS="$V3C_OPTS -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
+        V3C_OPTS="$V3C_OPTS -output=$T" run_v3c_multiple 100 $target $TESTS | tee $T/compile.out | $PROGRESS
     fi
 
     run_or_skip_io_tests $target $TESTS

--- a/test/unit/test.bash
+++ b/test/unit/test.bash
@@ -6,6 +6,6 @@ printf "  Running Aeneas unit tests..."
 P=$OUT/block_order.out
 pushd $VIRGIL_LOC > /dev/null
 SRCS="aeneas/src/*/*.v3 $(cat aeneas/DEPS)"
-run_v3c "" -fp -run $SRCS $AENEAS_LOC/../test/*.v3 -version | $PROGRESS $PROGRESS_ARGS
+run_v3c "" -fp -run $SRCS $AENEAS_LOC/../test/*.v3 -version | $PROGRESS
 popd > /dev/null
 

--- a/test/unit/test.bash
+++ b/test/unit/test.bash
@@ -6,6 +6,6 @@ printf "  Running Aeneas unit tests..."
 P=$OUT/block_order.out
 pushd $VIRGIL_LOC > /dev/null
 SRCS="aeneas/src/*/*.v3 $(cat aeneas/DEPS)"
-run_v3c "" -fp -run $SRCS $AENEAS_LOC/../test/*.v3 -version | $PROGRESS i
+run_v3c "" -fp -run $SRCS $AENEAS_LOC/../test/*.v3 -version | $PROGRESS $PROGRESS_ARGS
 popd > /dev/null
 

--- a/test/variants/test.bash
+++ b/test/variants/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS
     cd ..
 }
 

--- a/test/variants/test.bash
+++ b/test/variants/test.bash
@@ -3,14 +3,14 @@
 function do_parser_tests() {
     cd parser
     print_status Parser ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 
 function do_seman_tests() {
     cd seman
     print_status Semantic ""
-    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS i
+    run_v3c "" -test -expect=failures.txt *.v3 | tee $OUT/out | $PROGRESS $PROGRESS_ARGS
     cd ..
 }
 

--- a/test/wasi/test.bash
+++ b/test/wasi/test.bash
@@ -19,7 +19,7 @@ for target in $TEST_TARGETS; do
     mkdir -p $T
 
     print_compiling "$target" ""
-    V3C_OPTS="$V3C_OPTS -heap-size=32k -target=wasm -entry-export=_start -main-export=_start -output=$T -rt.files=$RT" run_v3c_multiple 100 ""  $TESTS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
+    V3C_OPTS="$V3C_OPTS -heap-size=32k -target=wasm -entry-export=_start -main-export=_start -output=$T -rt.files=$RT" run_v3c_multiple 100 ""  $TESTS | tee $T/compile.out | $PROGRESS
 
     run_or_skip_io_tests $target $TESTS
 done

--- a/test/wasi/test.bash
+++ b/test/wasi/test.bash
@@ -19,7 +19,7 @@ for target in $TEST_TARGETS; do
     mkdir -p $T
 
     print_compiling "$target" ""
-    V3C_OPTS="$V3C_OPTS -heap-size=32k -target=wasm -entry-export=_start -main-export=_start -output=$T -rt.files=$RT" run_v3c_multiple 100 ""  $TESTS | tee $T/compile.out | $PROGRESS i
+    V3C_OPTS="$V3C_OPTS -heap-size=32k -target=wasm -entry-export=_start -main-export=_start -output=$T -rt.files=$RT" run_v3c_multiple 100 ""  $TESTS | tee $T/compile.out | $PROGRESS $PROGRESS_ARGS
 
     run_or_skip_io_tests $target $TESTS
 done


### PR DESCRIPTION
Heyo! Just added a very simple test CI using GitHub actions. A few things to note:

 1. I'm not sure how the wasm target works as I tried to run the wasm tests on my local `node` installation and it simply skipped the execution
 2. `x86-macos` can't be tested in CI unless you use a self-hosted runner or use some sort of emulation. I believe only x86_64 MacOS is available in GitHub actions (not even arm64 MacOS is available!)
 3. I added the `int` target to all the native targets just for sanity -- you may want to make a separate one for it

Partially closes #92.
