### PR TITLE
WIP derive to_sexpr method for types

### DIFF
--- a/aeneas/src/vst/Verifier.v3
+++ b/aeneas/src/vst/Verifier.v3
@@ -504,6 +504,32 @@ class VstCompoundVerifier {
 			else decl.memberMap[mdecl.token.image] = mdecl;
 			mdecl.receiver = decl;
 		}
+		if (!decl.memberMap.has("to_sexp") && !VstLayout.?(decl)) {
+			var name = Token.new(decl.token.fileName, "to_sexpr", decl.token.beginLine, decl.token.beginColumn);
+			var superclause = decl.superclause;
+			var sexpr_token = decl.token.copy("SExpr");
+			var sexpr_type_con = decl.typeEnv.lookup("SExpr");
+			if (sexpr_type_con != null) {
+				var sexpr_type_ref = NamedTypeRef.new(null, sexpr_token, null);
+				// var sexpr_type_lit = Literal.new(Token.new(decl.token.fileName, "SExpr", decl.token.beginLine, decl.token.endLine), null, sexpr_type_ref.binding);
+				var sexpr_type_lit = VarExpr.new(null, name.range(), VstIdent.new(sexpr_token, 0, null));
+				var atom_token = decl.token.copy("Atom");
+				var list_token = decl.token.copy("List");
+				var atom_con = VarExpr.new(sexpr_type_lit, name.range(), VstIdent.new(atom_token, 0, null));
+				var list_con = VarExpr.new(sexpr_type_lit, name.range(), VstIdent.new(list_token, 0, null));
+				var str = StringExpr.new(decl.token, decl.name());
+				var args = TupleExpr.new(VstList.new(name.range(), List<Expr>.new(str, null)));
+				var body: VstFunc = VstFunc.new(VstList<ParamDecl>.new(name.range(), null), ReturnType.Explicit(sexpr_type_ref), ReturnStmt.new(name.range(), AppExpr.new(atom_con, args)));
+				var to_sexpr = VstMethod.new(decl.isPrivate, name, null, body);
+				to_sexpr.isSynthetic = true;
+				// to_sexpr.typeEnv = decl.typeEnv;
+				to_sexpr.receiver = decl;
+				decl.members = List.new(to_sexpr, decl.members);
+				decl.memberMap["to_sexpr"] = to_sexpr;
+			}
+		} else {
+			// TODO: typecheck existing to_sexp method
+		}
 		var constructor = decl.constructor;
 		if (constructor == null && !VstLayout.?(decl)) {
 			// fill in a default constructor if one wasn't declared

--- a/aeneas/src/vst/Verifier.v3
+++ b/aeneas/src/vst/Verifier.v3
@@ -504,32 +504,6 @@ class VstCompoundVerifier {
 			else decl.memberMap[mdecl.token.image] = mdecl;
 			mdecl.receiver = decl;
 		}
-		if (!decl.memberMap.has("to_sexp") && !VstLayout.?(decl)) {
-			var name = Token.new(decl.token.fileName, "to_sexpr", decl.token.beginLine, decl.token.beginColumn);
-			var superclause = decl.superclause;
-			var sexpr_token = decl.token.copy("SExpr");
-			var sexpr_type_con = decl.typeEnv.lookup("SExpr");
-			if (sexpr_type_con != null) {
-				var sexpr_type_ref = NamedTypeRef.new(null, sexpr_token, null);
-				// var sexpr_type_lit = Literal.new(Token.new(decl.token.fileName, "SExpr", decl.token.beginLine, decl.token.endLine), null, sexpr_type_ref.binding);
-				var sexpr_type_lit = VarExpr.new(null, name.range(), VstIdent.new(sexpr_token, 0, null));
-				var atom_token = decl.token.copy("Atom");
-				var list_token = decl.token.copy("List");
-				var atom_con = VarExpr.new(sexpr_type_lit, name.range(), VstIdent.new(atom_token, 0, null));
-				var list_con = VarExpr.new(sexpr_type_lit, name.range(), VstIdent.new(list_token, 0, null));
-				var str = StringExpr.new(decl.token, decl.name());
-				var args = TupleExpr.new(VstList.new(name.range(), List<Expr>.new(str, null)));
-				var body: VstFunc = VstFunc.new(VstList<ParamDecl>.new(name.range(), null), ReturnType.Explicit(sexpr_type_ref), ReturnStmt.new(name.range(), AppExpr.new(atom_con, args)));
-				var to_sexpr = VstMethod.new(decl.isPrivate, name, null, body);
-				to_sexpr.isSynthetic = true;
-				// to_sexpr.typeEnv = decl.typeEnv;
-				to_sexpr.receiver = decl;
-				decl.members = List.new(to_sexpr, decl.members);
-				decl.memberMap["to_sexpr"] = to_sexpr;
-			}
-		} else {
-			// TODO: typecheck existing to_sexp method
-		}
 		var constructor = decl.constructor;
 		if (constructor == null && !VstLayout.?(decl)) {
 			// fill in a default constructor if one wasn't declared
@@ -580,6 +554,58 @@ class VstCompoundVerifier {
 		}
 		if (compound.constructor != null) {
 			compound.constructor.memberinits = Lists.reverse(memberinits);
+		}
+		if (!compound.memberMap.has("to_sexp") && classType != null) {
+			var name = Token.new(compound.token.fileName, "to_sexpr", compound.token.beginLine, compound.token.beginColumn);
+			var superclause = compound.superclause;
+			var sexpr_token = compound.token.copy("SExpr");
+			var sexpr_type_con = compound.typeEnv.lookup("SExpr");
+			var null_token = compound.token.copy("null");
+			var null_literal = Literal.new(null_token, Values.BOTTOM, Null.TYPE);
+			if (sexpr_type_con != null) {
+				var sexpr_type_ref = NamedTypeRef.new(null, sexpr_token, null);
+				var member_code = StringBuilder.new().putc('[');
+				var printedFirst = false;
+				for (list = compound.members; list != null; list = list.tail) if (VstField.?(list.head)) {
+					var mem = VstField.!(list.head);
+					// if (mem.synthetic) continue;
+					if (printedFirst) member_code.putc(',');
+					printedFirst = true;
+
+					var member_body_sexp: string;
+					match (mem.getType()) {
+						ct: ClassType => {
+							if (ct.typeCon.kind == Kind.CLASS)
+								member_body_sexp = Strings.format2("if(this.%s != null, this.%s.to_sexpr(), SExpr.Atom(\"null\"))", mem.name(), mem.name());
+							else 
+								member_body_sexp = Strings.format1("this.%s.to_sexpr()", mem.name());
+						}
+						it: IntType => member_body_sexp = Strings.format1("SExpr.Atom(Strings.format1(\"%%d\", this.%s))", mem.name());
+						_ => {
+							def  t = mem.getType();
+							if (t != null) member_body_sexp = Strings.format1("SExpr.Atom(\"%s\")", t.render(StringBuilder.new()).toString());
+							else member_body_sexp = "SExpr.Atom(\"nulltype\")";
+						}
+					}
+					member_code.put2("SExpr.List(Lists.cons2<SExpr>(SExpr.Atom(\"%s\"), %s))", mem.name(), member_body_sexp);
+				}
+				member_code.putc(']');
+				def final_member_code = member_code.toString();
+				var code = StringBuilder.new().put2("SExpr.List(List.new(SExpr.Atom(\"%s\"), Lists.fromArray<SExpr>(%s)))", compound.name(), final_member_code);
+				var mock_file = VstFile.new(compound.token.fileName, code.toString());
+				var p = ParserState.new(mock_file, null, Parser.skipToNextToken, null);
+				var exp = Parser.parseExpr(p);
+				var body: VstFunc = VstFunc.new(VstList<ParamDecl>.new(name.range(), null), ReturnType.Explicit(sexpr_type_ref), ReturnStmt.new(name.range(), exp));
+				var to_sexpr = VstMethod.new(compound.isPrivate, name, null, body);
+				to_sexpr.isSynthetic = true;
+				// to_sexpr.typeEnv = compound.typeEnv;
+				to_sexpr.receiver = compound;
+				compound.members = List.new(to_sexpr, compound.members);
+				compound.memberMap["to_sexpr"] = to_sexpr;
+				checkMethod(to_sexpr);
+			}
+		} else {
+			// TODO: typecheck existing to_sexp method
 		}
 		verified = true;
 		if (classType != null) {

--- a/lib/util/Sexpr.v3
+++ b/lib/util/Sexpr.v3
@@ -2,21 +2,26 @@ type SExpr {
     case Atom(data: string);
     case List(elems: List<SExpr>); // usually Cons
 
-    def buildString(buf: StringBuilder) {
+    def toString() -> string {
+        return this.render(StringBuilder.new()).toString();
+    }
+
+    def render(buf: StringBuilder) -> StringBuilder {
         match (this) {
             Atom(data) => buf.puts(data);
             List(elems) => {
                 buf.putc('(');
-		var elem = elems;
-		while (elem.tail != null) {
-                    elem.head.buildString(buf);
+                var elem = elems;
+                while (elem.tail != null) {
+                    elem.head.render(buf);
                     buf.sp();
-		    elem = elem.tail;
-		}
-                elem.head.buildString(buf);
+                    elem = elem.tail;
+                }
+                elem.head.render(buf);
                 buf.putc(')');
             }
         }
+        return buf;
     }
 
     def forceAtom() -> string {

--- a/lib/util/Sexpr.v3
+++ b/lib/util/Sexpr.v3
@@ -98,9 +98,9 @@ class SExprParser extends TextReader {
             0 => return ParseResult.EmptySExpr;
             1 => return ParseResult.Success(elems[0]);
             _ => {
-		def ls = Lists.fromArray(elems.copy());
+                def ls = Lists.fromArray(elems.copy());
 	        return ParseResult.Success(SExpr.List(ls));
-	    }
+            }
         }
     }
 }

--- a/test_sexpr.v3
+++ b/test_sexpr.v3
@@ -1,0 +1,29 @@
+type TestType {
+    case Test;
+}
+
+class TestClass {
+    def x: int;
+    var y: string;
+    var z: TestClass;
+}
+
+class Point(x: int, y: int) {}
+
+def main() {
+    def x = TestClass.new();
+    System.puts(x.to_sexpr().toString());
+    System.ln();
+    x.z = TestClass.new();
+    x.z.y = "hello";
+    System.puts(x.to_sexpr().toString());
+    System.ln();
+
+    def p = Point.new(5, 10);
+    System.puts(p.to_sexpr().toString());
+    System.ln();
+
+    def ls = Lists.cons3(5, 10, 15);
+    System.puts(ls.to_sexpr().toString());
+    System.ln();
+}


### PR DESCRIPTION
I want this mostly for easier print debugging

```scala
class TestClass {
    def x: int;
    var y: string;
    var z: TestClass;
}

class Point(x: int, y: int) {}

def main() {
    def x = TestClass.new();
    System.puts(x.to_sexpr().toString());
    System.ln();
    x.z = TestClass.new();
    x.z.y = "hello";
    System.puts(x.to_sexpr().toString());
    System.ln();

    def p = Point.new(5, 10);
    System.puts(p.to_sexpr().toString());
    System.ln();

    def ls = Lists.cons3(5, 10, 15);
    System.puts(ls.to_sexpr().toString());
    System.ln();
}
```
```
(TestClass (x 0) (y Array<byte>) (z null))
(TestClass (x 0) (y Array<byte>) (z (TestClass (x 0) (y Array<byte>) (z null))))
(Point (x 5) (y 10))
(List (head T) (tail (List (head T) (tail (List (head T) (tail null))))))
```

The main issues are:
- it doesn't support generics, because it doesn't know if a typevar will have `.to_sexpr()`. I guess this could be fixed by generating a `has_sexpr() -> bool` or preferably by generating a different `to_sexpr` per typevar instantiation
- it doesn't print strings, because I don't think it can distinguish between strings and byte arrays