### PR TITLE
[fix] Upgrade Java source/target to 8

### DIFF
--- a/rt/jvm/Makefile
+++ b/rt/jvm/Makefile
@@ -1,5 +1,5 @@
 bin/V3S_System.class: src/V3S_System.java
-	javac -source 1.5 -target 1.5 -d bin/ src/V3S_System.java
+	javac -source 1.8 -target 1.8 -d bin/ src/V3S_System.java
 
 clean:
 	rm -f bin/*.class


### PR DESCRIPTION
This is needed because when building the JVM runtime an error pops up related to this:

```
javac -source 1.5 -target 1.5 -d bin/ src/V3S_System.java
warning: [options] bootstrap class path is not set in conjunction with -source 5
  not setting the bootstrap class path may lead to class files that cannot run on JDK 8
    --release 5 is recommended instead of -source 5 -target 1.5 because it sets the bootstrap class path automatically
error: Source option 5 is no longer supported. Use 8 or later.
error: Target option 5 is no longer supported. Use 8 or later.
make: *** [Makefile:2: bin/V3S_System.class] Error 2
```