### PR TITLE
Add exchange instructions to x86-64Assembler

### DIFF
--- a/lib/asm/x86-64/X86_64Assembler.v3
+++ b/lib/asm/x86-64/X86_64Assembler.v3
@@ -1048,16 +1048,31 @@ class X86_64Assembler(w: DataWriter, OP_REX: byte) {
 		}
 		emit_rex_b_r_r(b, a, OP_REX, 0x87);
 	}
+	
+	def xchgb_m_r(a: X86_64Addr, b: X86_64Gpr) -> this {
+		var rex = if(b.regnum > 3, REX_BYTE);
+		emit_rex_b_m_r(a, b, rex, 0x86);
+	}
+	def xchgw_m_r(a: X86_64Addr, b: X86_64Gpr) -> this {
+		emitb(PREFIX_W);
+		emit_rex_b_m_r(a, b, NO_REX, 0x87);
+	}
+	def xchgq_m_r(a: X86_64Addr, b: X86_64Gpr) -> this {
+		emit_rex_b_m_r(a, b, REX_W, 0x87);
+	}
+	def xchgd_m_r(a: X86_64Addr, b: X86_64Gpr) -> this {
+		emit_rex_b_m_r(a, b, NO_REX, 0x87);
+	}
 	def xchg_m_r(a: X86_64Addr, b: X86_64Gpr) -> this {
 		emit_rex_b_m_r(a, b, OP_REX, 0x87);
-	}
+	}	
+
 	def xadd_r_r(a: X86_64Gpr, b: X86_64Gpr) -> this {
 		emit_rex_bb_r_r(b, a, OP_REX, 0x0F, 0xC1);
 	}
 	def xadd_m_r(a: X86_64Addr, b: X86_64Gpr) -> this {
 		emit_rex_bb_r_m(b, a, OP_REX, 0x0F, 0xC1);
 	}
-
 	// SSE arithmetic
 	// XXX: factor SSE arithmetic further
 	def paddq_s_s(a: X86_64Xmmr, b: X86_64Xmmr) -> this {


### PR DESCRIPTION
Adds support for exchange instructions in `x86-64` that can be used  for atomic stores and other purposes.