### PR TITLE
[unbox] [WIP] Fix extraction of integer types from variants

### DIFF
--- a/aeneas/src/ir/SsaNormalizer.v3
+++ b/aeneas/src/ir/SsaNormalizer.v3
@@ -753,8 +753,8 @@ class SsaRaNormalizer extends SsaRebuilder {
 			for (j < f.indexes.length) {
 				var idx = f.indexes[j];
 				var cmp: SsaInstr, a = refs[idx], b = refs[idx + vn.size];
-				a = curBlock.opTypeSubsume(vn.sub[idx], f.tn.at(j), a);
-				b = curBlock.opTypeSubsume(vn.sub[idx], f.tn.at(j), b);
+				a = genVariantScalarView(vn.sub[idx], f.tn.at(j), a);
+				b = genVariantScalarView(vn.sub[idx], f.tn.at(j), b);
 				cmp = normEqual1(oldApp, f.tn.at(j), a, b);
 				if (expr == null) expr = cmp;
 				else expr = join(expr, cmp);
@@ -791,6 +791,10 @@ class SsaRaNormalizer extends SsaRebuilder {
 		curBlock = split.finish();
 		var result = split.addPhi(Bool.TYPE, results.extract());
 		return result;
+	}
+	def genVariantScalarView(oldType: Type, newType: Type, scalar: SsaInstr) -> SsaInstr {
+		if (IntType.?(oldType) && IntType.?(newType)) return curBlock.opIntViewI0(oldType, newType, scalar);
+		return curBlock.opTypeSubsume(oldType, newType, scalar);
 	}
 	def normVariantGetTag(vn: VariantNorm, args: Range<SsaInstr>) -> SsaInstr {
 		if (vn == null) return null;
@@ -1264,7 +1268,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 				var fieldRanges = vn.fieldRanges[i], os = fieldRanges.0;
 				for (j < f.indexes.length) {
 					var idx = f.indexes[j];
-					result[idx] = curBlock.opTypeSubsume(f.tn.at(j), vn.at(idx), inputs[os + j]);
+					result[idx] = genVariantScalarView(f.tn.at(j), vn.at(idx), inputs[os + j]);
 				}
 			}
 			return mapNnf(oldApp, result);
@@ -1309,7 +1313,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 			var field = rc.variantNorm.fields[raField.orig.index];
 			for (i < vals.length) {
 				var idx = field.indexes[i];
-				vals[i] = curBlock.opTypeSubsume(rc.variantNorm.sub[idx], field.tn.at(i), ninputs[idx]);
+				vals[i] = genVariantScalarView(rc.variantNorm.sub[idx], field.tn.at(i), ninputs[idx]);
 			}
 			return mapNnf(oldApp, vals);
 		}

--- a/test/variants/ub_merge04.v3
+++ b/test/variants/ub_merge04.v3
@@ -1,0 +1,19 @@
+//@execute 0=0;1=1;2=0;3=1;4=-1
+type A00 #unboxed {
+	case Y(b: i32) { def f() -> i32 { return b; }}
+	case X(a: u32) { def f() -> i32 { return i32.view(a); } }
+
+	def f() -> i32;
+}
+
+var arr = [
+	A00.X(0),
+	A00.X(1),
+	A00.Y(0),
+	A00.Y(1),
+	A00.Y(-1)
+];
+
+def main(a: int) -> i32 {
+	return arr[a].f();
+}


### PR DESCRIPTION
There was an issue with ordinary subsumption for extracting integer fields, when they differed from the signedness of the representative scalar in the variant norm (due to the addition of type checks).

TODO: Add more tests