### PR TITLE
Var rep hints / VstPrinter update

### DIFF
--- a/aeneas/src/vst/Parser.v3
+++ b/aeneas/src/vst/Parser.v3
@@ -1429,9 +1429,10 @@ class VarDefParser(isPrivate: bool, writability: Writability) {
 	def parseVars(p: ParserState, id: VstIdent<void>) -> List<VarDecl> {
 		var list: List<VarDecl>;
 		while (true) {
+			var hints = Parser.parseRepHints(p);
 			var tref = if(p.curByte == ':', Parser.parseTypeRef(p.advance1()));
 			var init = if(p.curByte == '=', Parser.parseExpr(p.advance1()));
-			var decl = VarDecl.new(id.name, tref, init);
+			var decl = VarDecl.new(id.name, tref, init).withRepHints(hints);
 			decl.isReadOnly = writability == Writability.READ_ONLY;
 			list = List.new(decl, list);
 			if (p.curByte == ',') {

--- a/aeneas/src/vst/Parser.v3
+++ b/aeneas/src/vst/Parser.v3
@@ -1429,8 +1429,8 @@ class VarDefParser(isPrivate: bool, writability: Writability) {
 	def parseVars(p: ParserState, id: VstIdent<void>) -> List<VarDecl> {
 		var list: List<VarDecl>;
 		while (true) {
-			var hints = Parser.parseRepHints(p);
 			var tref = if(p.curByte == ':', Parser.parseTypeRef(p.advance1()));
+			var hints = Parser.parseRepHints(p);
 			var init = if(p.curByte == '=', Parser.parseExpr(p.advance1()));
 			var decl = VarDecl.new(id.name, tref, init).withRepHints(hints);
 			decl.isReadOnly = writability == Writability.READ_ONLY;

--- a/aeneas/src/vst/Vst.v3
+++ b/aeneas/src/vst/Vst.v3
@@ -446,6 +446,18 @@ type VstRepHint {
 	case Packing(p: VstList<VstPackingExpr>);
 	case BigEndian;
 	case Other(hint: string);
+
+        def render(buf: StringBuilder) -> StringBuilder {
+		match (this) {
+			Boxed => buf.puts("#boxed");
+			Unboxed => buf.puts("#unboxed");
+			Packed => buf.puts("#packed");
+			Packing(p) => buf.puts("#packing(...)");
+			BigEndian => buf.puts("#big-endian");
+			Other(s) => buf.put1("#%s", s);
+		}
+                return buf;
+        }
 }
 
 type VstPackingExpr {

--- a/aeneas/src/vst/Vst.v3
+++ b/aeneas/src/vst/Vst.v3
@@ -591,8 +591,13 @@ class VarDecl extends Decl {
 	var vtype: Type;
 	var isReadOnly: bool;
 	var ssa: VstSsaVar;
+	var repHints: List<VstRepHint>;
 
 	new(name: Token, tref, init) super(name) { }
+	
+	def withRepHints(hints: List<VstRepHint>) -> this {
+	    repHints = hints;
+	}
 }
 // export name = expr
 class ExportDecl extends Decl {

--- a/aeneas/src/vst/VstPrinter.v3
+++ b/aeneas/src/vst/VstPrinter.v3
@@ -411,8 +411,9 @@ class VstPrinter extends VstVisitor<int, void> {
 	}
 	def printVar(vdecl: VarDecl, indent: int) {
 		var buf = StringBuilder.new();
-		if (vdecl.tref != null) buf.put2("\"%s\": %q", vdecl.name(), vdecl.tref.render);
-		else if (vdecl.vtype != null) buf.put2("\"%s\": %q", vdecl.name(), vdecl.vtype.render);
+		buf.puts(vdecl.name());
+		if (vdecl.tref != null) buf.put1(" (type %q)", vdecl.tref.render);
+		else if (vdecl.vtype != null) buf.put1(" (type %q)", vdecl.vtype.render);
                 if (vdecl.repHints != null) buf.put1(" (repHints %q)", Lists.renderSep<VstRepHint>(_, VstRepHint.render, vdecl.repHints, " "));
 		else buf.put1("\"%s\"", vdecl.name());
 		p.enter(buf.toString(), indent);
@@ -423,8 +424,8 @@ class VstPrinter extends VstVisitor<int, void> {
 		var buffer = StringBuilder.new();
 		buffer.puts(name);
 		if (param != null) buffer.put1(" \"%s\"", param);
-		if (exactType != null) buffer.put1(": %q", exactType.render);
-		if (implicitType != null) buffer.put1(" implicitly %q", implicitType.render);
+		if (exactType != null) buffer.put1(" (type %q)", exactType.render);
+		if (implicitType != null) buffer.put1(" (implicitType %q)", implicitType.render);
 		p.enter(buffer.toString(), indent);
 		Lists.apply(list, printExpr(_, indent + 1));
 		p.exit();

--- a/aeneas/src/vst/VstPrinter.v3
+++ b/aeneas/src/vst/VstPrinter.v3
@@ -411,11 +411,10 @@ class VstPrinter extends VstVisitor<int, void> {
 	}
 	def printVar(vdecl: VarDecl, indent: int) {
 		var buf = StringBuilder.new();
-		buf.puts(vdecl.name());
+		buf.put1("\"%s\"", vdecl.name());
 		if (vdecl.tref != null) buf.put1(" (type %q)", vdecl.tref.render);
 		else if (vdecl.vtype != null) buf.put1(" (type %q)", vdecl.vtype.render);
                 if (vdecl.repHints != null) buf.put1(" (repHints %q)", Lists.renderSep<VstRepHint>(_, VstRepHint.render, vdecl.repHints, " "));
-		else buf.put1("\"%s\"", vdecl.name());
 		p.enter(buf.toString(), indent);
 		if (vdecl.init != null) printExpr(vdecl.init, indent + 1);
 		p.exit();

--- a/aeneas/src/vst/VstPrinter.v3
+++ b/aeneas/src/vst/VstPrinter.v3
@@ -123,6 +123,12 @@ class Printer(printer: VstPrinter) {
 			Other(s) => Terminal.put1("#%s", s);
 		}
 	}
+        def printRepHints(repHints: List<VstRepHint>) {
+            for (node = repHints; node != null; node = node.tail) {
+                printRepHint(node.head);
+                Terminal.putc(' ');
+            }
+        }
 	def printToken(t: Token) {
 		Terminal.put1("%s", t.image);
 	}
@@ -407,6 +413,7 @@ class VstPrinter extends VstVisitor<int, void> {
 		var buf = StringBuilder.new();
 		if (vdecl.tref != null) buf.put2("\"%s\": %q", vdecl.name(), vdecl.tref.render);
 		else if (vdecl.vtype != null) buf.put2("\"%s\": %q", vdecl.name(), vdecl.vtype.render);
+                if (vdecl.repHints != null) buf.put1(" (repHints %q)", Lists.renderSep<VstRepHint>(_, VstRepHint.render, vdecl.repHints, " "));
 		else buf.put1("\"%s\"", vdecl.name());
 		p.enter(buf.toString(), indent);
 		if (vdecl.init != null) printExpr(vdecl.init, indent + 1);

--- a/lib/util/List.v3
+++ b/lib/util/List.v3
@@ -106,10 +106,14 @@ component Lists {
 	// Render a comma-separated list into the given StringBuffer.
 	def render<T>(buf: StringBuilder, append: (T, StringBuilder) -> StringBuilder,
 		list: List<T>) -> StringBuilder {
+                return renderSep(buf, append, list, ", ");
+	}
+	def renderSep<T>(buf: StringBuilder, append: (T, StringBuilder) -> StringBuilder,
+		list: List<T>, sep: string) -> StringBuilder {
 		if (list == null) return buf;
 		append(list.head, buf);
 		for (l = list.tail; l != null; l = l.tail) {
-			append(l.head, buf.csp());
+			append(l.head, buf.puts(sep));
 		}
 		return buf;
 	}

--- a/test/core/var_rephint.v3
+++ b/test/core/var_rephint.v3
@@ -1,0 +1,6 @@
+//@execute = 12
+
+def main() -> int {
+    def x: int #somehint #another = 12;
+    return x;
+}


### PR DESCRIPTION
For `var_rephint.v3`, it prints:

```
        (BlockStmt
            (LocalStmt
                ("x": int (repHints #somehint #another)
                    (Literal "12": int)))
            (ReturnStmt
                (VarExpr[Local] "x": int)))
```

I'm going to make all the printing more structured like so:
```
        (BlockStmt
            (LocalStmt
                ("x" (type int) (repHints #somehint #another)
                    (Literal "12" (type int))))
            (ReturnStmt
                (VarExpr[Local] "x" (type int))))
```

I'll also fix the nesting issue we saw with MatchStmt