### PR TITLE
Added extraction of `Range<T>` from `Vector<T>`

### DIFF
--- a/lib/util/Vector.v3
+++ b/lib/util/Vector.v3
@@ -94,6 +94,10 @@ class Vector<T> {
 		length = 0;
 		return result;
 	}
+	// Get the range corresponding to this vector.
+	def toRange() -> Range<T> {
+		return array[0 ... length];
+	}
 	// Send the elements of this vector to function {f}, avoiding an intermediate copy.
 	// Note that it is implementation dependent if {f} is called multiple times, e.g. if
 	// the internal storage is fragmented.


### PR DESCRIPTION
Added `Vector.toRange` to mimic the behavior of array's implicit promotion to range.

In particular this is to address [a few `pc` linear searches on Vector/Array in Wizard](https://github.com/linxuanm/wizard-engine/blob/d2779350806ee24670459ee07f67e0caa054db79/src/util/VectorUtil.v3#L9) that can be done with binary searches instead. Considering this it may make sense for data structures with random access to be promotable to ranges so that algorithms like binary search can be implemented generically.