### PR TITLE
[unbox] Fix variant equality to be case-by-case

### DIFF
--- a/aeneas/src/ir/SsaNormalizer.v3
+++ b/aeneas/src/ir/SsaNormalizer.v3
@@ -691,8 +691,10 @@ class SsaRaNormalizer extends SsaRebuilder {
 	def normEqualOp(oldApp: SsaApplyOp, op: Operator) {
 		var tn = normTypeArg(op, 0);
 		var refs = genRefs(oldApp.inputs);
-		if (!VariantNorm.?(tn) && V3.isVariant(tn.newType)) return map1(oldApp, normVariantEqual(oldApp, tn.newType, refs[0], refs[1]));
-		if (VariantNorm.?(tn) && !VariantNorm.!(tn).isEnum()) return map1(oldApp, normUnboxedVariantEqual(oldApp, VariantNorm.!(tn), refs));
+		match (tn) {
+			x: VariantNorm => if (!x.isEnum()) return map1(oldApp, normUnboxedVariantEqual(oldApp, x, refs));
+			_ => if (V3.isVariant(tn.newType)) return map1(oldApp, normVariantEqual(oldApp, tn.newType, refs[0], refs[1]));
+		}
 		map1(oldApp, normEqual(oldApp, tn, refs));
 	}
 	def normEqual1(oldApp: SsaApplyOp, t: Type, x: SsaInstr, y: SsaInstr) -> SsaInstr {

--- a/aeneas/src/ir/SsaNormalizer.v3
+++ b/aeneas/src/ir/SsaNormalizer.v3
@@ -692,6 +692,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 		var tn = normTypeArg(op, 0);
 		var refs = genRefs(oldApp.inputs);
 		if (!VariantNorm.?(tn) && V3.isVariant(tn.newType)) return map1(oldApp, normVariantEqual(oldApp, tn.newType, refs[0], refs[1]));
+		if (VariantNorm.?(tn) && !VariantNorm.!(tn).isEnum()) return map1(oldApp, normUnboxedVariantEqual(oldApp, VariantNorm.!(tn), refs));
 		map1(oldApp, normEqual(oldApp, tn, refs));
 	}
 	def normEqual1(oldApp: SsaApplyOp, t: Type, x: SsaInstr, y: SsaInstr) -> SsaInstr {
@@ -740,6 +741,54 @@ class SsaRaNormalizer extends SsaRebuilder {
 		var call = curBlock.addApply(oldApp.source, newOp, [x, y]);
 		call.setFact(facts);
 		return call;
+	}
+	// Normalize equality between two unboxed variants of the same case (e.g. x: T.A == y: T.A)
+	def normUnboxedVariantCaseEqual(oldApp: SsaApplyOp, vn: VariantNorm, refs: Array<SsaInstr>) -> SsaInstr {
+		var join = opBoolAnd;
+		var expr: SsaInstr;
+		for (i < vn.fields.length) {
+			var f = vn.fields[i];
+			for (j < f.indexes.length) {
+				var idx = f.indexes[j];
+				var cmp: SsaInstr, a = refs[idx], b = refs[idx + vn.size];
+				a = curBlock.opTypeSubsume(vn.sub[idx], f.tn.at(j), a);
+				b = curBlock.opTypeSubsume(vn.sub[idx], f.tn.at(j), b);
+				cmp = normEqual1(oldApp, f.tn.at(j), a, b);
+				if (expr == null) expr = cmp;
+				else expr = join(expr, cmp);
+			}
+		}
+		return if(expr != null, expr, newGraph.trueConst());
+	}
+	// Normalize equality between two unboxed variants of unknown case (e.g. x: T == y: T)
+	def normUnboxedVariantEqual(oldApp: SsaApplyOp, vn: VariantNorm, refs: Array<SsaInstr>) -> SsaInstr {
+		if (vn.isTagless()) return normEqual(oldApp, vn, refs); // we can always do a scalar-by-scalar comparison if no boxes are involved.
+		var ct = ClassType.!(vn.oldType);
+		if (ct.superType != null) return normUnboxedVariantCaseEqual(oldApp, vn, refs);
+
+		var xTag = normVariantGetTag(vn, refs[0 ... vn.size]);
+		var yTag = normVariantGetTag(vn, refs[vn.size ...]);
+
+		var tagsEqual = curBlock.opEqual(vn.tagType(), xTag, yTag);
+		var split = SsaBlockSplit.new(context, curBlock);
+		var results = Vector<SsaInstr>.new();
+
+		curBlock = split.addIfNot(tagsEqual);
+		results.put(newGraph.falseConst());
+
+		for (l = vn.children; l != null; l = l.tail) {
+			curBlock = split.addElse();
+			var cn = l.head;
+			var tag = V3.getVariantTag(cn.oldType);
+			curBlock = split.addIf(curBlock.opEqual(vn.tagType(), xTag, newGraph.intConst(tag)));
+			results.put(normUnboxedVariantCaseEqual(oldApp, cn, refs));
+		}
+
+		curBlock = split.addElse();
+		results.put(newGraph.falseConst());
+		curBlock = split.finish();
+		var result = split.addPhi(Bool.TYPE, results.extract());
+		return result;
 	}
 	def normVariantGetTag(vn: VariantNorm, args: Range<SsaInstr>) -> SsaInstr {
 		if (vn == null) return null;

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -9,6 +9,7 @@ class VariantNorm extends TypeNorm {
 
 	// for each field, this is the start + end index when ClassAlloc is called
 	var fieldRanges: Array<(int, int)>;
+	var children: List<VariantNorm>;
 
 	new(oldType: Type, newType: Type, sub: Array<Type>, fields, tag)
 		super(oldType, newType, sub) {}
@@ -240,6 +241,7 @@ class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: b
 		var newType = Tuple.newType(Lists.fromArray(types));
 
 		var parentNorm = VariantNorm.new(rc.oldType, newType, types, NO_FIELDS, tagField);
+		var childrenNorms: List<VariantNorm>;
 		rc.variantNorm = parentNorm;
 
 		for (l = rc.children; l != null; l = l.tail) {
@@ -248,8 +250,11 @@ class VariantSolver(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbose: b
 			vn.fieldRanges = cases.head.1;
 			vn.tagValue = V3.getVariantTag(c.oldType);
 			c.variantNorm = vn;
+			childrenNorms = List<VariantNorm>.new(vn, childrenNorms);
 			cases = cases.tail;
 		}
+		
+		parentNorm.children = childrenNorms;
 		return true;
 	}
 	private def unboxUsingEnumVariantNorm(rc: RaClass, tagType: IntType, tagField: VariantField) {

--- a/test/variants/ub_eq08.v3
+++ b/test/variants/ub_eq08.v3
@@ -1,0 +1,22 @@
+//@execute 0=true;1=false;2=true;3=false;4=true;5=false
+type A #unboxed {
+	case X(b: B);
+	case Y(c: C);
+}
+
+type B {
+	case X(x: int);
+	case Y(y: int);
+}
+
+type C {
+	case X(x: int);
+	case Y(y: int);
+}
+
+def arr1 = [A.X(B.X(12)), A.X(B.X(12)), A.X(B.Y(34)), A.X(B.Y(56)), A.Y(C.Y(12)), A.Y(C.Y(12))];
+def arr2 = [A.X(B.X(12)), A.X(B.X(34)), A.X(B.Y(34)), A.Y(C.Y(23)), A.Y(C.Y(12)), A.X(B.X(7))];
+
+def main(a: int) -> bool {
+	return arr1[a] == arr2[a];
+}

--- a/test/variants/ub_eq09.v3
+++ b/test/variants/ub_eq09.v3
@@ -1,0 +1,22 @@
+//@execute 0=true;1=false;2=true;3=false;4=true;5=false
+type A<T, U> #unboxed {
+	case X(b: T);
+	case Y(c: U);
+}
+
+type B {
+	case X(x: int);
+	case Y(y: int);
+}
+
+type C {
+	case X(x: int);
+	case Y(y: int);
+}
+
+def arr1 = [A<B, C>.X(B.X(12)), A<B, C>.X(B.X(12)), A<B, C>.X(B.Y(34)), A<B, C>.X(B.Y(56)), A<B, C>.Y(C.Y(12)), A<B, C>.Y(C.Y(12))];
+def arr2 = [A<B, C>.X(B.X(12)), A<B, C>.X(B.X(34)), A<B, C>.X(B.Y(34)), A<B, C>.Y(C.Y(23)), A<B, C>.Y(C.Y(12)), A<B, C>.X(B.X(7))];
+
+def main(a: int) -> bool {
+	return arr1[a] == arr2[a];
+}

--- a/test/variants/ub_eq10.v3
+++ b/test/variants/ub_eq10.v3
@@ -1,0 +1,21 @@
+//@execute 0=true;1=false;2=true;3=false;4=true;5=false
+type A<T, U> #unboxed {
+	case X(b: T);
+	case Y(c: U);
+}
+
+type B {
+	case X(x: int);
+	case Y(y: int);
+}
+
+type C {
+	case X(x: int);
+}
+
+def arr1 = [A<B, C>.X(B.X(12)), A<B, C>.X(B.X(12)), A<B, C>.X(B.Y(34)), A<B, C>.X(B.Y(56)), A<B, C>.Y(C.X(12)), A<B, C>.Y(C.X(12))];
+def arr2 = [A<B, C>.X(B.X(12)), A<B, C>.X(B.X(34)), A<B, C>.X(B.Y(34)), A<B, C>.Y(C.X(23)), A<B, C>.Y(C.X(12)), A<B, C>.X(B.X(7))];
+
+def main(a: int) -> bool {
+	return arr1[a] == arr2[a];
+}

--- a/test/variants/ub_eq11.v3
+++ b/test/variants/ub_eq11.v3
@@ -1,0 +1,25 @@
+//@execute 0=true;1=false;2=true;3=false;4=true;5=false;6=true;7=false;8=false;9=true
+type A<T, U> #unboxed {
+	case X(b: T);
+	case Y(c: U);
+}
+
+type B {
+	case X(x: int);
+	case Y(y: int);
+}
+
+type C {
+	case X(x: int);
+}
+
+def arr1 = [A<B, C>.X(B.X(12)), A<B, C>.X(B.X(12)), A<B, C>.X(B.Y(34)), A<B, C>.X(B.Y(56)), A<B, C>.Y(C.X(12)), A<B, C>.Y(C.X(12))];
+def arr2 = [A<B, C>.X(B.X(12)), A<B, C>.X(B.X(34)), A<B, C>.X(B.Y(34)), A<B, C>.Y(C.X(23)), A<B, C>.Y(C.X(12)), A<B, C>.X(B.X(7))];
+
+def arr3 = [A<int, int>.X(12), A<int, int>.X(34), A<int, int>.Y(56), A<int, int>.Y(78)];
+def arr4 = [A<int, int>.X(12), A<int, int>.X(12), A<int, int>.X(56), A<int, int>.Y(78)];
+
+def main(a: int) -> bool {
+	if (a < arr1.length) return arr1[a] == arr2[a];
+	return arr3[a - arr1.length] == arr4[a - arr2.length];
+}

--- a/test/variants/ub_eq12.v3
+++ b/test/variants/ub_eq12.v3
@@ -1,0 +1,25 @@
+//@execute 0=true;1=false;2=true;3=false;4=true;5=false;6=true;7=false;8=true;9=false;10=true;11=false
+type A<T, U> #unboxed {
+	case X(b: T);
+	case Y(c: U);
+}
+
+type B {
+	case X(x: int);
+	case Y(y: int);
+}
+
+type C {
+	case X(x: int);
+}
+
+def arr1 = [A<B, C>.X(B.X(12)), A<B, C>.X(B.X(12)), A<B, C>.X(B.Y(34)), A<B, C>.X(B.Y(56)), A<B, C>.Y(C.X(12)), A<B, C>.Y(C.X(12))];
+def arr2 = [A<B, C>.X(B.X(12)), A<B, C>.X(B.X(34)), A<B, C>.X(B.Y(34)), A<B, C>.Y(C.X(23)), A<B, C>.Y(C.X(12)), A<B, C>.X(B.X(7))];
+
+def arr3 = [A<B, B>.X(B.X(12)), A<B, B>.X(B.X(12)), A<B, B>.X(B.Y(34)), A<B, B>.X(B.Y(56)), A<B, B>.Y(B.X(12)), A<B, B>.Y(B.X(12))];
+def arr4 = [A<B, B>.X(B.X(12)), A<B, B>.X(B.X(34)), A<B, B>.X(B.Y(34)), A<B, B>.Y(B.X(23)), A<B, B>.Y(B.X(12)), A<B, B>.X(B.X(7))];
+
+def main(a: int) -> bool {
+	if (a < arr1.length) return arr1[a] == arr2[a];
+	return arr3[a - arr1.length] == arr4[a - arr2.length];
+}

--- a/test/variants/ub_eq13.v3
+++ b/test/variants/ub_eq13.v3
@@ -1,0 +1,26 @@
+//@execute 0=true;1=false;2=true;3=false;4=true;5=false;6=true;7=false;8=true;9=false;10=true;11=false
+type A<T, U> #unboxed {
+	case X(b: T);
+	case Y(c: U);
+}
+
+type B {
+	case X(x: int);
+	case Y(y: int);
+}
+
+type C {
+	case X(x: int);
+	case Y(y: int);
+}
+
+def arr1 = [A<B, C>.X(B.X(12)), A<B, C>.X(B.X(12)), A<B, C>.X(B.Y(34)), A<B, C>.X(B.Y(56)), A<B, C>.Y(C.X(12)), A<B, C>.Y(C.X(12))];
+def arr2 = [A<B, C>.X(B.X(12)), A<B, C>.X(B.X(34)), A<B, C>.X(B.Y(34)), A<B, C>.Y(C.X(23)), A<B, C>.Y(C.X(12)), A<B, C>.X(B.X(7))];
+
+def arr3 = [A<C, C>.X(C.X(12)), A<C, C>.X(C.X(12)), A<C, C>.X(C.Y(34)), A<C, C>.X(C.Y(56)), A<C, C>.Y(C.X(12)), A<C, C>.Y(C.X(12))];
+def arr4 = [A<C, C>.X(C.X(12)), A<C, C>.X(C.X(34)), A<C, C>.X(C.Y(34)), A<C, C>.Y(C.X(23)), A<C, C>.Y(C.X(12)), A<C, C>.X(C.X(7))];
+
+def main(a: int) -> bool {
+	if (a < arr1.length) return arr1[a] == arr2[a];
+	return arr3[a - arr1.length] == arr4[a - arr2.length];
+}


### PR DESCRIPTION
Variant equality is now done on a case-by-case basis. Previously, it did not correctly dispatch the variant equality method.

In the added test case, the old version would merge `B` and `C` together to become `#ref`, and then use `RefEq` instead, which is incorrect.