### PR TITLE
[unbox] Fix Wasm Unboxing Bug

### DIFF
--- a/aeneas/src/wasm/WasmTarget.v3
+++ b/aeneas/src/wasm/WasmTarget.v3
@@ -95,7 +95,7 @@ class WasmTarget extends Target {
 		var none: Scalar.set;
 		match (t) {
 			x: BoolType => return Scalar.B32 | Scalar.B64;
-			x: IntType => return if(x.width <= 32, Scalar.B32 | Scalar.B64, Scalar.B32); // XXX: Scalar.R64, once packed refs
+			x: IntType => return if(x.width <= 32, Scalar.B32 | Scalar.B64, Scalar.B64); // XXX: Scalar.R64, once packed refs
 			x: FloatType => return if(x.is64, Scalar.F64 | Scalar.B64, Scalar.F32 | Scalar.B32);
 			_ => return Scalar.R64;
 		}


### PR DESCRIPTION
Failure on `ub_merge00` and `ub_prim02` tests as compiler was picking a 32-bit scalar to represent a 64-bit field.