### PR TITLE
Add global-regalloc compile option using matcher

### DIFF
--- a/aeneas/src/main/CLOptions.v3
+++ b/aeneas/src/main/CLOptions.v3
@@ -140,6 +140,8 @@ component CLOptions {
 		"Enable GC testing mode where every allocation triggers a collection.");
 	def RT_FILES		= compileOpt.newOption("rt.files", Array<string>.new(0), "=<path*>", parseStringArray,
 		"Specify a list of .v3 files that are included with every compiled program (with -multiple).");
+	def USE_GLOBALREGALLOC = compileOpt.newMatcherOption("global-regalloc",
+		"Enable global register allocator.");
 	// JVM target options
 	def JVM_RT_PATH		= jvmOpt.newStringOption("jvm.rt-path", null,
 		"Specify the path to the Java runtime.");

--- a/aeneas/src/main/Compiler.v3
+++ b/aeneas/src/main/Compiler.v3
@@ -64,6 +64,7 @@ class Compiler(target: Target) {
 	def printSsaMatcher = CLOptions.PRINT_SSA.get();
 	def printMachMatcher = CLOptions.PRINT_MACH.get();
 	def statsMatcher = CLOptions.PRINT_SSA_STATS.get();
+	def useGlobalRegAllocMatcher = CLOptions.USE_GLOBALREGALLOC.get();
 	var icMon: (IrSpec, IcMethod) -> void;	 // monitor for IC generation
 	// major phases of compilation
 	var Trace			= CLOptions.TRACE.get();
@@ -94,7 +95,6 @@ class Compiler(target: Target) {
 	var PostpassOptimize		= flags.get("PostpassOptimize", true);
 	var EmitSwitch			= flags.get("EmitSwitch", true);
 	var LocalRegAlloc		= flags.get("LocalRegAlloc", true);
-	var GlobalRegAlloc  = flags.get("GlobalRegAlloc", false);
 	var NormOptimize		= flags.get("NormOptimize", false);
 	var MachOptimize		= flags.get("MachOptimize", false);
 	// XXX: flags for folding, reduction, typechecks, dead code, phi simplification

--- a/aeneas/src/main/Version.v3
+++ b/aeneas/src/main/Version.v3
@@ -3,6 +3,6 @@
 
 // Updated by VCS scripts. DO NOT EDIT.
 component Version {
-	def version: string = "III-7.1617";
+	def version: string = "III-7.1618";
 	var buildData: string;
 }

--- a/aeneas/src/ssa/SsaContext.v3
+++ b/aeneas/src/ssa/SsaContext.v3
@@ -57,6 +57,9 @@ class SsaContext(compiler: Compiler, prog: Program) {
 	def shouldPrintMach() -> bool {
 		return filter(compiler.printMachMatcher);
 	}
+	def shouldUseGlobalRegAlloc() -> bool {
+		return filter(compiler.useGlobalRegAllocMatcher);
+	}
 	def filter(f: VstMatcher) -> bool {
 		return method != null && f.matches(method.source);
 	}

--- a/aeneas/src/x86-64/X86_64Backend.v3
+++ b/aeneas/src/x86-64/X86_64Backend.v3
@@ -38,6 +38,7 @@ class X86_64Backend extends MachBackend {
 	def test: bool;
 	var codegen: SsaX86_64Gen;
 	var allocateRegs: void -> void;
+	var allocateRegsGlobal: void -> void;
 
 	// memory allocator configuration
 	var objReg: X86_64Gpr;
@@ -63,8 +64,8 @@ class X86_64Backend extends MachBackend {
 			sizeReg = X86_64Regs.RAX;
 		}
 		codegen = SsaX86_64Gen.new(context, mach, asm, w);
-		if (compiler.GlobalRegAlloc) allocateRegs = GlobalRegAlloc.new(X86_64RegSet.SET, codegen).allocate;
-		else if (compiler.LocalRegAlloc) allocateRegs = LocalRegAlloc.new(X86_64RegSet.SET, codegen).allocate;
+		if (compiler.useGlobalRegAllocMatcher != VstMatcher.None) allocateRegsGlobal = GlobalRegAlloc.new(X86_64RegSet.SET, codegen).allocate;
+		if (compiler.LocalRegAlloc) allocateRegs = LocalRegAlloc.new(X86_64RegSet.SET, codegen).allocate;
 		else allocateRegs = SimpleRegAlloc.new(X86_64RegSet.SET, codegen).allocate;
 	}
 	def genEntryStub() {
@@ -138,7 +139,8 @@ class X86_64Backend extends MachBackend {
 		var rtsrc = mach.runtime.src;
 		if (rtsrc != null) rtsrc.curFrame = frame;
 		codegen.generate(context.method, frame);
-		allocateRegs();
+		if (context.shouldUseGlobalRegAlloc()) allocateRegsGlobal();
+		else allocateRegs();
 		computeFrameSize(frame);
 		if (rtsrc != null) rtsrc.recordMethodStart(w.endOffset(), context.method.source, frame);
 		codegen.assembleInstrs();


### PR DESCRIPTION
To enable globalRegAlloc: use `-global-regalloc` instead of `-opt=+GlobalRegAlloc`