### PR TITLE
Shift DataNorm representation to VariantNorm

### DIFF
--- a/aeneas/src/ir/Normalization.v3
+++ b/aeneas/src/ir/Normalization.v3
@@ -33,6 +33,9 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 	var specializer: Specializer;
 	var virtuals: List<RaVirtual>;
 	var ovfAlloc: OverflowFieldAllocator;
+	var vs: VariantSolver;
+
+	new() { vs = VariantSolver.new(config, this, /* CLOptions.PRINT_RA.get() */ true); }
 
 	def normalize() {
 		if (CLOptions.PRINT_DEAD_CODE.get()) DeadCodeAnalyzer.new(ra).report();
@@ -83,7 +86,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 				ra.queue.add(normClassRecord, (rc, oldRecord, newRecord.values));
 			}
 			ra.prog.setComponentRecord(comp, newRecord);
-		} else if (rc.dataNorm == null) {
+		} else if (rc.variantNorm == null) {
 			// create and map new records to be normalized
 			for (l = rc.instances; l != null; l = l.tail) {
 				var oldRecord = l.head, newRecord = ra.prog.newRecord(tn.newType, rc.normFields.length);
@@ -105,9 +108,9 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 				var rm = l.head, m = rm.orig;
 				if (rm.norm != null) continue; // already done
 				var ftype = if(rm.spec == null, m.sig.funcType(), rm.spec.getMethodType());
-				if (rc.raFacts.RC_UNBOXED) {
+				if (rc.variantNorm != null) {
 					// move flattened data type receiver to function sig
-					ftype = Function.prependParamTypes(rc.dataNorm.sub, ftype);
+					ftype = Function.prependParamTypes(rc.variantNorm.sub, ftype);
 				}
 				rm.funcNorm = FuncNorm.!(norm(ftype));
 				var typeParams = if(rm.spec != null, rm.spec.getTypes().methodTypeArgs);
@@ -205,7 +208,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			V3Kind.VARIANT => {
 				// try flattening variants and data types
 				var rc = ra.getClass(t);
-				if (rc != null) tn = normVariant(t, rc);
+				if (rc != null) tn = vs.normVariant(t, rc);
 				else tn = TypeNorm.new(t, t, null);
 			}
 			V3Kind.ENUM => {
@@ -251,7 +254,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 	// number a variant and children consistent with tagging order
 	def numberVariant(rc: RaClass) {
 		rc.minClassId = liveClasses.length;
-		if (rc.children  == null) {
+		if (rc.children == null) {
 			liveClasses.put(rc); // special case of a data type
 		} else {
 			for (l = rc.children; l != null; l = l.tail) {
@@ -266,98 +269,8 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 		}
 		rc.maxClassId = liveClasses.length;
 	}
-	// lay out a variant's fields, which may be flattened
-	def normVariant(t: Type, rc: RaClass) -> TypeNorm {
-		if (rc.dataNorm != null) return rc.dataNorm; // already unboxed
-		if (rc.orig.boxing == Boxing.BOXED) mapSimple(t); // XXX, ugly, don't recurse through explicitly boxed types
-
-		var prev = rc.recursive;
-		match (rc.recursive) {
-			ON_STACK => {
-				rc.recursive = 2; // cycle detected; box
-			}
-			0 => {
-				rc.recursive = ON_STACK;
-				tryUnboxing(rc);
-				if (rc.recursive == ON_STACK) rc.recursive = 1;
-				if (rc.dataNorm != null) return rc.dataNorm;
-			}
-			// recursive or not; there was no data norm, so box
-		}
-		rc.raFacts |= RaFact.RC_BOXED;
-		return mapSimple(t);
-	}
 	def mapSimple(t: Type) -> TypeNorm {
 		return typeMap[t] = TypeNorm.new(t, t, null);
-	}
-	def tryUnboxing(rc: RaClass) -> bool {
-		if (rc.normFields != null) return rc.dataNorm != null; // already done
-
-		while (rc.parent != null) rc = rc.parent;
-		makeNormFields(rc);
-		var isEmpty = rc.normFields.length == 0, closure = rc.raFacts.RC_CLOSURE;
-		for (l = rc.children; l != null; l = l.tail) {
-			var c = l.head;
-			makeNormFields(c);
-			if (c.normFields.length > 0) isEmpty = false;
-			closure |= c.raFacts.RC_CLOSURE;
-		}
-		if (isEmpty && !closure) {
-			// normalize empty variant to just its tag; i.e. become an enum
-			var tagType = V3.getVariantTagType(rc.oldType);
-			setDataNormForChildren(rc, tagType, [tagType], RaFact.RC_ENUM | RaFact.RC_UNBOXED);
-			return true;
-		}
-		if (rc.children != null) return false; // only flatten data types for now
-		match (rc.orig.boxing) {
-			BOXED => return false; // program specified boxed
-			AUTO => if (rc.normFields.length > config.MaxFlatDataValues) return false; // auto unbox up to compiler limit
-			UNBOXED => ; // program specified unboxed; TODO: recursion or closure should be an error
-		}
-		if (rc.recursive > 1 || closure) return false; // recursive or closed over
-
-
-		// Flatten a data type
-		var of = rc.orig.fields;
-		var origRanges = Array<(int, int)>.new(of.length);
-		var normRanges = Array<(int, int)>.new(of.length);
-		var vecO = Vector<Type>.new();
-		var vecT = Vector<Type>.new();
-		// map fields of original IrClass to ranges in the original and normalized type
-		for (i < of.length) {
-			var origStart = vecO.length, normStart = vecT.length;
-			if (i <= rc.fields.length) {
-				var rf = rc.fields[i];
-				if (rf != null) {
-					rf.raFacts |= RaFact.RC_UNBOXED;
-					if (rf.normIndex >= 0) {
-						if (rf.typeNorm != null) {
-							rf.typeNorm.addTo(vecT);
-						} else if (rf.fieldType != null) {
-							rf.typeNorm = norm(rf.fieldType);
-							rf.typeNorm.addTo(vecT);
-						} else {
-							vecT.put(rf.orig.fieldType);
-						}
-					}
-				}
-			}
-			var fieldType = of[i].fieldType.substitute(V3.getTypeArgs(rc.oldType));
-			norm(fieldType).addTo(vecO);
-			origRanges[i] = (origStart, vecO.length);
-			normRanges[i] = (normStart, vecT.length);
-		}
-		var ta = vecT.extract();
-		rc.dataNorm = DataNorm.new(rc.oldType, Tuple.newType(Lists.fromArray(ta)), null, origRanges, normRanges, ta);
-		rc.raFacts |= RaFact.RC_UNBOXED;
-		return true;
-	}
-	def setDataNormForChildren(rc: RaClass, tagType: IntType, sub: Array<Type>, facts: RaFact.set) {
-		rc.dataNorm = DataNorm.new(rc.oldType, tagType, tagType, NO_RANGES, NO_RANGES, sub);
-		rc.raFacts |= facts;
-		for (l = rc.children; l != null; l = l.tail) {
-			setDataNormForChildren(l.head, tagType, sub, facts);
-		}
 	}
 	// map a complex array to an array of records
 	def createComplexArrayRecord(r: Record, rt: ArrayNorm) -> Array<Record> {
@@ -421,18 +334,35 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 	}
 	// normalize a live instance of a class
 	def normClassRecord(rc: RaClass, oldRecord: Record, array: Array<Val>) {
-		if (rc.dataNorm != null && rc.dataNorm.tagType != null) {
-			array[0] = Int.box(V3.getVariantTag(oldRecord.rtype));
+		var vrc = ra.getClass(oldRecord.rtype), vn = vrc.variantNorm;
+		if (vn == null) {
+			var rfs = rc.fields;
+			for (i < rfs.length) {
+				var rf = rfs[i];
+				if (rf != null && rf.normIndex >= 0) {
+					var v = oldRecord.values[i];
+					if (rf.fieldType == null) array[rf.normIndex] = normSimpleVal(null, v);
+					else normValIntoArray(v, rf.typeNorm, array, rf.normIndex);
+				}
+			}
+			return;
 		}
-		var rfs = rc.fields;
-		for (i < rfs.length) {
-			var rf = rfs[i];
-			if (rf != null && rf.normIndex >= 0) {
-				var v = oldRecord.values[i];
-				if (rf.fieldType == null) array[rf.normIndex] = normSimpleVal(null, v);
-				else normValIntoArray(v, rf.typeNorm, array, rf.normIndex);
+
+		if (!vn.isEnum()) {
+			var rfs = vrc.fields;
+			for (i < vrc.fields.length) {
+				var rf = vrc.fields[i];
+				if (rf != null && rf.normIndex >= 0) {
+					var v = oldRecord.values[i];
+					var indexes = vn.fields[i].indexes;
+					var fieldArray = Array<Val>.new(indexes.length);
+					if (rf.fieldType == null) fieldArray[0] = normSimpleVal(null, v);
+					else normValIntoArray(v, rf.typeNorm, fieldArray, 0);
+					for (j < indexes.length) array[indexes[j]] = fieldArray[j];
+				}
 			}
 		}
+		if (!vn.isTagless()) array[vn.tagIndex()] = Int.box(vn.tagValue);
 	}
 	// normalize the live instances of a simple (i.e. size-1 element) array type
 	def normSimpleArrayRecord(record: Record) {
@@ -461,7 +391,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 	def normSimpleVal(tn: TypeNorm, v: Val) -> Val {
 		match (v) {
 			x: Record => {
-				if (DataNorm.?(tn)) return normDataVal(DataNorm.!(tn), x)[0];
+				if (tn != null && VariantNorm.?(tn) && VariantNorm.!(tn).isEnum()) return normVariantVal(VariantNorm.!(tn), x)[0];
 				var r = recordMap[x];
 				return if(r == null, x, r);
 			}
@@ -520,7 +450,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 		var table = Array<IrMethod>.new(size), mtable = IrMtable.new(rm.norm, rc.minClassId, table);
 		rv.mtable = mtable;
 
-		if (rc.raFacts.RC_UNBOXED) {
+		if (rc.variantNorm != null) {
 			var ft = Function.funcRefType(rm.norm.getMethodType());
 			mtable.record = ra.prog.newRecord(V3Array.newType(ft), size);
 		}
@@ -560,9 +490,9 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 				// look for simple mapping first
 				var simple = recordMap[x];
 				if (simple != null) return (array[index] = simple, ()).1;
-				if (DataNorm.?(tn)) {
+				if (VariantNorm.?(tn)) {
 					// flattened data type
-					var result = normDataVal(DataNorm.!(tn), x);
+					var result = normVariantVal(VariantNorm.!(tn), x);
 					for (i < result.length) array[index + i] = result[i];
 				} else {
 					var result = complexRecordMap[x];
@@ -598,12 +528,12 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			_ => if (index < array.length) array[index] = v;
 		}
 	}
-	def normDataVal(dn: DataNorm, x: Record) -> Array<Val> {
+	def normVariantVal(vn: VariantNorm, x: Record) -> Array<Val> {
 		var result = complexRecordMap[x];
 		if (result != null) return result;
-		result = Array.new(dn.size);
+		result = Array.new(vn.size);
 		complexRecordMap[x] = result; // skip this work next time
-		normClassRecord(ra.getClass(dn.oldType), x, result);
+		normClassRecord(ra.getClass(vn.oldType), x, result);
 		return result;
 	}
 	def normalizeMethodRef(spec: IrSpec) -> (RaMethod, IrSpec) {
@@ -620,7 +550,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 	}
 	def createIrClass(rc: RaClass) {
 		var sc = if(rc.parent != null, rc.parent.normClass);
-		var normFields = if(rc.raFacts.RC_UNBOXED, NO_FIELDS, rc.normFields);
+		var normFields = if(rc.variantNorm != null, NO_FIELDS, rc.normFields);
 		var ic = IrClass.new(rc.newIrType, null, sc, normFields, rc.normMethods);
 		ic.minClassId = rc.minClassId;
 		ic.maxClassId = rc.maxClassId;
@@ -644,7 +574,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			var receiver = ra.oldIr.getIrClass(ctype);
 			var root = ra.oldIr.getIrClass(V3.getRootType(ctype));
 			var rc = ra.getClass(rm.receiver);
-			if (false && rc.dataNorm != null) { // TODO: disable generation of compare method bodies
+			if (false && rc.variantNorm != null) { // TODO: disable generation of compare method bodies
 				// flattened data types will have inlined compare
 				rm.orig.ssa = SsaGraph.new([], Bool.TYPE);
 				rm.orig.ssa.startBlock.append(SsaReturn.new([rm.orig.ssa.falseConst()]));

--- a/aeneas/src/ir/Normalization.v3
+++ b/aeneas/src/ir/Normalization.v3
@@ -86,7 +86,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 				ra.queue.add(normClassRecord, (rc, oldRecord, newRecord.values));
 			}
 			ra.prog.setComponentRecord(comp, newRecord);
-		} else if (rc.variantNorm == null) {
+		} else if (!rc.isUnboxed()) {
 			// create and map new records to be normalized
 			for (l = rc.instances; l != null; l = l.tail) {
 				var oldRecord = l.head, newRecord = ra.prog.newRecord(tn.newType, rc.normFields.length);
@@ -108,7 +108,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 				var rm = l.head, m = rm.orig;
 				if (rm.norm != null) continue; // already done
 				var ftype = if(rm.spec == null, m.sig.funcType(), rm.spec.getMethodType());
-				if (rc.variantNorm != null) {
+				if (rc.isUnboxed()) {
 					// move flattened data type receiver to function sig
 					ftype = Function.prependParamTypes(rc.variantNorm.sub, ftype);
 				}
@@ -348,21 +348,22 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			return;
 		}
 
-		if (!vn.isEnum()) {
-			var rfs = vrc.fields;
-			for (i < vrc.fields.length) {
-				var rf = vrc.fields[i];
-				if (rf != null && rf.normIndex >= 0) {
-					var v = oldRecord.values[i];
-					var indexes = vn.fields[i].indexes;
-					var fieldArray = Array<Val>.new(indexes.length);
-					if (rf.fieldType == null) fieldArray[0] = normSimpleVal(null, v);
-					else normValIntoArray(v, rf.typeNorm, fieldArray, 0);
-					for (j < indexes.length) array[indexes[j]] = fieldArray[j];
-				}
+		if (!vn.isTagless()) array[vn.tagIndex()] = Int.box(vn.tagValue);
+		if (vn.isEnum()) return;
+
+		var rfs = vrc.fields;
+		for (i < vrc.fields.length) {
+			var rf = vrc.fields[i];
+			if (rf != null && rf.normIndex >= 0) {
+				var v = oldRecord.values[i];
+				var indexes = vn.fields[i].indexes;
+				// XXX: get rid of fieldArray or reuse
+				var fieldArray = Array<Val>.new(indexes.length);
+				if (rf.fieldType == null) fieldArray[0] = normSimpleVal(null, v);
+				else normValIntoArray(v, rf.typeNorm, fieldArray, 0);
+				for (j < indexes.length) array[indexes[j]] = fieldArray[j];
 			}
 		}
-		if (!vn.isTagless()) array[vn.tagIndex()] = Int.box(vn.tagValue);
 	}
 	// normalize the live instances of a simple (i.e. size-1 element) array type
 	def normSimpleArrayRecord(record: Record) {
@@ -391,7 +392,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 	def normSimpleVal(tn: TypeNorm, v: Val) -> Val {
 		match (v) {
 			x: Record => {
-				if (tn != null && VariantNorm.?(tn) && VariantNorm.!(tn).isEnum()) return normVariantVal(VariantNorm.!(tn), x)[0];
+				if (VariantNorm.?(tn) && VariantNorm.!(tn).isEnum()) return normVariantVal(VariantNorm.!(tn), x)[0];
 				var r = recordMap[x];
 				return if(r == null, x, r);
 			}
@@ -450,7 +451,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 		var table = Array<IrMethod>.new(size), mtable = IrMtable.new(rm.norm, rc.minClassId, table);
 		rv.mtable = mtable;
 
-		if (rc.variantNorm != null) {
+		if (rc.isUnboxed()) {
 			var ft = Function.funcRefType(rm.norm.getMethodType());
 			mtable.record = ra.prog.newRecord(V3Array.newType(ft), size);
 		}
@@ -550,7 +551,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 	}
 	def createIrClass(rc: RaClass) {
 		var sc = if(rc.parent != null, rc.parent.normClass);
-		var normFields = if(rc.variantNorm != null, NO_FIELDS, rc.normFields);
+		var normFields = if(rc.isUnboxed(), NO_FIELDS, rc.normFields);
 		var ic = IrClass.new(rc.newIrType, null, sc, normFields, rc.normMethods);
 		ic.minClassId = rc.minClassId;
 		ic.maxClassId = rc.maxClassId;
@@ -574,7 +575,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			var receiver = ra.oldIr.getIrClass(ctype);
 			var root = ra.oldIr.getIrClass(V3.getRootType(ctype));
 			var rc = ra.getClass(rm.receiver);
-			if (false && rc.variantNorm != null) { // TODO: disable generation of compare method bodies
+			if (false && rc.isUnboxed()) { // TODO: disable generation of compare method bodies
 				// flattened data types will have inlined compare
 				rm.orig.ssa = SsaGraph.new([], Bool.TYPE);
 				rm.orig.ssa.startBlock.append(SsaReturn.new([rm.orig.ssa.falseConst()]));

--- a/aeneas/src/ir/Normalization.v3
+++ b/aeneas/src/ir/Normalization.v3
@@ -35,7 +35,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 	var ovfAlloc: OverflowFieldAllocator;
 	var vs: VariantSolver;
 
-	new() { vs = VariantSolver.new(config, this, /* CLOptions.PRINT_RA.get() */ true); }
+	new() { vs = VariantSolver.new(config, this, CLOptions.PRINT_RA.get()); }
 
 	def normalize() {
 		if (CLOptions.PRINT_DEAD_CODE.get()) DeadCodeAnalyzer.new(ra).report();

--- a/aeneas/src/ir/Reachability.v3
+++ b/aeneas/src/ir/Reachability.v3
@@ -18,7 +18,6 @@ enum RaFact {
 	RC_ENUM,
 	RC_CLOSURE,
 	RC_BOXED,
-	RC_UNBOXED
 }
 
 def DUMP: Terminal;
@@ -108,7 +107,6 @@ class ReachabilityAnalyzer(compilation: Compilation) {
 		if (facts.RC_EQUALITY) DUMP.put(" equal");
 		if (facts.RC_CLOSURE) DUMP.put(" closure");
 		if (facts.RC_BOXED) DUMP.put(" boxed");
-		if (facts.RC_UNBOXED) DUMP.put(" unboxed");
 		if (countVals(facts) == 1) {
 			DUMP.put1(" const[%s]", V3.renderVal(val));
 		}
@@ -588,7 +586,7 @@ class RaClass extends RaType {
 	var normMethods: Array<IrMethod>;	// normalized methods
 	var minClassId = -1;			// minimum class ID
 	var maxClassId = -1;			// maximum class ID
-	var dataNorm: DataNorm;			// non-null for flattened variants
+	var variantNorm: VariantNorm;			// non-null for flattened variants
 	var newIrType: Type;
 
 	new(oldType: Type, orig, parent) super(oldType) {

--- a/aeneas/src/ir/Reachability.v3
+++ b/aeneas/src/ir/Reachability.v3
@@ -634,6 +634,7 @@ class RaClass extends RaType {
 		}
 		return true;
 	}
+	def isUnboxed() -> bool { return variantNorm != null; }
 }
 // Tracks instances of an array type.
 class RaArray extends RaType {

--- a/aeneas/src/ir/SsaNormalizer.v3
+++ b/aeneas/src/ir/SsaNormalizer.v3
@@ -52,7 +52,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 					// receiver became void
 					newParams.put(SsaParam.new(newParams.length, tn.newType));
 					start++; // skip synthesized receiver
-				} else if (DataNorm.?(tn)) {
+				} else if (VariantNorm.?(tn)) {
 					// receiver became flattened data
 					var newIrType = norm.ra.getClass(tn.oldType).newIrType;
 					newParams.put(SsaParam.new(newParams.length, newIrType));
@@ -204,10 +204,8 @@ class SsaRaNormalizer extends SsaRebuilder {
 			}
 			VariantGetTag => {
 				var rc = norm.ra.makeClass(op.typeArgs[0]);
-				if (rc.dataNorm != null) {
-					if (rc.dataNorm.tagType != null) return map1(app, genRef1(args[0]));
-					return map1(app, newGraph.zeroConst());
-				}
+				var t = normVariantGetTag(rc.variantNorm, genRefs(args));
+				if (t != null) return map1(app, t);
 				else normDefault(app, op);
 			}
 			VariantGetField(field) =>	normGetField(true, app, field, op);
@@ -241,7 +239,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 				var newOp = V3Op.newCallMethod(m);
 				var newArgs = normArgs(funcNorm, genRefs(app.inputs));
 				if (V3.isVariant(rc.oldType)) {
-					if (rc.dataNorm != null) {
+					if (rc.variantNorm != null) {
 						// flattened data type becomes component call and needs new receiver
 						newArgs = Arrays.prepend(newGraph.nullReceiver(), newArgs);
 					} else {
@@ -283,19 +281,19 @@ class SsaRaNormalizer extends SsaRebuilder {
 				var t = extractVirtualRef(orig, method), funcNorm = t.0, m = t.1;
 				var newArgs = normArgs(funcNorm, genRefs(app.inputs));
 				if (t.2) { // still a virtual dispatch
-					if (rc.dataNorm != null) {
+					if (rc.variantNorm != null) {
 						// use the variant tag as an index into a table of functions
 						var tag = newArgs[0];
 						var record = IrSelector.!(m.member).mtable.record;
 						var table = newGraph.valConst(record.rtype, record);
-						var func = curBlock.opArrayGetElem(record.rtype, rc.dataNorm.tagType, Facts.O_SAFE_BOUNDS, table, tag);
+						var func = curBlock.opArrayGetElem(record.rtype, rc.variantNorm.tagType(), Facts.O_SAFE_BOUNDS, table, tag);
 						newArgs = Arrays.concat([func, newGraph.nullReceiver()], newArgs);
 						normCall(app, funcNorm, V3Op.newCallFunction(funcNorm.sub[0]), newArgs);
 					} else {
 						normCall(app, funcNorm, V3Op.newCallVariantSelector(m), newArgs);
 					}
 				} else {
-					if (rc.dataNorm != null) {
+					if (rc.variantNorm != null) {
 						// flattened data type becomes component call and needs new receiver
 						newArgs = Arrays.prepend(newGraph.nullReceiver(), newArgs);
 					} else {
@@ -678,7 +676,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 	// normalize an equality operator
 	def normEqualOp(oldApp: SsaApplyOp, op: Operator) {
 		var tn = normTypeArg(op, 0);
-		if (!DataNorm.?(tn) && V3.isVariant(tn.newType)) return normVariantEqual(oldApp, tn.newType);
+		if (!VariantNorm.?(tn) && V3.isVariant(tn.newType)) return normVariantEqual(oldApp, tn.newType);
 		genEqualN(oldApp, tn);
 	}
 	def normSimpleEqualOp(oldApp: SsaApplyOp, op: Operator) {
@@ -714,6 +712,11 @@ class SsaRaNormalizer extends SsaRebuilder {
 		call.setFact(facts);
 		map1(oldApp, call);
 	}
+	def normVariantGetTag(vn: VariantNorm, args: Range<SsaInstr>) -> SsaInstr {
+		if (vn == null) return null;
+		if (vn.isTagless()) return newGraph.zeroConst();
+		return args[vn.tagIndex()];
+	}
 	def normTupleGetElem(oldInstr: SsaInstr, args: Array<SsaDfEdge>, op: Operator, index: int) {
 		var tn = TupleNorm.!(normTypeArg(op, 0));
 		return mapNnf(oldInstr, tn.getElem(genRefs(args), index));
@@ -742,11 +745,12 @@ class SsaRaNormalizer extends SsaRebuilder {
 			}
 			// XXX: CLASS_CAST special-case non-allocated classes
 			VARIANT_CAST => {
-				if (DataNorm.?(atn) && DataNorm.?(rtn)) {
-					var dn = DataNorm.!(rtn);
-					var tag = V3.getVariantTag(rtn.oldType);
-					curBlock.opIntRangeCheck(1, tag, tag + 1, oi[offset]);
-					for (i < dn.size) result.put(oi[offset + i]);
+				if (VariantNorm.?(atn) && VariantNorm.?(rtn)) {
+					var avn = VariantNorm.!(atn), rvn = VariantNorm.!(rtn);
+					var actualTag = normVariantGetTag(avn, oi[offset ...]);
+					var expectedTag = rvn.tagValue;
+					curBlock.opIntRangeCheck(1, expectedTag, expectedTag + 1, actualTag);
+					for (i < avn.size) result.put(oi[offset + i]);
 					return;
 				}
 				// break
@@ -813,10 +817,11 @@ class SsaRaNormalizer extends SsaRebuilder {
 			}
 			// XXX: CLASS_QUERY special-case non-allocated classes
 			VARIANT_QUERY => {
-				if (DataNorm.?(atn) && DataNorm.?(rtn)) {
-					var dn = DataNorm.!(rtn);
-					var tag = newGraph.intConst(V3.getVariantTag(rtn.oldType));
-					var check = curBlock.pure(V3Op.newIntEq(dn.tagType), [oi[offset], tag]);
+				if (VariantNorm.?(atn) && VariantNorm.?(rtn)) {
+					var avn = VariantNorm.!(atn), rvn = VariantNorm.!(rtn);
+					var expectedTag = newGraph.intConst(rvn.tagValue);
+					var actualTag = normVariantGetTag(avn, oi[offset ...]);
+					var check = curBlock.pure(V3Op.newIntEq(avn.tagType()), [actualTag, expectedTag]);
 					return opAnd(left, check);
 				}
 				// break
@@ -1166,16 +1171,20 @@ class SsaRaNormalizer extends SsaRebuilder {
 	}
 	def normClassAlloc(oldApp: SsaApplyOp, m: IrMethod, op: Operator) {
 		var rc = norm.ra.getClass(op.typeArgs[0]);
-		var dn = rc.dataNorm;
-		if (dn != null) {
+		var vn = rc.variantNorm;
+		if (vn != null) {
 			var inputs = genRefs(oldApp.inputs);
-			var result = Vector<SsaInstr>.new().grow(dn.size);
-			if (dn.tagType != null) result.put(newGraph.intConst(V3.getVariantTag(rc.oldType)));
-			for (i < dn.normRanges.length) {
-				var nr = dn.normRanges[i], or = dn.origRanges[i];
-				for (j < (nr.1 - nr.0)) result.put(inputs[or.0 + j]);
+			var result = Array<SsaInstr>.new(vn.size);
+			for (i < result.length) result[i] = newGraph.nullConst(vn.sub[i]);
+
+			if (!vn.isTagless()) result[vn.tagIndex()] = newGraph.intConst(vn.tagValue);
+
+			for (i < vn.fields.length) {
+				var f = vn.fields[i];
+				var fieldRanges = vn.fieldRanges[i], os = fieldRanges.0;
+				for (j < f.indexes.length) result[f.indexes[j]] = inputs[os + j];
 			}
-			return mapNnf(oldApp, result.extract());
+			return mapNnf(oldApp, result);
 		}
 		if (m == null) {
 			// trivial constructor
@@ -1209,15 +1218,13 @@ class SsaRaNormalizer extends SsaRebuilder {
 			if (!isVariant) addNullCheck(oldApp, ninputs[0]);
 			return map0(oldApp);
 		}
-		if (raField.raFacts.RC_UNBOXED) {
-			// field of flattened data type
-			normType(raField.receiver); // XXX: normType() side-effect of flattening
-			var rc = norm.ra.getClass(raField.receiver);
+		normType(raField.receiver); // XXX: normType() side-effect of flattening
+		var rc = norm.ra.getClass(raField.receiver);
+		if (isVariant && raField != null && rc.variantNorm != null) {
+			// field of unboxed data type
 			var vals = Array<SsaInstr>.new(nf.length);
-			var start = rc.dataNorm.normRanges[raField.orig.index].0;
-			for (i < vals.length) {
-				vals[i] = ninputs[start + i];
-			}
+			var field = rc.variantNorm.fields[raField.orig.index];
+			for (i < vals.length) vals[i] = ninputs[field.indexes[i]];
 			return mapNnf(oldApp, vals);
 		}
 		var receiver = ninputs[0];
@@ -1239,12 +1246,14 @@ class SsaRaNormalizer extends SsaRebuilder {
 		var raField = extractFieldRef(oldApp, field);
 		var newArgs = genRefs(oldApp.inputs), receiver = newArgs[0];
 		var nf = raField.norm;
+		var rc = norm.ra.getClass(raField.receiver);
+
 		if (nf == null || nf.length == 0 || !raField.raFacts.RF_READ) {
 			// OPT: remove write to useless field
 			// OPT: remove write of zero-width field
 			// OPT: remove write of write-only field
 			return addNullCheck(oldApp, receiver);
-		} else if (raField.raFacts.RC_UNBOXED) {
+		} else if (rc.variantNorm != null) {
 			// init/set of field of flattened data type
 			return map0(oldApp);
 		} else if (nf.length == 1) {

--- a/aeneas/src/ir/SsaNormalizer.v3
+++ b/aeneas/src/ir/SsaNormalizer.v3
@@ -239,7 +239,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 				var newOp = V3Op.newCallMethod(m);
 				var newArgs = normArgs(funcNorm, genRefs(app.inputs));
 				if (V3.isVariant(rc.oldType)) {
-					if (rc.variantNorm != null) {
+					if (rc.isUnboxed()) {
 						// flattened data type becomes component call and needs new receiver
 						newArgs = Arrays.prepend(newGraph.nullReceiver(), newArgs);
 					} else {
@@ -281,7 +281,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 				var t = extractVirtualRef(orig, method), funcNorm = t.0, m = t.1;
 				var newArgs = normArgs(funcNorm, genRefs(app.inputs));
 				if (t.2) { // still a virtual dispatch
-					if (rc.variantNorm != null) {
+					if (rc.isUnboxed()) {
 						// use the variant tag as an index into a table of functions
 						var tag = newArgs[0];
 						var record = IrSelector.!(m.member).mtable.record;
@@ -293,7 +293,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 						normCall(app, funcNorm, V3Op.newCallVariantSelector(m), newArgs);
 					}
 				} else {
-					if (rc.variantNorm != null) {
+					if (rc.isUnboxed()) {
 						// flattened data type becomes component call and needs new receiver
 						newArgs = Arrays.prepend(newGraph.nullReceiver(), newArgs);
 					} else {
@@ -1218,9 +1218,9 @@ class SsaRaNormalizer extends SsaRebuilder {
 			if (!isVariant) addNullCheck(oldApp, ninputs[0]);
 			return map0(oldApp);
 		}
-		normType(raField.receiver); // XXX: normType() side-effect of flattening
 		var rc = norm.ra.getClass(raField.receiver);
-		if (isVariant && raField != null && rc.variantNorm != null) {
+		normType(raField.receiver); // XXX: normType() side-effect of flattening
+		if (isVariant && raField != null && rc.isUnboxed()) {
 			// field of unboxed data type
 			var vals = Array<SsaInstr>.new(nf.length);
 			var field = rc.variantNorm.fields[raField.orig.index];
@@ -1253,7 +1253,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 			// OPT: remove write of zero-width field
 			// OPT: remove write of write-only field
 			return addNullCheck(oldApp, receiver);
-		} else if (rc.variantNorm != null) {
+		} else if (rc.isUnboxed()) {
 			// init/set of field of flattened data type
 			return map0(oldApp);
 		} else if (nf.length == 1) {

--- a/aeneas/src/ir/TypeNorm.v3
+++ b/aeneas/src/ir/TypeNorm.v3
@@ -128,13 +128,3 @@ class FuncNorm extends TypeNorm {
 		return FuncType.!(sub[0]).sig();
 	}
 }
-// Data type or variant classes can be flattened and represented as scalars.
-class DataNorm extends TypeNorm {
-	def tagType: IntType;
-	def origRanges: Array<(int, int)>;
-	def normRanges: Array<(int, int)>;
-
-	new(oldType: Type, newType: Type, tagType, origRanges, normRanges, sub: Array<Type>)
-		super(oldType, newType, sub) {
-	}
-}

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -87,6 +87,7 @@ class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: b
 		var vn = VariantNorm.new(rc.oldType, tagType, [tagType], [], tagField);
 		vn.tagValue = V3.getVariantTag(rc.oldType);
 		rc.raFacts |= RaFact.RC_ENUM;
+		rc.variantNorm = vn;
 		
 		for (l = rc.children; l != null; l = l.tail) {
 			setVariantNormForChildren(l.head, tagType, tagField);
@@ -111,7 +112,7 @@ class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: b
 		if (isEmpty && !closure) {
 			// normalize empty variant to just its tag; i.e. become an enum
 			var tagType = V3.getVariantTagType(rc.oldType);
-			var tagTypeNorm = rn.mapSimple(tagType);
+			var tagTypeNorm = rn.norm(tagType);
 			var tagField = VariantField.new(tagTypeNorm, [0]);
 			setVariantNormForChildren(rc, tagType, tagField);
 			return true;
@@ -132,10 +133,10 @@ class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: b
 	def unboxUsingTaglessVariantNorm(rc: RaClass) {
 		var ofs = rc.orig.fields;
 		var fields = Array<VariantField>.new(ofs.length);
+		var fieldRanges = Array<(int, int)>.new(ofs.length);
 
 		var vecO = Vector<Type>.new();
 		var vecT = Vector<Type>.new();
-		var fieldRanges = Array<(int, int)>.new(ofs.length);
 
 		for (i < ofs.length) {
 			var normStart = vecT.length, origStart = vecO.length;
@@ -144,8 +145,8 @@ class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: b
 
 			if (rf != null && rf.normIndex >= 0) {
 				if (rf.typeNorm != null) tn = rf.typeNorm;
-				else if (rf.fieldType != null) tn = rn.norm(rf.fieldType);
-				else tn = rn.mapSimple(rf.orig.fieldType);
+				else if (rf.fieldType != null) rf.typeNorm = tn = rn.norm(rf.fieldType);
+				else tn = rn.norm(rf.orig.fieldType);
 
 				tn.addTo(vecT);
 				indexes = Array<int>.new(tn.size);

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -1,0 +1,170 @@
+// Copyright 2024 Virgil authors. All rights reserved.
+// See LICENSE for details of Apache 2.0 license.
+
+class VariantNorm extends TypeNorm {
+	def fields: Array<VariantField>;
+
+	def tag: VariantField;
+	var tagValue: int = -1;
+
+	// for each field, this is the start + end index when ClassAlloc is called
+	var fieldRanges: Array<(int, int)>;
+
+	new(oldType: Type, newType: Type, sub: Array<Type>, fields, tag)
+		super(oldType, newType, sub) {}
+
+	// represent empty variant as tag
+	def isEnum() -> bool { return size == 1 && tag != null && fields.length == 0; }
+	def isEnumCase() -> bool { return size == 1 && tag != null && tagValue >= 0 && fields.length == 0; }
+
+	def tagType() -> IntType { return IntType.!(tag.tn.first()); }
+	def tagIndex() -> int { return tag.indexes[0]; }
+	
+	// represent single-case, unboxed variant without its tag
+	def isTagless() -> bool { return tag == null; }
+
+	def render(buf: StringBuilder) -> StringBuilder {
+		buf.put3("%q ## %q |%d|", oldType.render, newType.render, size);
+		buf.puts(" [");
+		for (i < sub.length) {
+			if (i > 0) buf.csp();
+			sub[i].render(buf);
+		}
+		buf.puts("] {");
+		if (tag != null) {
+			buf.put1("tag: %q", tag.render);
+		}
+		for (i < fields.length) {
+			if (i > 0 || tag != null) buf.csp();
+			fields[i].render(buf);
+		}
+		buf.puts("}");
+		return buf;
+	}
+}
+
+// Metadata about a variant's fields before/after normalization
+class VariantField {
+	def tn: TypeNorm;
+	def indexes: Array<int>; // Indexes into the variant's representation to extract the field from
+
+	new(tn, indexes) {}
+
+	def render(buf: StringBuilder) -> StringBuilder {
+		buf.puts("(");
+		for (i < indexes.length) {
+			if (i > 0) buf.csp();
+			buf.put1("#%d", indexes[i]);
+		}
+		buf.puts(")");
+		if (tn != null) buf.put1(": [%q]", tn.newType.render);
+		return buf;
+	}
+}
+
+def ON_STACK = -1;
+
+class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: bool) {
+	def normVariant(t: Type, rc: RaClass) -> TypeNorm {
+		if (rc.variantNorm != null) return rc.variantNorm;
+		if (rc.orig.boxing == Boxing.BOXED) rn.mapSimple(t);
+
+		var prev = rc.recursive;
+		match (rc.recursive) {
+			ON_STACK => {
+				rc.recursive = 2; // cycle detected; box
+			}
+			0 => {
+				rc.recursive = ON_STACK;
+				tryUnboxing(rc);
+				if (rc.recursive == ON_STACK) rc.recursive = 1;
+				if (rc.variantNorm != null) return rc.variantNorm;
+			}
+		}
+		return rn.mapSimple(t); 
+	}
+	def setVariantNormForChildren(rc: RaClass, tagType: IntType, tagField: VariantField) {
+		var vn = VariantNorm.new(rc.oldType, tagType, [tagType], [], tagField);
+		vn.tagValue = V3.getVariantTag(rc.oldType);
+		rc.raFacts |= RaFact.RC_ENUM;
+		
+		for (l = rc.children; l != null; l = l.tail) {
+			setVariantNormForChildren(l.head, tagType, tagField);
+		}
+	}
+	def tryUnboxing(rc: RaClass) -> bool {
+		if (rc.variantNorm != null) return true; // already done
+		while (rc.parent != null) rc = rc.parent;
+		
+		rn.makeNormFields(rc);
+
+		var isEmpty = rc.normFields.length == 0;
+		var closure = rc.raFacts.RC_CLOSURE;
+
+		for (l = rc.children; l != null; l = l.tail) {
+			var c = l.head;
+			rn.makeNormFields(c);
+			if (c.normFields.length > 0) isEmpty = false;
+			closure |= c.raFacts.RC_CLOSURE;
+		}
+
+		if (isEmpty && !closure) {
+			// normalize empty variant to just its tag; i.e. become an enum
+			var tagType = V3.getVariantTagType(rc.oldType);
+			var tagTypeNorm = rn.mapSimple(tagType);
+			var tagField = VariantField.new(tagTypeNorm, [0]);
+			setVariantNormForChildren(rc, tagType, tagField);
+			return true;
+		}
+		if (rc.children != null) {
+			// TODO: multi-case variant unboxing
+			return false;
+		}
+		match (rc.orig.boxing) {
+			BOXED => return false;
+			AUTO => if (rc.normFields.length > nc.MaxFlatDataValues && CLOptions.UNBOX_ALL.get()) return false;
+			UNBOXED => ; // program specified unboxed; TODO: recursion or closure should be an error
+		}
+		if (rc.recursive > 1 || closure) return false; // recursive or closed over
+		unboxUsingTaglessVariantNorm(rc);
+		return true;
+	}
+	def unboxUsingTaglessVariantNorm(rc: RaClass) {
+		var ofs = rc.orig.fields;
+		var fields = Array<VariantField>.new(ofs.length);
+
+		var vecO = Vector<Type>.new();
+		var vecT = Vector<Type>.new();
+		var fieldRanges = Array<(int, int)>.new(ofs.length);
+
+		for (i < ofs.length) {
+			var normStart = vecT.length, origStart = vecO.length;
+			var rf = rc.fields[i];
+			var tn: TypeNorm, indexes: Array<int>;
+
+			if (rf != null && rf.normIndex >= 0) {
+				if (rf.typeNorm != null) tn = rf.typeNorm;
+				else if (rf.fieldType != null) tn = rn.norm(rf.fieldType);
+				else tn = rn.mapSimple(rf.orig.fieldType);
+
+				tn.addTo(vecT);
+				indexes = Array<int>.new(tn.size);
+				for (j < indexes.length) indexes[j] = normStart + j;
+				fields[i] = VariantField.new(tn, indexes);
+			} else {
+				fields[i] = VariantField.new(null, []);
+			}
+			
+			var fieldType = ofs[i].fieldType.substitute(V3.getTypeArgs(rc.oldType));
+			rn.norm(fieldType).addTo(vecO);
+			fieldRanges[i] = (origStart, vecO.length);
+		}
+
+		var ta = vecT.extract();
+		var vn = VariantNorm.new(rc.oldType, Tuple.newType(Lists.fromArray(ta)), ta, fields, null);
+		vn.fieldRanges = fieldRanges;
+		rc.variantNorm = vn;
+
+		if (verbose) Terminal.put1("variant norm %q\n", rc.variantNorm.render);
+	}
+}

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -65,6 +65,10 @@ class VariantField {
 def ON_STACK = -1;
 
 class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: bool) {
+	def variantUnboxMatcher = GlobMatcher.new(CLOptions.UNBOX_VARIANTS.get());
+
+	// Normalizes a non-recursive variant, returns either a VariantNorm for an unboxed variant,
+	// or a simple TypeNorm for a boxed variant
 	def normVariant(t: Type, rc: RaClass) -> TypeNorm {
 		if (rc.variantNorm != null) return rc.variantNorm;
 		if (rc.orig.boxing == Boxing.BOXED) rn.mapSimple(t);
@@ -83,17 +87,10 @@ class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: b
 		}
 		return rn.mapSimple(t); 
 	}
-	def setVariantNormForChildren(rc: RaClass, tagType: IntType, tagField: VariantField) {
-		var vn = VariantNorm.new(rc.oldType, tagType, [tagType], [], tagField);
-		vn.tagValue = V3.getVariantTag(rc.oldType);
-		rc.raFacts |= RaFact.RC_ENUM;
-		rc.variantNorm = vn;
-		
-		for (l = rc.children; l != null; l = l.tail) {
-			setVariantNormForChildren(l.head, tagType, tagField);
-		}
-	}
-	def tryUnboxing(rc: RaClass) -> bool {
+	// Try to unbox a variant in one of two ways:
+	// 1. If a (non-closure) variant has all empty fields in all cases, represent it as a single uN tag (enum representation).
+	// 2. If a variant has only one case, represent it as a tagless tuple of scalars (data representation).
+	private def tryUnboxing(rc: RaClass) -> bool {
 		if (rc.variantNorm != null) return true; // already done
 		while (rc.parent != null) rc = rc.parent;
 		
@@ -114,7 +111,7 @@ class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: b
 			var tagType = V3.getVariantTagType(rc.oldType);
 			var tagTypeNorm = rn.norm(tagType);
 			var tagField = VariantField.new(tagTypeNorm, [0]);
-			setVariantNormForChildren(rc, tagType, tagField);
+			unboxUsingEnumVariantNorm(rc, tagType, tagField);
 			return true;
 		}
 		if (rc.children != null) {
@@ -123,14 +120,19 @@ class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: b
 		}
 		match (rc.orig.boxing) {
 			BOXED => return false;
-			AUTO => if (rc.normFields.length > nc.MaxFlatDataValues && CLOptions.UNBOX_ALL.get()) return false;
+			AUTO => {
+				if (rc.normFields.length > nc.MaxFlatDataValues) {
+					var classDecl = ClassType.!(rc.orig.ctype).classDecl;
+					if (!variantUnboxMatcher.matches(classDecl.token.image)) return false;
+				}
+			}
 			UNBOXED => ; // program specified unboxed; TODO: recursion or closure should be an error
 		}
 		if (rc.recursive > 1 || closure) return false; // recursive or closed over
 		unboxUsingTaglessVariantNorm(rc);
 		return true;
 	}
-	def unboxUsingTaglessVariantNorm(rc: RaClass) {
+	private def unboxUsingTaglessVariantNorm(rc: RaClass) {
 		var ofs = rc.orig.fields;
 		var fields = Array<VariantField>.new(ofs.length);
 		var fieldRanges = Array<(int, int)>.new(ofs.length);
@@ -167,5 +169,15 @@ class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: b
 		rc.variantNorm = vn;
 
 		if (verbose) Terminal.put1("variant norm %q\n", rc.variantNorm.render);
+	}
+	private def unboxUsingEnumVariantNorm(rc: RaClass, tagType: IntType, tagField: VariantField) {
+		var vn = VariantNorm.new(rc.oldType, tagType, [tagType], [], tagField);
+		vn.tagValue = V3.getVariantTag(rc.oldType);
+		rc.raFacts |= RaFact.RC_ENUM;
+		rc.variantNorm = vn;
+		
+		for (l = rc.children; l != null; l = l.tail) {
+			unboxUsingEnumVariantNorm(l.head, tagType, tagField);
+		}
 	}
 }

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -65,8 +65,6 @@ class VariantField {
 def ON_STACK = -1;
 
 class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: bool) {
-	def variantUnboxMatcher = GlobMatcher.new(CLOptions.UNBOX_VARIANTS.get());
-
 	// Normalizes a non-recursive variant, returns either a VariantNorm for an unboxed variant,
 	// or a simple TypeNorm for a boxed variant
 	def normVariant(t: Type, rc: RaClass) -> TypeNorm {
@@ -120,12 +118,7 @@ class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: b
 		}
 		match (rc.orig.boxing) {
 			BOXED => return false;
-			AUTO => {
-				if (rc.normFields.length > nc.MaxFlatDataValues) {
-					var classDecl = ClassType.!(rc.orig.ctype).classDecl;
-					if (!variantUnboxMatcher.matches(classDecl.token.image)) return false;
-				}
-			}
+			AUTO => if (rc.normFields.length > nc.MaxFlatDataValues) return false;
 			UNBOXED => ; // program specified unboxed; TODO: recursion or closure should be an error
 		}
 		if (rc.recursive > 1 || closure) return false; // recursive or closed over

--- a/aeneas/src/main/CLOptions.v3
+++ b/aeneas/src/main/CLOptions.v3
@@ -149,8 +149,12 @@ component CLOptions {
 		"Normalize ranges using RangeStart's to support off-heap ranges.");
 	def SET_EXEC		= compileOpt.newBoolOption("set-exec", true,
 		"Automatically set execute permission for compiled binaries.");
-	def USE_GLOBALREGALLOC = compileOpt.newMatcherOption("global-regalloc",
+	def USE_GLOBALREGALLOC	= compileOpt.newMatcherOption("global-regalloc",
 		"Enable global register allocator.");
+	def UNBOX_VARIANTS	= compileOpt.newBoolOption("unbox-variants", false,
+		"Enable variant unboxing features.");
+	def UNBOX_ALL		= compileOpt.newBoolOption("unbox-all", false,
+		"Unbox all non-recursive variants.");
 	// JVM target options
 	def JVM_RT_PATH		= jvmOpt.newStringOption("jvm.rt-path", null,
 		"Specify the path to the Java runtime.");

--- a/aeneas/src/main/CLOptions.v3
+++ b/aeneas/src/main/CLOptions.v3
@@ -151,9 +151,9 @@ component CLOptions {
 		"Automatically set execute permission for compiled binaries.");
 	def USE_GLOBALREGALLOC	= compileOpt.newMatcherOption("global-regalloc",
 		"Enable global register allocator.");
-	def UNBOX_VARIANTS	= compileOpt.newStringOption("unbox-variants", "*",
+	def UNBOX_VARIANTS	= compileOpt.newStringOption("unbox-variants", null,
 		"Enable variant unboxing features.");
-	def UNBOX_VARIANT_CASES	= compileOpt.newStringOption("unbox-variant-cases", "",
+	def UNBOX_VARIANT_CASES	= compileOpt.newStringOption("unbox-variant-cases", null,
 		"Unbox all non-recursive variants.");
 	// JVM target options
 	def JVM_RT_PATH		= jvmOpt.newStringOption("jvm.rt-path", null,

--- a/aeneas/src/main/CLOptions.v3
+++ b/aeneas/src/main/CLOptions.v3
@@ -151,9 +151,9 @@ component CLOptions {
 		"Automatically set execute permission for compiled binaries.");
 	def USE_GLOBALREGALLOC	= compileOpt.newMatcherOption("global-regalloc",
 		"Enable global register allocator.");
-	def UNBOX_VARIANTS	= compileOpt.newBoolOption("unbox-variants", false,
+	def UNBOX_VARIANTS	= compileOpt.newStringOption("unbox-variants", "*",
 		"Enable variant unboxing features.");
-	def UNBOX_ALL		= compileOpt.newBoolOption("unbox-all", false,
+	def UNBOX_VARIANT_CASES	= compileOpt.newStringOption("unbox-variant-cases", "",
 		"Unbox all non-recursive variants.");
 	// JVM target options
 	def JVM_RT_PATH		= jvmOpt.newStringOption("jvm.rt-path", null,

--- a/aeneas/src/vst/Verifier.v3
+++ b/aeneas/src/vst/Verifier.v3
@@ -12,6 +12,9 @@ class Verifier(compiler: Compiler, prog: Program) {
 	def ir = prog.ir = IrModule.new();
 	var exportMap: PartialMap<string, ExportDecl>;
 
+	private def unboxVariantsOpt = CLOptions.UNBOX_VARIANTS.get();
+	private def variantUnboxMatcher = if(unboxVariantsOpt != null, GlobMatcher.new(unboxVariantsOpt));
+
 	def forAll<T>(vec: Vector<T>, do: T -> void) {
 		for (i < vec.length) {
 			if (!ERROR.notTooMany) break;
@@ -235,6 +238,12 @@ class Verifier(compiler: Compiler, prog: Program) {
 				cv.superInitOrder = superDecl.verifier.initMax;
 				decl.numFields = superDecl.numFields;
 				decl.numMethods = superDecl.numMethods;
+			}
+		} else if (decl.kind == V3Kind.VARIANT) {
+			// top-level variant class
+			if (variantUnboxMatcher != null && (
+				Strings.equal(unboxVariantsOpt, "") || variantUnboxMatcher.matches(decl.token.image))) {
+				decl.repHints = List.new(VstRepHint.Unboxed, decl.repHints);
 			}
 		}
 		cv.verify();


### PR DESCRIPTION
This PR shifts the variant logic into `VariantSolver.v3`, and migrates away from the use of `DataNorm` to `VariantNorm`. `VariantNorm`s are able to represent both enum-like variants (no fields) and single-case, flattened variants.
This does not add any additional functionality.