### PR TITLE
[wasi]: add openat systemcall in LinuxConst.v3

### DIFF
--- a/rt/x86-64-linux/LinuxConst.v3
+++ b/rt/x86-64-linux/LinuxConst.v3
@@ -86,6 +86,8 @@ component LinuxConst {
 	def SYS_chmod		= 90;
 	def SYS_gettimeofday	= 96;
 	def SYS_sigaltstack	= 131;
+	def SYS_openat      = 257;
+	def SYS_openat2     = 437;
 
 	// TODO: word offset of st_size in statbuf
 	def STAT_BUF_SIZE = 144;


### PR DESCRIPTION
`openat` and `openat2` system calls are required for wasi implementation in https://github.com/titzer/wizard-engine/, so I added some constants in `LinuxConst.v3`