### PR TITLE
[lib] Fixed assymetry between `Ranges.startsWith` and `Ranges.endsWith`

### DIFF
--- a/lib/util/Ranges.v3
+++ b/lib/util/Ranges.v3
@@ -84,7 +84,7 @@ component Ranges {
 	}
 	// Check if {range} ends with {end}, i.e. the latter is a suffix.
 	def endsWith<T>(range: Range<T>, end: Range<T>) -> bool {
-		if (range.length <= end.length) return false;
+		if (range.length < end.length) return false;
 		for (i < end.length) {
 			if (range[range.length - i - 1] != end[end.length - i - 1]) return false;
 		}

--- a/test/lib/RangesTest.v3
+++ b/test/lib/RangesTest.v3
@@ -18,6 +18,7 @@ def X = [
 	T("binsrch_dup", test_binsrch_dup),
 	T("binsrch_lteq", test_binsrch_lteq),
 	T("binsrch_gteq", test_binsrch_gteq),
+	T("start_end", test_start_end),
 	()
 ];
 
@@ -342,4 +343,33 @@ def test_binsrch_gteq(t: LibTest) {
 	test(3, search([2, 4, 4], 5));
 	test(4, search([2, 2, 4, 4], 5));
 	test(4, search([2, 2, 2, 4], 5));
+}
+
+def test_start_end(t: LibTest) {
+	def T = t.assertz(true, _);
+	def F = t.assertz(false, _);
+
+	T(Ranges.endsWith("", ""));
+	T(Ranges.endsWith("abc", ""));
+	F(Ranges.endsWith("", "a"));
+	T(Ranges.startsWith("", ""));
+	T(Ranges.startsWith("abc", ""));
+	F(Ranges.startsWith("", "a"));
+
+	T(Ranges.endsWith("abc", "abc"));
+	T(Ranges.endsWith("abc", "bc"));
+	T(Ranges.endsWith("abc", "c"));
+	T(Ranges.startsWith("abc", "abc"));
+	T(Ranges.startsWith("abc", "ab"));
+	T(Ranges.startsWith("abc", "a"));
+
+	F(Ranges.endsWith("hello ", "hello"));
+	F(Ranges.startsWith(" hello", "hello"));
+
+	T(Ranges.endsWith<int>([1], []));
+	T(Ranges.startsWith<int>([1], []));
+	T(Ranges.endsWith<int>([1], [1]));
+	T(Ranges.startsWith<int>([1], [1]));
+	T(Ranges.endsWith<int>([1, 2, 3], [1, 2, 3]));
+	T(Ranges.startsWith<int>([1, 2, 3], [1, 2, 3]));
 }


### PR DESCRIPTION
It seems like `startsWith` and `endsWith` currently exhibits different behaviors in that a range can be a prefix of itself in `startsWith`, but cannot be a suffix of itself in `endsWith`. This PR changes `endsWith` to match with `startsWith`.