### PR TITLE
Fix bug with unboxed refs

### DIFF
--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -17,7 +17,10 @@ def getScalarFromSet(s: Scalar.set) -> Scalar {
 	return Scalar.B32; // should be unreachable
 }
 def getTypeFromScalarSet(s: Scalar.set, usePacking: bool) -> Type {
-	for (i in s) return if(usePacking, IntRep.getType(i), i.ty);
+	for (i in s) {
+		if (i.tag >= Scalar.R32.tag) return AnyRef.TYPE;
+		return if(usePacking, IntRep.getType(i), i.ty);
+	}
 	return null;
 }
 


### PR DESCRIPTION
We should not be using `u32[R32]/u64[R64]` at all while packed refs are not supported.
Fixes bug so `type Operand #unboxed #packed` can bootstrap.