### PR TITLE
[lib] Added `HashMap.remove` to `Map.v3`

### DIFF
--- a/lib/util/Map.v3
+++ b/lib/util/Map.v3
@@ -65,9 +65,6 @@ class HashMap<K, V> extends PartialMap<K, V> {
 			// missed the cache, table not yet allocated, insert both
 			table = Array.new(16); // TUNABLE: initial HashMap table size
 			if (c != null) insert(c);
-			
-			var v = hash(key); // NPE here
-
 			insert(cache = Bucket.new(key, val, null));
 			return;
 		}

--- a/lib/util/Map.v3
+++ b/lib/util/Map.v3
@@ -112,7 +112,47 @@ class HashMap<K, V> extends PartialMap<K, V> {
 	}
 	// Remove {key} from this map. Return true if {key} existed.
 	def remove(key: K) -> bool {
-		return false;
+		var c = cache;
+		if (c == null) return false; // empty map
+		var found = false;
+
+		// search table
+		if (table != null) {
+			for (i < table.length) {
+				if (table[i] == null) continue;
+				if (table[i].key == key || equals(table[i].key, key)) {
+					table[i] = table[i].next;
+					found = true;
+					break;
+				}
+				for (b = table[i]; b.next != null; b = b.next) {
+					if (b.next.key == key || equals(b.next.key, key)) {
+						b.next = b.next.next;
+						found = true;
+						break;
+					}
+				}
+				if (found) break;
+			}
+		}
+
+		// if cache hit, clear cache and set it to any bucket
+		if (c.key == key || equals(c.key, key)) {
+			found = true;
+			// set cache to any bucket
+			// XXX: better cache refill?
+			cache = try_find_bucket();
+		}
+
+		return found;
+	}
+	private def try_find_bucket() -> Bucket<K, V> {
+		if (table != null) {
+			for (b in table) {
+				if (b != null) return b;
+			}
+		}
+		return null;
 	}
 	private def insert(bucket: Bucket<K, V>) {
 		var hashval = dohash(bucket.key);

--- a/lib/util/Map.v3
+++ b/lib/util/Map.v3
@@ -118,26 +118,21 @@ class HashMap<K, V> extends PartialMap<K, V> {
 		}
 		// search table
 		if (table != null) {
-			for (i < table.length) {
-				var curr = table[i];
-				if (curr == null) continue;
-				if (curr.key == key || equals(curr.key, key)) {
-					table[i] = curr.next;
-					found = true;
-					break;
+			var hashval = dohash(key);
+			var curr = table[hashval];
+			if (curr == null) return found;
+			if (curr.key == key || equals(curr.key, key)) {
+				table[hashval] = curr.next;
+				return true;
+			}
+			while (curr.next != null) {
+				if (curr.next.key == key || equals(curr.next.key, key)) {
+					curr.next = curr.next.next;
+					return true;
 				}
-				while (curr.next != null) {
-					if (curr.next.key == key || equals(curr.next.key, key)) {
-						curr.next = curr.next.next;
-						found = true;
-						break;
-					}
-					curr = curr.next;
-				}
-				if (found) break;
+				curr = curr.next;
 			}
 		}
-
 		return found;
 	}
 	private def insert(bucket: Bucket<K, V>) {

--- a/lib/util/Map.v3
+++ b/lib/util/Map.v3
@@ -21,25 +21,25 @@ class HashMap<K, V> extends PartialMap<K, V> {
 	private var table: Array<Bucket<K, V>>;	// lazily allocated hashtable
 	private var cache: Bucket<K, V>;	// cache for last entry get/set
 
+	// Cases for {cache} and {table}:
+	// - {cache == null}, {table == null}: map is empty
+	// - {cache == v}, {table == null}: map has a single entry {v}
+	// - {cache == v}, {table == t}: {v} is an entry in {t} (cached an entry)
+	// - {cache == null}, {table == t}: cache not populated
+
 	new(hash, equals) { }
 
 	// Get the value for {key}, if one exists; otherwise return the default value for {V}.
 	def [key: K] -> V {
 		var c = cache;
-		if (c == null) { var none: V; return none; }
-		// cache is valid, must be at least one entry
-		if (c.key == key) return c.val;
-		// if table is null, there is only one key/value pair
-		if (table == null) {
-			if (equals(c.key, key)) return c.val; // a slow hit in the cache
-			var none: V; 
-			return none;
-		}
-		// cache did not match, hash and do bucket search
-		for (bucket = table[dohash(key)]; bucket != null; bucket = bucket.next) {
-			if (bucket.key == key || equals(bucket.key, key)) {
-				cache = bucket;
-				return bucket.val;
+		if (c != null && (c.key == key || equals(c.key, key))) return c.val;
+		// cache is empty or did not match, hash and do bucket search
+		if (table != null) {
+			for (bucket = table[dohash(key)]; bucket != null; bucket = bucket.next) {
+				if (bucket.key == key || equals(bucket.key, key)) {
+					cache = bucket;
+					return bucket.val;
+				}
 			}
 		}
 		var none: V;
@@ -48,25 +48,26 @@ class HashMap<K, V> extends PartialMap<K, V> {
 	// Set the value for {key} to {val}, overwriting any previous value.
 	def [key: K] = val: V {
 		var c = cache;
-		if (c == null) {
-			// no entries yet, simply add it as the cache
-			cache = Bucket<K, V>.new(key, val, null);
+		// empty map: only populate {cache}
+		// note that {cache} in single-element map will not be overwritten unless
+		// by another insertion
+		if (c == null && table == null) {
+			cache = Bucket.new(key, val, null);
 			return;
 		}
-		if (c.key == key) {
-			// ==, a fast hit in the cache
+		// cache hit
+		if (c != null && (c.key == key || equals(c.key, key))) {
 			c.val = val;
 			return;
 		}
+		// cache miss
 		if (table == null) {
-			if (equals(c.key, key)) {
-				// equals(), a slow hit in the cache
-				c.val = val;
-				return;
-			}
 			// missed the cache, table not yet allocated, insert both
 			table = Array.new(16); // TUNABLE: initial HashMap table size
-			insert(c);
+			if (c != null) insert(c);
+			
+			var v = hash(key); // NPE here
+
 			insert(cache = Bucket.new(key, val, null));
 			return;
 		}
@@ -88,9 +89,8 @@ class HashMap<K, V> extends PartialMap<K, V> {
 	// Check if this map has a value for the {key}.
 	def has(key: K) -> bool {
 		var c = cache;
-		if (c == null) return false; // no entries
-		if (c.key == key) return true; // hit cache
-		if (table == null) return equals(c.key, key); // no table, slow hit cache?
+		if (c != null && (c.key == key || equals(c.key, key))) return true;
+		if (table == null) return false; // no table
 		for (bucket = table[dohash(key)]; bucket != null; bucket = bucket.next) {
 			if (bucket.key == key || equals(bucket.key, key)) return true;
 		}
@@ -113,46 +113,35 @@ class HashMap<K, V> extends PartialMap<K, V> {
 	// Remove {key} from this map. Return true if {key} existed.
 	def remove(key: K) -> bool {
 		var c = cache;
-		if (c == null) return false; // empty map
 		var found = false;
-
+		// if cache hit, clear cache
+		if (c != null && (c.key == key || equals(c.key, key))) {
+			found = true;
+			cache = null;
+		}
 		// search table
 		if (table != null) {
 			for (i < table.length) {
-				if (table[i] == null) continue;
-				if (table[i].key == key || equals(table[i].key, key)) {
-					table[i] = table[i].next;
+				var curr = table[i];
+				if (curr == null) continue;
+				if (curr.key == key || equals(curr.key, key)) {
+					table[i] = curr.next;
 					found = true;
 					break;
 				}
-				for (b = table[i]; b.next != null; b = b.next) {
-					if (b.next.key == key || equals(b.next.key, key)) {
-						b.next = b.next.next;
+				while (curr.next != null) {
+					if (curr.next.key == key || equals(curr.next.key, key)) {
+						curr.next = curr.next.next;
 						found = true;
 						break;
 					}
+					curr = curr.next;
 				}
 				if (found) break;
 			}
 		}
 
-		// if cache hit, clear cache and set it to any bucket
-		if (c.key == key || equals(c.key, key)) {
-			found = true;
-			// set cache to any bucket
-			// XXX: better cache refill?
-			cache = try_find_bucket();
-		}
-
 		return found;
-	}
-	private def try_find_bucket() -> Bucket<K, V> {
-		if (table != null) {
-			for (b in table) {
-				if (b != null) return b;
-			}
-		}
-		return null;
 	}
 	private def insert(bucket: Bucket<K, V>) {
 		var hashval = dohash(bucket.key);

--- a/lib/util/Map.v3
+++ b/lib/util/Map.v3
@@ -110,6 +110,10 @@ class HashMap<K, V> extends PartialMap<K, V> {
 			}
 		}
 	}
+	// Remove {key} from this map. Return true if {key} existed.
+	def remove(key: K) -> bool {
+		return false;
+	}
 	private def insert(bucket: Bucket<K, V>) {
 		var hashval = dohash(bucket.key);
 		bucket.next = table[hashval];

--- a/test/lib/MapTest.v3
+++ b/test/lib/MapTest.v3
@@ -35,40 +35,44 @@ def test_get(t: LibTest) {
 	var c = Counter.new();
 	var i_s = int_map<string>();
 	var s_s = Strings.newMap<string>();
+	var arr = Array<string>.new(100);
 	for (i < 100) {
 		var s = int2str(i);
 		i_s[i] = s;
 		s_s[s] = s;
+		arr[i] = s;
 	}
 	for (i < 100) {
-		var s = int2str(i);
-		t.assert_string(i_s[i], s);
-		t.assert_string(s_s[s], s);
+		var s = arr[i];
+		t.asserteq(i_s[i], s);
+		t.asserteq(s_s[s], s);
 	}
 }
 
 def test_set(t: LibTest) {
 	var i_s = int_map<string>();
 	var s_s = Strings.newMap<string>();
+	var arr = Array<string>.new(100);
 	for (i < 100) {
 		var s = int2str(i);
 		i_s[i] = s;
 		s_s[s] = s;
+		arr[i] = s;
 	}
 	for (i < 100) {
-		var s = int2str(i);
-		t.assert_string(i_s[i], s);
-		t.assert_string(s_s[s], s);
+		var s = arr[i];
+		t.asserteq(i_s[i], s);
+		t.asserteq(s_s[s], s);
 	}
 	t.asserteq(size(i_s), 100);
 	t.asserteq(size(s_s), 100);
 	for (i < 100) {
-		var s = int2str(i);
+		var s = arr[i];
 		i_s[i] = "foo";
 		s_s[s] = "bar";
 	}
 	for (i < 100) {
-		var s = int2str(i);
+		var s = arr[i];
 		t.assert_string(i_s[i], "foo");
 		t.assert_string(s_s[s], "bar");
 	}
@@ -116,10 +120,10 @@ def test_remove(t: LibTest) {
 	i_i[1] = 0;
 	i_i[2] = 4;
 	t.assert(i_i.has(1));
-	// t.assert(i_i.remove(2));
+	t.assert(i_i.remove(2));
 
-	// for (i < 100) i_i[i] = i * 2;
-	// for (i < 100) t.assert(i_i.remove(i));
-	// for (i = 100; i < 200; i++) t.assert(!i_i.remove(i));
-	// t.asserteq(size(i_i), 0);
+	for (i < 100) i_i[i] = i * 2;
+	for (i < 100) t.assert(i_i.remove(i));
+	for (i = 100; i < 200; i++) t.assert(!i_i.remove(i));
+	t.asserteq(size(i_i), 0);
 }

--- a/test/lib/MapTest.v3
+++ b/test/lib/MapTest.v3
@@ -113,8 +113,13 @@ def test_remove(t: LibTest) {
 	t.assert(!i_i.has(2));
 	t.asserteq(size(i_i), 0);
 
-	for (i < 100) i_i[i] = i * 2;
-	for (i < 100) t.assert(i_i.remove(i));
-	for (i = 100; i < 200; i++) t.assert(!i_i.remove(i));
-	t.asserteq(size(i_i), 0);
+	i_i[1] = 0;
+	i_i[2] = 4;
+	t.assert(i_i.has(1));
+	// t.assert(i_i.remove(2));
+
+	// for (i < 100) i_i[i] = i * 2;
+	// for (i < 100) t.assert(i_i.remove(i));
+	// for (i = 100; i < 200; i++) t.assert(!i_i.remove(i));
+	// t.asserteq(size(i_i), 0);
 }

--- a/test/lib/MapTest.v3
+++ b/test/lib/MapTest.v3
@@ -1,0 +1,35 @@
+// Copyright 2023 Virgil authors. All rights reserved.
+// See LICENSE for details of Apache 2.0 license.
+
+def T = LibTests.register("Map", _, _);
+def X = [
+	T("get", test_get),
+	T("set", test_set),
+	T("has", test_has),
+	T("apply", test_apply),
+	()
+];
+
+def str_map<V>() -> HashMap<string, V> {
+	return HashMap<string, V>.new(Strings.hash, Strings.equal);
+}
+
+def int_map<V>() -> HashMap<int, V> {
+	return HashMap<int, V>.new(int.!, int.==);
+}
+
+def test_get(t: LibTest) {
+
+}
+
+def test_set(t: LibTest) {
+
+}
+
+def test_has(t: LibTest) {
+
+}
+
+def test_apply(t: LibTest) {
+
+}

--- a/test/lib/MapTest.v3
+++ b/test/lib/MapTest.v3
@@ -7,6 +7,7 @@ def X = [
 	T("set", test_set),
 	T("has", test_has),
 	T("apply", test_apply),
+	T("remove", test_remove),
 	()
 ];
 
@@ -20,7 +21,15 @@ def int_map<V>() -> HashMap<int, V> {
 	return HashMap<int, V>.new(int.!, int.==);
 }
 
-def int2str(v: int) -> string { return StringBuilder.new().putd(v).extract(); }
+def int2str(v: int) -> string {
+	return StringBuilder.new().putd(v).extract();
+}
+
+def size<K, V>(m: HashMap<K, V>) -> int {
+	var c = Counter.new();
+	m.apply(c.add);
+	return c.x;
+}
 
 def test_get(t: LibTest) {
 	var c = Counter.new();
@@ -39,7 +48,6 @@ def test_get(t: LibTest) {
 }
 
 def test_set(t: LibTest) {
-	var c = Counter.new();
 	var i_s = int_map<string>();
 	var s_s = Strings.newMap<string>();
 	for (i < 100) {
@@ -52,12 +60,8 @@ def test_set(t: LibTest) {
 		t.assert_string(i_s[i], s);
 		t.assert_string(s_s[s], s);
 	}
-	i_s.apply(c.add);
-	t.asserteq(c.x, 100);
-	c.reset();
-	s_s.apply(c.add);
-	t.asserteq(c.x, 100);
-	c.reset();
+	t.asserteq(size(i_s), 100);
+	t.asserteq(size(s_s), 100);
 	for (i < 100) {
 		var s = int2str(i);
 		i_s[i] = "foo";
@@ -68,12 +72,8 @@ def test_set(t: LibTest) {
 		t.assert_string(i_s[i], "foo");
 		t.assert_string(s_s[s], "bar");
 	}
-	i_s.apply(c.add);
-	t.asserteq(c.x, 100);
-	c.reset();
-	s_s.apply(c.add);
-	t.asserteq(c.x, 100);
-	c.reset();
+	t.asserteq(size(i_s), 100);
+	t.asserteq(size(s_s), 100);
 }
 
 def test_has(t: LibTest) {
@@ -91,3 +91,30 @@ def test_apply(t: LibTest) {
 }
 
 def inc_counter(k: int, c: Counter) { c.x += k; }
+
+def test_remove(t: LibTest) {
+	var i_i = int_map<int>();
+	i_i[12] = 24;
+	t.assert(i_i.remove(12));
+	t.assert(!i_i.remove(12));
+	t.assert(!i_i.has(12));
+	t.asserteq(size(i_i), 0);
+	t.asserteq(i_i[12], 0);
+
+	i_i[1] = 10;
+	i_i[2] = 20;
+	t.assert(!i_i.remove(0));
+	t.assert(i_i.remove(1));
+	t.assert(!i_i.remove(1));
+	t.assert(!i_i.has(1));
+	t.assert(i_i.has(2));
+	t.asserteq(size(i_i), 1);
+	t.assert(i_i.remove(2));
+	t.assert(!i_i.has(2));
+	t.asserteq(size(i_i), 0);
+
+	for (i < 100) i_i[i] = i * 2;
+	for (i < 100) t.assert(i_i.remove(i));
+	for (i = 100; i < 200; i++) t.assert(!i_i.remove(i));
+	t.asserteq(size(i_i), 0);
+}

--- a/test/lib/MapTest.v3
+++ b/test/lib/MapTest.v3
@@ -10,20 +10,78 @@ def X = [
 	()
 ];
 
-def str_map<V>() -> HashMap<string, V> {
-	return HashMap<string, V>.new(Strings.hash, Strings.equal);
+class Counter {
+	var x = 0;
+	def add<K, V>(a: K, b: V) { x++; }
+	def reset() { x = 0; } 
 }
 
 def int_map<V>() -> HashMap<int, V> {
 	return HashMap<int, V>.new(int.!, int.==);
 }
 
-def test_get(t: LibTest) {
+def int2str(v: int) -> string { return StringBuilder.new().putd(v).extract(); }
 
+def test_get(t: LibTest) {
+	var c = Counter.new();
+	var i_s = int_map<string>();
+	var s_s = Strings.newMap<string>();
+
+	for (i < 100) {
+		var s = int2str(i);
+		i_s[i] = s;
+		s_s[s] = s;
+	}
+
+	for (i < 100) {
+		var s = int2str(i);
+		t.assert_string(i_s[i], s);
+		t.assert_string(s_s[s], s);
+	}
 }
 
 def test_set(t: LibTest) {
+	var c = Counter.new();
+	var i_s = int_map<string>();
+	var s_s = Strings.newMap<string>();
 
+	for (i < 100) {
+		var s = int2str(i);
+		i_s[i] = s;
+		s_s[s] = s;
+	}
+
+	for (i < 100) {
+		var s = int2str(i);
+		t.assert_string(i_s[i], s);
+		t.assert_string(s_s[s], s);
+	}
+
+	i_s.apply(c.add);
+	t.asserteq(c.x, 100);
+	c.reset();
+	s_s.apply(c.add);
+	t.asserteq(c.x, 100);
+	c.reset();
+
+	for (i < 100) {
+		var s = int2str(i);
+		i_s[i] = "foo";
+		s_s[s] = "bar";
+	}
+
+	for (i < 100) {
+		var s = int2str(i);
+		t.assert_string(i_s[i], "foo");
+		t.assert_string(s_s[s], "bar");
+	}
+
+	i_s.apply(c.add);
+	t.asserteq(c.x, 100);
+	c.reset();
+	s_s.apply(c.add);
+	t.asserteq(c.x, 100);
+	c.reset();
 }
 
 def test_has(t: LibTest) {

--- a/test/lib/MapTest.v3
+++ b/test/lib/MapTest.v3
@@ -26,13 +26,11 @@ def test_get(t: LibTest) {
 	var c = Counter.new();
 	var i_s = int_map<string>();
 	var s_s = Strings.newMap<string>();
-
 	for (i < 100) {
 		var s = int2str(i);
 		i_s[i] = s;
 		s_s[s] = s;
 	}
-
 	for (i < 100) {
 		var s = int2str(i);
 		t.assert_string(i_s[i], s);
@@ -44,38 +42,32 @@ def test_set(t: LibTest) {
 	var c = Counter.new();
 	var i_s = int_map<string>();
 	var s_s = Strings.newMap<string>();
-
 	for (i < 100) {
 		var s = int2str(i);
 		i_s[i] = s;
 		s_s[s] = s;
 	}
-
 	for (i < 100) {
 		var s = int2str(i);
 		t.assert_string(i_s[i], s);
 		t.assert_string(s_s[s], s);
 	}
-
 	i_s.apply(c.add);
 	t.asserteq(c.x, 100);
 	c.reset();
 	s_s.apply(c.add);
 	t.asserteq(c.x, 100);
 	c.reset();
-
 	for (i < 100) {
 		var s = int2str(i);
 		i_s[i] = "foo";
 		s_s[s] = "bar";
 	}
-
 	for (i < 100) {
 		var s = int2str(i);
 		t.assert_string(i_s[i], "foo");
 		t.assert_string(s_s[s], "bar");
 	}
-
 	i_s.apply(c.add);
 	t.asserteq(c.x, 100);
 	c.reset();
@@ -85,9 +77,17 @@ def test_set(t: LibTest) {
 }
 
 def test_has(t: LibTest) {
-
+	var i_s = int_map<string>();
+	for (i < 100) i_s[i] = int2str(i);
+	for (i < 100) t.assert(i_s.has(i));
+	for (i = 100; i < 200; i++) t.assert(!i_s.has(i));
 }
 
 def test_apply(t: LibTest) {
-
+	var i_s = int_map<Counter>();
+	for (i < 100) i_s[i] = Counter.new();
+	i_s.apply(inc_counter);
+	for (i < 100) t.asserteq(i_s[i].x, i);
 }
+
+def inc_counter(k: int, c: Counter) { c.x += k; }


### PR DESCRIPTION
This PR adds support for removing a key-value pair from hash map along with a basic test for `lib/util/Map.v3`.

This would be useful for the Virgil language server that I'm working on, which needs a LRU implementation (with hashmap) and I thought it would be useful to be in the standard util library.