### PR TITLE
Added `pushr` to `ArrayStack`

### DIFF
--- a/lib/util/Stack.v3
+++ b/lib/util/Stack.v3
@@ -32,7 +32,7 @@ class ListStack<T> extends Stack<T> {
 	}
 }
 // Stack implementation using an array as storage.
-class ArrayStack<T> {
+class ArrayStack<T> extends Stack<T> {
 	def var elems = Array<T>.new(10);
 	var top = 0; // TODO: stack top should not be directly mutable
 
@@ -56,11 +56,15 @@ class ArrayStack<T> {
 	}
 	// Push the elements in {v}.
 	def pusha(v: Array<T>) {
-		var end = top + v.length;
+		pushr(v);
+	}
+	// Push the elements in range {r}.
+	def pushr(r: Range<T>) {
+		var end = top + r.length;
 		if (end > elems.length) {
 			elems = Arrays.grow(elems, end + elems.length * 3);
 		}
-		for (i < v.length) elems[top + i] = v[i];
+		for (i < r.length) elems[top + i] = r[i];
 		top = end;
 	}
 	// Push {v} {n} times.


### PR DESCRIPTION
This PR adds the capability to push a range of values on to `ArrayStack`, created for resolving [this](https://github.com/titzer/wizard-engine/blob/d989c9038e7357f41bb0fa41d0d944e224ae09bd/src/engine/v3/V3Interpreter.v3#L42) in Wizard.