### PR TITLE
fix duplicate DefCase print in VstPrinter

### DIFF
--- a/aeneas/src/vst/VstPrinter.v3
+++ b/aeneas/src/vst/VstPrinter.v3
@@ -268,7 +268,6 @@ class VstPrinter extends VstVisitor<int, void> {
 		p.enter("MatchStmt", indent);
 		stmt.expr.accept(this, indent + 1);
 		Lists.apply(stmt.cases.list, printCases(_, indent + 2));
-		if (stmt.defcase != null) printCases(stmt.defcase, indent + 2);
 		p.exit();
 	}
 	def visitEmpty(stmt: EmptyStmt, indent: int) {


### PR DESCRIPTION
I'm not sure if this is the correct fix, since I don't really understand what we expect `defcase` to be. If it's meant to be for `match else`, the bug is somewhere upstream. If it's supposed to point to a wildcard in `stmt.cases` this makes sense though.

```
            (MatchStmt
                (VarExpr[Local] "kind": FieldKind)
                    (VarExpr[None] "U8")
                    (...)
                    ...
                    (DefCase)
                    (ReturnStmt
                        (AppExpr "invalid": void
                            (VarExpr[ComponentMethod] "invalid": void -> void)
                            (VarExpr[Local] "invalid": CanonicalDefs)))
                    (DefCase) /* ! Duplicate ! */
                    (ReturnStmt
                        (AppExpr "invalid": void
                            (VarExpr[ComponentMethod] "invalid": void -> void)
                            (VarExpr[Local] "invalid": CanonicalDefs)))))

```