### PR TITLE
Fix bugs with `-unbox-variants`

### DIFF
--- a/aeneas/src/ir/Normalization.v3
+++ b/aeneas/src/ir/Normalization.v3
@@ -57,6 +57,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 
 	var vn: VariantNormalizer;
 	var variantInterp = SsaInterpreter.new(ra.prog, null).setTrace(CLOptions.TRACE.get()); // interpreter to normalize records
+	var constructors = TypeUtil.newTypeMap<IrMethod>();
 
 	new() { vn = VariantNormalizer.new(config, this, CLOptions.PRINT_RA.get()); }
 
@@ -344,6 +345,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 	private def normRecordAsArray(rc: RaClass, oldRecord: Record, array: Array<Val>) {
 	}
 	private def getClassAllocIr(vn: VariantNorm) -> IrMethod {
+		if (constructors[vn.oldType] != null) return constructors[vn.oldType];
 		var context = SsaContext.new(ra.compiler, ra.prog);
 		var meth = IrMethod.new(vn.oldType, null, Function.siga(vn.vecO, vn.newType));
 
@@ -363,7 +365,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 		s.curBlock.addReturn(r);
 		context.printSsa("ClassAlloc");
 
-		return meth;
+		return constructors[vn.oldType] = meth;
 	}
 	// normalize an old record of a class into a new record of a class
 	def normClassRecord(rc: RaClass, oldRecord: Record, newRecord: Record) {

--- a/aeneas/src/ir/Normalization.v3
+++ b/aeneas/src/ir/Normalization.v3
@@ -397,8 +397,8 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			}
 
 			// Unboxed variants might require some type conversions; generate and run the constructor to do so.
-			var constructor = rc.orig.methods[0];
-			if (constructor == null || constructor.source != null) constructor = rc.orig.methods[0] = getClassAllocIr(vn);
+			// XXX: Cache constructor; we can't put the constructor in the first slot of rc.orig.methods, since multiple RaClasses could map to the same IrClass
+			var constructor = getClassAllocIr(vn);
 			var r = variantInterp.invoke(Closure.new(Values.BOTTOM, IrSpec.new(vn.oldType, TypeUtil.NO_TYPES, constructor)), inputs.extract());
 			match (r) {
 				x: BoxVal => for (i < x.values.length) result[i] = x.values[i];

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -97,7 +97,7 @@ class VariantField(tn: TypeNorm, indexes: Array<int>) {
 	}
 }
 
-def ON_STACK = -1, IS_RECURSIVE = 1, NOT_RECURSIVE = 2;
+def ON_STACK = -1, IS_RECURSIVE = 2, NOT_RECURSIVE = 1;
 def EMPTY_FIELD = VariantField.new(null, []);
 def NO_FIELDS = Array<VariantField>.new(0);
 
@@ -385,26 +385,24 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 	// Entrypoint into representation selection. Recursively tries to unbox and pack this variant.
 	// Returns either a {VariantNorm} for an unboxed variant or a simple {TypeNorm} for a boxed variant.
 	def normVariant(t: Type, rc: RaClass) -> TypeNorm {
-		if (rc.variantNorm != null)	return rc.variantNorm; // already done
+		Terminal.put2("normVariant rc=%q rec=%d\n", rc.oldType.render, rc.recursive);
+		if (rc.variantNorm != null) return rc.variantNorm; // already done
 		if (rc.orig.boxing == Boxing.BOXED) rn.mapSimple(t);
 
+		// deal with parent variant types here, not case types
+		var parent = rc;
+		while (parent.parent != null) parent = parent.parent;
+
 		var prev = rc.recursive;
-		match (rc.recursive) {
+		match (parent.recursive) {
 			ON_STACK => {
-				rc.recursive = IS_RECURSIVE; // cycle detected; box
+				parent.recursive = IS_RECURSIVE; // cycle detected; box
 			}
 			0 => {
-				var parent = rc;
-				while (parent.parent != null) parent = parent.parent;
-
-				if (parent.recursive == ON_STACK) {
-					parent.recursive = IS_RECURSIVE;
-				} else if (parent.recursive != IS_RECURSIVE) {
-					parent.recursive = ON_STACK;
-					tryUnboxing(parent);
-					if (parent.recursive == ON_STACK) parent.recursive = NOT_RECURSIVE;
-					if (rc.variantNorm != null) return rc.variantNorm;
-				}
+				parent.recursive = ON_STACK;
+				tryUnboxing(parent);
+				if (parent.recursive == ON_STACK) parent.recursive = NOT_RECURSIVE;
+				if (rc.variantNorm != null) return rc.variantNorm;
 			}
 		}
 		return rn.mapSimple(t);
@@ -414,6 +412,7 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 	// 2. If a variant has only one case, represent it as a tagless tuple of scalars (data representation).
 	// 3. If a variant has multiple cases and is marked #unboxed, use a flattened representation with the smallest set of scalars.
 	private def tryUnboxing(rc: RaClass) -> bool {
+		Terminal.put2("tryUnboxing rc=%q rec=%d\n", rc.oldType.render, rc.recursive);
 		if (rc.variantNorm != null) return true; // already done
 
 		rn.makeNormFields(rc);

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -40,7 +40,7 @@ class VariantNorm extends TypeNorm {
 	def tag: VariantField;
 	var vecO: Array<Type>;
 	var fieldRanges: Array<(int, int)>; // (start, end) index for ClassAlloc instructions
-	
+
 	var tagValue: int = -1;
 	var children: List<VariantNorm>;
 
@@ -52,7 +52,7 @@ class VariantNorm extends TypeNorm {
 	def isEnumCase() -> bool { return size == 1 && tag != null && tagValue >= 0 && fields.length == 0; }
 	def tagType() -> IntType { return IntType.!(tag.tn.first()); }
 	def tagIndex() -> int { return tag.indexes[0]; }
-	
+
 	// represent single-case, unboxed variant without its tag
 	def hasNoTag() -> bool { return tag == null; }
 	// tagging is explicit - may be packed, or a separate scalar
@@ -97,7 +97,7 @@ class VariantField(tn: TypeNorm, indexes: Array<int>) {
 	}
 }
 
-def ON_STACK = -1;
+def ON_STACK = -1, IS_RECURSIVE = 1, NOT_RECURSIVE = 2;
 def EMPTY_FIELD = VariantField.new(null, []);
 def NO_FIELDS = Array<VariantField>.new(0);
 
@@ -219,7 +219,7 @@ class VariantSolver(vnorm: VariantNormalizer, usePacking: bool) {
 			for (i < curRep.length) curUsed.put(0);
 			return tryRepresentationForField(curCase + 1, 0);
 		}
-		
+
 		var sc = vnorm.getScalar(normFields[curCase][curField]);
 		var bw = getBitWidth(normFields[curCase][curField]);
 		var none: Scalar.set;
@@ -333,7 +333,7 @@ class VariantSolver(vnorm: VariantNormalizer, usePacking: bool) {
 
 		var packedTag: bool;
 		if (usePacking) packedTag = tryExplicitTaggingHeuristic();
-		
+
 		var types = getTypes(!packedTag);
 		curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
 		curSoln.tagType = Int.getType(false, getTagLength(normFields.length));
@@ -385,22 +385,29 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 	// Entrypoint into representation selection. Recursively tries to unbox and pack this variant.
 	// Returns either a {VariantNorm} for an unboxed variant or a simple {TypeNorm} for a boxed variant.
 	def normVariant(t: Type, rc: RaClass) -> TypeNorm {
-		if (rc.variantNorm != null) return rc.variantNorm; // already done
+		if (rc.variantNorm != null)	return rc.variantNorm; // already done
 		if (rc.orig.boxing == Boxing.BOXED) rn.mapSimple(t);
 
 		var prev = rc.recursive;
 		match (rc.recursive) {
 			ON_STACK => {
-				rc.recursive = 2; // cycle detected; box
+				rc.recursive = IS_RECURSIVE; // cycle detected; box
 			}
 			0 => {
-				rc.recursive = ON_STACK;
-				tryUnboxing(rc);
-				if (rc.recursive == ON_STACK) rc.recursive = 1;
-				if (rc.variantNorm != null) return rc.variantNorm;
+				var parent = rc;
+				while (parent.parent != null) parent = parent.parent;
+
+				if (parent.recursive == ON_STACK) {
+					parent.recursive = IS_RECURSIVE;
+				} else if (parent.recursive != IS_RECURSIVE) {
+					parent.recursive = ON_STACK;
+					tryUnboxing(parent);
+					if (parent.recursive == ON_STACK) parent.recursive = NOT_RECURSIVE;
+					if (rc.variantNorm != null) return rc.variantNorm;
+				}
 			}
 		}
-		return rn.mapSimple(t); 
+		return rn.mapSimple(t);
 	}
 	// Try to unbox a variant in one of three ways:
 	// 1. If a (non-closure) variant has all empty fields in all cases, represent it as a single uN tag (enum representation).
@@ -408,8 +415,7 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 	// 3. If a variant has multiple cases and is marked #unboxed, use a flattened representation with the smallest set of scalars.
 	private def tryUnboxing(rc: RaClass) -> bool {
 		if (rc.variantNorm != null) return true; // already done
-		while (rc.parent != null) rc = rc.parent;
-		
+
 		rn.makeNormFields(rc);
 
 		var isEmpty = rc.liveFields.length == 0;
@@ -432,7 +438,7 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 		}
 		if (rc.children != null) {
 			// multi-case variant unboxing
-			if (closure) return printNoUnboxReason(rc, false, true);
+			if (rc.recursive > 1 || closure) return printNoUnboxReason(rc, rc.recursive > 1, closure);
 			match (rc.orig.boxing) {
 				BOXED, AUTO => return false;
 				_ => return unboxUsingTaggedVariantNorm(rc);
@@ -469,7 +475,7 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 
 		rc.fieldRangesO = Array<(int, int)>.new(rfs.length);
 		rc.fieldRangesT = Array<(int, int)>.new(rfs.length);
-		
+
 		var fieldTypes = Vector<Type>.new();
 		var vecO = Vector<Type>.new();
 
@@ -524,7 +530,7 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 
 		var shouldPack = rc.orig.packed;
 		var needsTagScalar = !shouldPack;
-		
+
 		var solver = VariantSolver.new(this, shouldPack);
 		var solution = solver.solve(normFields);
 		if (solution == null) return false; // XXX: warn that no solution was found
@@ -552,7 +558,7 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 			vn.vecO = child.vecO;
 			vn.tagValue = V3.getVariantTag(child.oldType);
 			child.variantNorm = vn;
-			
+
 			parentNorm.children = List<VariantNorm>.new(vn, parentNorm.children);
 			if (verbose) Terminal.put1("  %q\n", vn.render);
 		}
@@ -564,7 +570,7 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 		vn.tagValue = V3.getVariantTag(rc.oldType);
 		rc.raFacts |= RaFact.RC_ENUM;
 		rc.variantNorm = vn;
-		
+
 		for (l = rc.children; l != null; l = l.tail) unboxUsingEnumVariantNorm(l.head, tagType, tagField);
 	}
 	private def fieldNorm(rf: RaField) -> TypeNorm {
@@ -580,7 +586,7 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 	}
 	private def printSingleNorm(rc: RaClass, vn: VariantNorm) {
 		buf.typeColor().put1("              %q ", rc.oldType.render).end();
-				
+
 		for (field in vn.fields) {
 			if (field == EMPTY_FIELD) continue;
 			for (j < field.tn.size) {

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -385,7 +385,6 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 	// Entrypoint into representation selection. Recursively tries to unbox and pack this variant.
 	// Returns either a {VariantNorm} for an unboxed variant or a simple {TypeNorm} for a boxed variant.
 	def normVariant(t: Type, rc: RaClass) -> TypeNorm {
-		Terminal.put2("normVariant rc=%q rec=%d\n", rc.oldType.render, rc.recursive);
 		if (rc.variantNorm != null) return rc.variantNorm; // already done
 		if (rc.orig.boxing == Boxing.BOXED) rn.mapSimple(t);
 
@@ -412,7 +411,6 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 	// 2. If a variant has only one case, represent it as a tagless tuple of scalars (data representation).
 	// 3. If a variant has multiple cases and is marked #unboxed, use a flattened representation with the smallest set of scalars.
 	private def tryUnboxing(rc: RaClass) -> bool {
-		Terminal.put2("tryUnboxing rc=%q rec=%d\n", rc.oldType.render, rc.recursive);
 		if (rc.variantNorm != null) return true; // already done
 
 		rn.makeNormFields(rc);

--- a/test/variants/ub_rec05.v3
+++ b/test/variants/ub_rec05.v3
@@ -1,0 +1,27 @@
+//@execute 0=0; 1=5; 2=10; 3=120
+
+type T #unboxed {
+	case Leaf(x: int);
+	case One(a: T.Leaf, b: T.Leaf);
+	case Two(a: T.One, b: T.One);
+}
+
+def main(a: int) -> int {
+	var leaf: T.Leaf;
+	var one: T.One;
+	var two: T.Two;
+
+	if (a == 0) return count(leaf);
+	if (a == 1) return count(T.Leaf(5));
+	if (a == 2) return count(one);
+	if (a == 3) return count(two);
+	return 49;
+}
+
+def count(t: T) -> int {
+	match (t) {
+		Leaf(x) => return x;
+		One(a, b) => return 10 + count(a) + count(b);
+		Two(a, b) => return 100 + count(a) + count(b);
+	}
+}

--- a/test/variants/ub_rec06.v3
+++ b/test/variants/ub_rec06.v3
@@ -1,0 +1,28 @@
+//@execute 0=0; 1=5; 2=10; 3=120
+
+type T<E> #unboxed {
+	case Leaf(x: E);
+	case One(a: T<E>.Leaf, b: T<E>.Leaf);
+	case Two(a: T<E>.One, b: T<E>.One);
+}
+
+def main(a: int) -> int {
+	var leaf: T<int>.Leaf;
+	var one: T<int>.One;
+	var two: T<int>.Two;
+	var nop = int.!<int>;
+
+	if (a == 0) return count(leaf, nop);
+	if (a == 1) return count(T<int>.Leaf(5), nop);
+	if (a == 2) return count(one, nop);
+	if (a == 3) return count(two, nop);
+	return 49;
+}
+
+def count<E>(t: T<E>, num: E -> int) -> int {
+	match (t) {
+		Leaf(x) => return num(x);
+		One(a, b) => return 10 + count(a, num) + count(b, num);
+		Two(a, b) => return 100 + count(a, num) + count(b, num);
+	}
+}


### PR DESCRIPTION
Fixes two separate bugs with variant unboxing uncovered by the `-unbox-variants` flag:
- Recursive tests are more exhaustive: previously, it would attempt to unbox variants even if cases referred to their sibling types.
- We were saving space by caching the ClassAlloc constructor in `rc.orig.methods[0]`. This is not correct, because multiple `RaClass`es can have the same `rc.orig`. 