### PR TITLE
[X86-64]: Add assembler methods for v128 extract_lane and insert_lane

### DIFF
--- a/lib/asm/x86-64/X86_64Assembler.v3
+++ b/lib/asm/x86-64/X86_64Assembler.v3
@@ -1835,7 +1835,7 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 		emitb(0x66);
 		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x6C);
 	}
-	def pshufd_s_s_imm(a: X86_64Xmmr, b: X86_64Xmmr, imm: u8) -> this {
+	def pshufd_s_s_i(a: X86_64Xmmr, b: X86_64Xmmr, imm: u8) -> this {
 		emitb(0x66);
 		emit_rex_bb_r_r(a, b, NO_REX, 0x0F, 0x70);
 		emitb(imm);
@@ -1863,6 +1863,26 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 	def pblendw_s_s_i(a: X86_64Xmmr, b: X86_64Xmmr, imm: u8) -> this {
 		emitb(0x66);
 		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x3A, 0x0E);
+		emitb(imm);
+	}
+	def pinsrb_s_r_i(a: X86_64Xmmr, b: X86_64Gpr, imm: u8) -> this {
+		emitb(0x66);
+		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x3A, 0x20);
+		emitb(imm);
+	}
+	def pinsrq_s_r_i(a: X86_64Xmmr, b: X86_64Gpr, imm: u8) -> this {
+		emitb(0x66);
+		emit_rex_bbb_r_r(a, b, REX_W, 0x0F, 0x3A, 0x22);
+		emitb(imm);
+	}
+	def pextrb_r_s_i(a: X86_64Gpr, b: X86_64Xmmr, imm: u8) -> this {
+		emitb(0x66);
+		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x3A, 0x14);
+		emitb(imm);
+	}
+	def pextrq_r_s_i(a: X86_64Gpr, b: X86_64Xmmr, imm: u8) -> this {
+		emitb(0x66);
+		emit_rex_bbb_r_r(a, b, REX_W, 0x0F, 0x3A, 0x16);
 		emitb(imm);
 	}
 

--- a/lib/asm/x86-64/X86_64Assembler.v3
+++ b/lib/asm/x86-64/X86_64Assembler.v3
@@ -1882,17 +1882,22 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 	}
 	def pextrb_r_s_i(a: X86_64Gpr, b: X86_64Xmmr, imm: u8) -> this {
 		emitb(0x66);
-		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x3A, 0x14);
+		emit_rex_bbb_r_r2(a, b, NO_REX, 0x0F, 0x3A, 0x14);
 		emitb(imm);
 	}
 	def pextrd_r_s_i(a: X86_64Gpr, b: X86_64Xmmr, imm: u8) -> this {
 		emitb(0x66);
-		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x3A, 0x16);
+		emit_rex_bbb_r_r2(a, b, NO_REX, 0x0F, 0x3A, 0x16);
 		emitb(imm);
 	}
 	def pextrq_r_s_i(a: X86_64Gpr, b: X86_64Xmmr, imm: u8) -> this {
 		emitb(0x66);
-		emit_rex_bbb_r_r(a, b, REX_W, 0x0F, 0x3A, 0x16);
+		emit_rex_bbb_r_r2(a, b, REX_W, 0x0F, 0x3A, 0x16);
+		emitb(imm);
+	}
+	def pextrq_m_s_i(a: X86_64Addr, b: X86_64Xmmr, imm: u8) -> this {
+		emitb(0x66);
+		emit_rex_bbb_m_r(a, b, REX_W, 0x0F, 0x3A, 0x16);
 		emitb(imm);
 	}
 
@@ -2007,11 +2012,24 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 		emitbb(c1, c2);
 		emitb_r(c3, b, a.low3); // note: reverse
 	}
+	private def emit_rex_bbb_r_r2(a: X86_64Reg, b: X86_64Reg, rex: byte, c1: byte, c2: byte, c3: byte) {
+		// reversed version of emit_rex_bbb_r_r
+		rex |= rex_r(a, REX_B) | rex_r(b, REX_R);
+		if (rex != 0) emitb(REX_BYTE | rex);
+		emitbb(c1, c2);
+		emitb_r(c3, a, b.low3);
+	}
 	private def emit_rex_bbb_r_m(a: X86_64Reg, b: X86_64Addr, rex: byte, c1: byte, c2: byte, c3: byte) {
 		rex |= rex_r(a, REX_R) | rex_m(b, REX_B);
 		if (rex != 0) emitb(REX_BYTE | rex);
 		emitbb(c1, c2);
 		emitb_m(c3, b, a.low3);
+	}
+	private def emit_rex_bbb_m_r(a: X86_64Addr, b: X86_64Reg, rex: byte, c1: byte, c2: byte, c3: byte) {
+		rex |= rex_m(a, REX_B) | rex_r(b, REX_R);
+		if (rex != 0) emitb(REX_BYTE | rex);
+		emitbb(c1, c2);
+		emitb_m(c3, a, b.low3);
 	}
 
 	private def emitb_r(b0: int, a: X86_64Reg, eop: int) {

--- a/lib/asm/x86-64/X86_64Assembler.v3
+++ b/lib/asm/x86-64/X86_64Assembler.v3
@@ -1870,6 +1870,11 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x3A, 0x20);
 		emitb(imm);
 	}
+	def pinsrd_s_r_i(a: X86_64Xmmr, b: X86_64Gpr, imm: u8) -> this {
+		emitb(0x66);
+		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x3A, 0x22);
+		emitb(imm);
+	}
 	def pinsrq_s_r_i(a: X86_64Xmmr, b: X86_64Gpr, imm: u8) -> this {
 		emitb(0x66);
 		emit_rex_bbb_r_r(a, b, REX_W, 0x0F, 0x3A, 0x22);
@@ -1878,6 +1883,11 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 	def pextrb_r_s_i(a: X86_64Gpr, b: X86_64Xmmr, imm: u8) -> this {
 		emitb(0x66);
 		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x3A, 0x14);
+		emitb(imm);
+	}
+	def pextrd_r_s_i(a: X86_64Gpr, b: X86_64Xmmr, imm: u8) -> this {
+		emitb(0x66);
+		emit_rex_bbb_r_r(a, b, NO_REX, 0x0F, 0x3A, 0x16);
 		emitb(imm);
 	}
 	def pextrq_r_s_i(a: X86_64Gpr, b: X86_64Xmmr, imm: u8) -> this {

--- a/test/asm/x86-64/X86_64AssemblerTestGen.v3
+++ b/test/asm/x86-64/X86_64AssemblerTestGen.v3
@@ -663,13 +663,15 @@ def do_sse() {
 	do_s_s("punpcklbw", asm.punpcklbw_s_s);
 	do_s_s("punpcklqdq", asm.punpcklqdq_s_s);
 	do_s_s("punpckhdq", asm.punpckhdq_s_s);
-	// do_s_s_i("pshufd", asm.pshufd_s_s);
+	do_s_s_b("pshufd", asm.pshufd_s_s_i);
 	do_s_s("pshufb", asm.pshufb_s_s);
 	do_s_s("packuswb", asm.packuswb_s_s);
 	do_s_s("packsswb", asm.packsswb_s_s);
 	do_s_s("packssdw", asm.packssdw_s_s);
 	do_s_s("packusdw", asm.packusdw_s_s);
-	// do_s_s_i("pblendw", asm.pblendw_s_s);
+	do_s_s_b("pblendw", asm.pblendw_s_s_i);
+	do_s_r_b("pinsrb", asm.pinsrb_s_r_i);
+	do_r_s_b("pextrb", asm.pextrb_r_s_i);
 }
 
 def ADDRS = [
@@ -857,6 +859,7 @@ def IMMS_NOT_BYTE = [128, 253, 255, 1023, 65535, -32767, 0x11223344, 0x55443322,
 
 def BYTES = [0, 1, 2, -1, -2, -128, 96, 127];
 def UBYTES = [0, 1, 2, 55, 96, 127, 128, 253];
+def UBYTES2: Array<byte> = [0, 1, 2, 55, 96, 127, 128, 253];
 
 def WORDS = [0, 1, 2, -1, -2, -128, 96, 127, 128, 1023, -999, 32767, -32768];
 
@@ -864,6 +867,11 @@ def U5: Array<u5> = [1, 2, 3, 7, 15, 16, 30, 31];
 def U6: Array<u6> = [1, 2, 3, 7, 30, 31, 32, 62, 63];
 
 def renderImm(i: int, buf: StringBuilder) -> StringBuilder {
+	buf.putd(i);
+	return buf;
+}
+
+def renderByte(i: byte, buf: StringBuilder) -> StringBuilder {
 	buf.putd(i);
 	return buf;
 }
@@ -897,6 +905,7 @@ def arg_i = (IMMS, renderImm);
 def arg_l = (IMM64, renderImm64);
 def arg_nb = (IMMS_NOT_BYTE, renderImm);
 def arg_b = (BYTES, renderImm);
+def arg_b2 = (UBYTES2, renderByte);
 def arg_w = (WORDS, renderImm);
 def arg_ub = (UBYTES, renderImm);
 def arg_bm = (ADDRS, renderAddr8);
@@ -935,6 +944,9 @@ def do_m_b = do2(_, arg_m, arg_b, _);
 def do_m_w = do2(_, arg_m, arg_w, _);
 
 def do_s_s = do2(_, arg_s, arg_s, _);
+def do_s_s_b = do3(_, arg_s, arg_s, arg_b2, _);
+def do_s_r_b = do3(_, arg_s, arg_r, arg_b2, _);
+def do_r_s_b = do3(_, arg_r, arg_s, arg_b2, _);
 def do_s_r = do2(_, arg_s, arg_r, _);
 def do_r_s = do2(_, arg_r, arg_s, _);
 def do_m_s = do2(_, arg_m, arg_s, _);

--- a/test/asm/x86-64/X86_64AssemblerTestGen.v3
+++ b/test/asm/x86-64/X86_64AssemblerTestGen.v3
@@ -670,8 +670,14 @@ def do_sse() {
 	do_s_s("packssdw", asm.packssdw_s_s);
 	do_s_s("packusdw", asm.packusdw_s_s);
 	do_s_s_b("pblendw", asm.pblendw_s_s_i);
+	regSize = 32;
 	do_s_r_b("pinsrb", asm.pinsrb_s_r_i);
+	do_s_r_b("pinsrd", asm.pinsrd_s_r_i);
 	do_r_s_b("pextrb", asm.pextrb_r_s_i);
+	do_r_s_b("pextrd", asm.pextrd_r_s_i);
+	regSize = 64;
+	do_s_r_b("pinsrq", asm.pinsrq_s_r_i);
+	do_r_s_b("pextrq", asm.pextrq_r_s_i);
 }
 
 def ADDRS = [

--- a/test/asm/x86-64/X86_64AssemblerTestGen.v3
+++ b/test/asm/x86-64/X86_64AssemblerTestGen.v3
@@ -678,6 +678,7 @@ def do_sse() {
 	regSize = 64;
 	do_s_r_b("pinsrq", asm.pinsrq_s_r_i);
 	do_r_s_b("pextrq", asm.pextrq_r_s_i);
+	do_m_s_b("pextrq", asm.pextrq_m_s_i);
 }
 
 def ADDRS = [
@@ -953,6 +954,7 @@ def do_s_s = do2(_, arg_s, arg_s, _);
 def do_s_s_b = do3(_, arg_s, arg_s, arg_b2, _);
 def do_s_r_b = do3(_, arg_s, arg_r, arg_b2, _);
 def do_r_s_b = do3(_, arg_r, arg_s, arg_b2, _);
+def do_m_s_b = do3(_, arg_m, arg_s, arg_b2, _);
 def do_s_r = do2(_, arg_s, arg_r, _);
 def do_r_s = do2(_, arg_r, arg_s, _);
 def do_m_s = do2(_, arg_m, arg_s, _);


### PR DESCRIPTION
I tried to add two test patterns: `do_s_r_b` and `do_r_s_b" in X86_64AssemblerTestGen.v3. However, when I invoked them with newly implemented instructions `pinsrb_s_r_i` and `pextrb_r_s_i`, the tests failed:

- `pinsrb_s_r_i`: error: invalid combination of opcode and operands
    - Insert a byte integer value from r32/m8 into xmm1 at the destination element in xmm1 specified by imm8.
- `pextrb_r_s_i`: Comparing...failed
    - Extract a byte integer value from xmm2 at the source byte offset specified by imm8 into reg or m8. The upper bits of r32 or r64 are zeroed.

For both of the two instructions I'm sure I wrote the bytes correctly. But I have no clues what would lead to the failures. Could you give me some help here?
