### PR TITLE
Add support for lock prefix

### DIFF
--- a/lib/asm/x86-64/X86_64Assembler.v3
+++ b/lib/asm/x86-64/X86_64Assembler.v3
@@ -452,6 +452,7 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 	}
 	def cdq() -> this { emitb(0x99); }
 	def cqo() -> this { emitbb(REX_BYTE | REX_W, 0x99); }
+	def lock() -> this { emitb(0xF0); }
 
 	private def checkAbs(m: X86_64Addr) -> int {
 		if (m.base != null || m.index != null) System.error(ERROR, "expected absolute address");

--- a/lib/asm/x86/X86Assembler.v3
+++ b/lib/asm/x86/X86Assembler.v3
@@ -396,6 +396,7 @@ class X86Assembler(w: DataWriter) {
 	def movwsx(a: X86Reg, b: X86Rm) { emitbb_rm(0x0F, 0xBF, b, a.index); } // word load, sign extend
 	def not(a: X86Rm) { emitb_rm(0xF7, a, 2); }
 	def neg(a: X86Rm) { emitb_rm(0xF7, a, 3); }
+	def lock() -> this { emitb(0xF0); }
 	def repz() -> this { emitb(0xF3); }
 	def repne() -> this { emitb(0xF2); }
 	def scasb() { emitb(0xAE); }


### PR DESCRIPTION
This adds support for the lock prefix to be used when writing is `asm`.