### PR TITLE
Fix typo in comment

### DIFF
--- a/lib/x86-64-linux/SyscallLayouts.v3
+++ b/lib/x86-64-linux/SyscallLayouts.v3
@@ -1,7 +1,7 @@
 // Copyright 2021 Ben L. Titzer. All rights reserved.
 // See LICENSE for details of Apache 2.0 license.
 
-// All data layouture layouts for X86-64 linux kernel calls.
+// All data structure layouts for X86-64 linux kernel calls.
 // Empirically derived from C declarations in headers.
 
 layout statbuf {


### PR DESCRIPTION
I think a typo was introduced by doing `s/struct/layout` haha