### PR TITLE
Small change to the aeneas script to make it more robust

### DIFF
--- a/aeneas/src/ssa/SsaOptimizer.v3
+++ b/aeneas/src/ssa/SsaOptimizer.v3
@@ -1911,6 +1911,7 @@ class SsaLoadOptimizer(context: SsaContext) {
 		pure.length = 0;
 		impure.length = 0;
 		var i = block.next;
+		if (SsaPhi.?(i)) i = i.next;
 		while (SsaApplyOp.?(i)) {
 			var instr = SsaApplyOp.!(i);
 			var next = instr.next;

--- a/bin/dev/aeneas
+++ b/bin/dev/aeneas
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-BIN=$(builtin cd $(dirname ${BASH_SOURCE[0]})/.. && builtin pwd)
+BIN=$(builtin cd $(dirname ${BASH_SOURCE[0]})/.. >/dev/null && builtin pwd)
 JAR=$BIN/jar
 JAR_LINK=$BIN/Aeneas.jar
 V3C_LINK=$BIN/v3c
-VIRGIL_LOC=${VIRGIL_LOC:=$(builtin cd $BIN/.. && builtin pwd)}
+VIRGIL_LOC=${VIRGIL_LOC:=$(builtin cd $BIN/.. >/dev/null && builtin pwd)}
 AENEAS_SYS=${AENEAS_SYS:=${VIRGIL_LOC}/rt/darwin/*.v3}
 AENEAS_LOC=${AENEAS_LOC:=${VIRGIL_LOC}/aeneas/src}
 AENEAS_JVM_TUNING=${AENEAS_JVM_TUNING:="-client -Xms900m -Xmx900m -XX:+UseSerialGC"}


### PR DESCRIPTION
Otherwise, blocks that start with a phi do not get optimized.
An interesting question is whether there are other things in a block, besides SsaApplyOp's, that should get skipped over (or otherwise handled) in the while loop.  But this change was effective in removing junk from XXGetField's expanded in normalization from accesses to unboxed variants, at least in my test case.  Your CI can check to see whether this causes any regressions ...