### PR TITLE
[x86-64]: Add assembler methods for v128 population count

### DIFF
--- a/lib/asm/x86-64/X86_64Assembler.v3
+++ b/lib/asm/x86-64/X86_64Assembler.v3
@@ -1026,6 +1026,14 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 		emitb(0xF2);
 		emit_rex_bb_r_m(a, b, NO_REX, 0x0F, 0x58);
 	}
+	def addps_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
+		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x58);
+	}
+	def addpd_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
+		emitb(0x66);
+		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x58);
+	}
+
 	def subss_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
 		emitb(0xF3);
 		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x5C);
@@ -1041,9 +1049,6 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 	def subsd_s_m(a: X86_64Xmmr, b: X86_64Addr) -> this {
 		emitb(0xF2);
 		emit_rex_bb_r_m(a, b, NO_REX, 0x0F, 0x5C);
-	}
-	def subps_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
-		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x5C);
 	}
 	def psubb_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
 		emitb(0x66);
@@ -1076,6 +1081,13 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 	def psubusw_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
 		emitb(0x66);
 		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0xD9);
+	}
+	def subps_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
+		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x5C);
+	}
+	def subpd_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
+		emitb(0x66);
+		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x5C);
 	}
 
 	def mulss_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
@@ -1124,6 +1136,13 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x38, 0x0B);
 	}
 
+	def mulps_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
+		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x59);
+	}
+	def mulpd_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
+		emitb(0x66);
+		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x59);
+	}
 	def pclmulqdq_s_s_imm(a: X86_64Xmmr, b: X86_64Xmmr, imm: u8) -> this {
 		emitb(0x66);
 		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x38, 0x0B);
@@ -1145,6 +1164,13 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 	def divsd_s_m(a: X86_64Xmmr, b: X86_64Addr) -> this {
 		emitb(0xF2);
 		emit_rex_bb_r_m(a, b, NO_REX, 0x0F, 0x5E);
+	}
+	def divps_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
+		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x5E);
+	}
+	def divpd_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
+		emitb(0x66);
+		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x5E);
 	}
 	def sqrtss_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
 		emitb(0xF3);
@@ -1403,6 +1429,9 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 	def andpd_s_m(a: X86_64Xmmr, b: X86_64Addr) -> this {
 		emitb(0x66);
 		emit_rex_bb_r_m(a, b, NO_REX, 0x0F, 0x54);
+	}
+	def andnps_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
+		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x55);
 	}
 	def orps_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
 		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x56);
@@ -1663,10 +1692,18 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 		emitb(0x66);
 		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x60);
 	}
+	def punpcklqdq_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
+		emitb(0x66);
+		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x6C);
+	}
 	def pshufd_s_s_imm(a: X86_64Xmmr, b: X86_64Xmmr, imm: u8) -> this {
 		emitb(0x66);
 		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x70);
 		emitb(imm);
+	}
+	def pshufb_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
+		emitb(0x66);
+		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x38, 0x00);
 	}
 	def packuswb_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {
 		emitb(0x66);

--- a/test/asm/x86-64/X86_64AssemblerTestGen.v3
+++ b/test/asm/x86-64/X86_64AssemblerTestGen.v3
@@ -472,14 +472,26 @@ def do_sse() {
 	do_s_s("pabsd", asm.pabsd_s_s);
 	do_s_m("pabsd", asm.pabsd_s_m);
 
+	do_s_s("paddb", asm.paddb_s_s);
+	do_s_s("paddw", asm.paddw_s_s);
+	do_s_s("paddd", asm.paddd_s_s);
+	do_s_s("paddq", asm.paddq_s_s);
 	do_s_s("addsd", asm.addsd_s_s);
 	do_s_m("addsd", asm.addsd_s_m);
+	do_s_s("addps", asm.addps_s_s);
+	do_s_s("addpd", asm.addpd_s_s);
 	do_s_s("subsd", asm.subsd_s_s);
 	do_s_m("subsd", asm.subsd_s_m);
+	do_s_s("subps", asm.subps_s_s);
+	do_s_s("subpd", asm.subpd_s_s);
 	do_s_s("mulsd", asm.mulsd_s_s);
 	do_s_m("mulsd", asm.mulsd_s_m);
+	do_s_s("mulps", asm.mulps_s_s);
+	do_s_s("mulpd", asm.mulpd_s_s);
 	do_s_s("divsd", asm.divsd_s_s);
 	do_s_m("divsd", asm.divsd_s_m);
+	do_s_s("divps", asm.divps_s_s);
+	do_s_s("divpd", asm.divpd_s_s);
 	do_s_s("sqrtsd", asm.sqrtsd_s_s);
 	do_s_m("sqrtsd", asm.sqrtsd_s_m);
 	do_s_s("maxsd", asm.maxsd_s_s);
@@ -512,6 +524,7 @@ def do_sse() {
 	do_s_m("andps", asm.andps_s_m);
 	do_s_s("andpd", asm.andpd_s_s);
 	do_s_m("andpd", asm.andpd_s_m);
+	do_s_s("andnps", asm.andnps_s_s);
 
 	do_s_s("paddq", asm.paddq_s_s);
 	do_s_s("paddd", asm.paddd_s_s);
@@ -613,7 +626,9 @@ def do_sse() {
 	do_s_s("punpcklwd", asm.punpcklwd_s_s);
 	do_s_s("punpckhbw", asm.punpckhbw_s_s);
 	do_s_s("punpcklbw", asm.punpcklbw_s_s);
+	do_s_s("punpcklqdq", asm.punpcklqdq_s_s);
 	// do_s_s_i("pshufd", asm.pshufd_s_s);
+	do_s_s("pshufb", asm.pshufb_s_s);
 	do_s_s("packuswb", asm.packuswb_s_s);
 	do_s_s("packsswb", asm.packsswb_s_s);
 


### PR DESCRIPTION
Also added tests to cover previously implemented instructions.