### PR TITLE
Fix load optimizer to skip the phi at a start of some blocks

### DIFF
--- a/aeneas/src/ssa/SsaOptimizer.v3
+++ b/aeneas/src/ssa/SsaOptimizer.v3
@@ -1911,6 +1911,7 @@ class SsaLoadOptimizer(context: SsaContext) {
 		pure.length = 0;
 		impure.length = 0;
 		var i = block.next;
+		if (SsaPhi.?(i)) i = i.next;
 		while (SsaApplyOp.?(i)) {
 			var instr = SsaApplyOp.!(i);
 			var next = instr.next;

--- a/bin/dev/aeneas
+++ b/bin/dev/aeneas
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-BIN=$(builtin cd $(dirname ${BASH_SOURCE[0]})/.. && builtin pwd)
+BIN=$(builtin cd $(dirname ${BASH_SOURCE[0]})/.. >/dev/null && builtin pwd)
 JAR=$BIN/jar
 JAR_LINK=$BIN/Aeneas.jar
 V3C_LINK=$BIN/v3c
-VIRGIL_LOC=${VIRGIL_LOC:=$(builtin cd $BIN/.. && builtin pwd)}
+VIRGIL_LOC=${VIRGIL_LOC:=$(builtin cd $BIN/.. >/dev/null && builtin pwd)}
 AENEAS_SYS=${AENEAS_SYS:=${VIRGIL_LOC}/rt/darwin/*.v3}
 AENEAS_LOC=${AENEAS_LOC:=${VIRGIL_LOC}/aeneas/src}
 AENEAS_JVM_TUNING=${AENEAS_JVM_TUNING:="-client -Xms900m -Xmx900m -XX:+UseSerialGC"}


### PR DESCRIPTION
Without this change, the load optimizer does nothing to a block that starts with a phi.
We should also consider whether there are things other than an SsaApplyOp where we should do something, or at least keep going.
(Sorry about the aeneas script change lurking in there.)