### PR TITLE
Add s-expression parser to lib/util

### DIFF
--- a/lib/util/Sexpr.v3
+++ b/lib/util/Sexpr.v3
@@ -1,0 +1,75 @@
+type Sexp {
+    case Atom(data: string);
+    case List(elts: Range<Sexp>); // usually Cons
+
+    def buildString(buf: StringBuilder) {
+        match (this) {
+            Atom(data) => buf.puts(data);
+            List(elts) => {
+                buf.putc('(');
+                for (i = 0; i < elts.length - 1; i += 1) {
+                    elts[i].buildString(buf);
+                    buf.sp();
+                }
+                elts[elts.length - 1].buildString(buf);
+                buf.putc(')');
+            }
+        }
+    }
+}
+
+type ParseResult<T> {
+    case Success(res: T);
+    case Expected(str: string);
+    case EmptySexp;
+}
+
+class SexpParser extends TextReader {
+    new(filename: string, data: Array<byte>) super(filename, data) {}
+
+    def atomChar(b: byte) -> bool {
+        match (b) {
+            ' ' => return false;
+            '\t' => return false;
+            '\n' => return false;
+            ')' => return false;
+            _ => return true;
+        }
+    }
+
+    // can't make it ParseResult<Sexp.Atom>?
+    def readAtom() -> ParseResult<Sexp> {
+        skipWhitespace();
+        def atom_end = star_rel(1, atomChar);
+        if (atom_end == -1) return ParseResult.Expected("atom");
+
+        def tok = readToken(atom_end - pos);
+        skipWhitespace();
+        return ParseResult.Success(Sexp.Atom(tok.image));
+    }
+
+    def readSexp() -> ParseResult<Sexp> {
+        skipWhitespace();
+        if (req1('(') == -1) return ParseResult.Expected("(");
+        skipWhitespace();
+
+        def elts = Vector<Sexp>.new();
+        while (opt1(')') == -1) {
+            skipWhitespace();
+            def res: ParseResult<Sexp> = if(peekRel(0) == '(', readSexp(), readAtom());
+
+            match (res) {
+                Success(elt) => elts.put(elt);
+                _ => return res;
+            }
+        }
+
+        skipWhitespace();
+
+        match (elts.length) {
+            0 => return ParseResult.EmptySexp;
+            1 => return ParseResult.Success(elts[0]);
+            _ => return ParseResult.Success(Sexp.List(elts.copy()));
+        }
+    }
+}

--- a/lib/util/Sexpr.v3
+++ b/lib/util/Sexpr.v3
@@ -1,17 +1,19 @@
-type Sexp {
+type SExpr {
     case Atom(data: string);
-    case List(elts: Range<Sexp>); // usually Cons
+    case List(elems: List<SExpr>); // usually Cons
 
     def buildString(buf: StringBuilder) {
         match (this) {
             Atom(data) => buf.puts(data);
-            List(elts) => {
+            List(elems) => {
                 buf.putc('(');
-                for (i = 0; i < elts.length - 1; i += 1) {
-                    elts[i].buildString(buf);
+		var elem = elems;
+		while (elem.tail != null) {
+                    elem.head.buildString(buf);
                     buf.sp();
-                }
-                elts[elts.length - 1].buildString(buf);
+		    elem = elem.tail;
+		}
+                elem.head.buildString(buf);
                 buf.putc(')');
             }
         }
@@ -21,10 +23,10 @@ type Sexp {
 type ParseResult<T> {
     case Success(res: T);
     case Expected(str: string);
-    case EmptySexp;
+    case EmptySExpr;
 }
 
-class SexpParser extends TextReader {
+class SExprParser extends TextReader {
     new(filename: string, data: Array<byte>) super(filename, data) {}
 
     def atomChar(b: byte) -> bool {
@@ -37,39 +39,42 @@ class SexpParser extends TextReader {
         }
     }
 
-    // can't make it ParseResult<Sexp.Atom>?
-    def readAtom() -> ParseResult<Sexp> {
+    // can't make it ParseResult<SExpr.Atom>?
+    def readAtom() -> ParseResult<SExpr> {
         skipWhitespace();
         def atom_end = star_rel(1, atomChar);
         if (atom_end == -1) return ParseResult.Expected("atom");
 
         def tok = readToken(atom_end - pos);
         skipWhitespace();
-        return ParseResult.Success(Sexp.Atom(tok.image));
+        return ParseResult.Success(SExpr.Atom(tok.image));
     }
 
-    def readSexp() -> ParseResult<Sexp> {
+    def readSExpr() -> ParseResult<SExpr> {
         skipWhitespace();
         if (req1('(') == -1) return ParseResult.Expected("(");
         skipWhitespace();
 
-        def elts = Vector<Sexp>.new();
+        def elems = Vector<SExpr>.new();
         while (opt1(')') == -1) {
             skipWhitespace();
-            def res: ParseResult<Sexp> = if(peekRel(0) == '(', readSexp(), readAtom());
+            def res: ParseResult<SExpr> = if(peekRel(0) == '(', readSExpr(), readAtom());
 
             match (res) {
-                Success(elt) => elts.put(elt);
+                Success(elt) => elems.put(elt);
                 _ => return res;
             }
         }
 
         skipWhitespace();
 
-        match (elts.length) {
-            0 => return ParseResult.EmptySexp;
-            1 => return ParseResult.Success(elts[0]);
-            _ => return ParseResult.Success(Sexp.List(elts.copy()));
+        match (elems.length) {
+            0 => return ParseResult.EmptySExpr;
+            1 => return ParseResult.Success(elems[0]);
+            _ => {
+		def ls = Lists.fromArray(elems.copy());
+	        return ParseResult.Success(SExpr.List(ls));
+	    }
         }
     }
 }


### PR DESCRIPTION
I don't remember if you thought this should be added to util, but:


```
    def parser = SexpParser.new(filename, file_bytes);
    def res = parser.readSexp();
    match (res) {
        Success(res) => {
            ...
        }
        err => {
            ...
        }
    }
```