### PR TITLE
These calls are used in Wizard versions under development

### DIFF
--- a/rt/x86-64-linux/System.v3
+++ b/rt/x86-64-linux/System.v3
@@ -22,6 +22,11 @@ component System {
 	// the method that can print a stack trace
 	var printStack: (Pointer, Pointer) -> void;
 
+	// get the current process's pid
+	def getpid() -> int {
+		return int.view(Linux.syscall(LinuxConst.SYS_getpid, ()).0);
+	}
+
 	// change the permissions of a file
 	def chmod(fileName: string, mode: int) {
 		Linux.syscall(LinuxConst.SYS_chmod, (pathName(fileName), mode));
@@ -29,6 +34,12 @@ component System {
 	// open a file
 	def fileOpen(fileName: string, read: bool) -> int {
 		var mode = if(read, LinuxConst.O_RDONLY, LinuxConst.O_WRONLY | LinuxConst.O_TRUNC | LinuxConst.O_CREAT);
+		var fd = Linux.syscall(LinuxConst.SYS_open, (pathName(fileName), mode, 420)).0;
+		return if(fd >= 0, int.view(fd), -1);
+	}
+	// open a file to append
+	def fileAppend(fileName: string) -> int {
+		var mode = LinuxConst.O_WRONLY | LinuxConst.O_CREAT | LinuxConst.O_APPEND;
 		var fd = Linux.syscall(LinuxConst.SYS_open, (pathName(fileName), mode, 420)).0;
 		return if(fd >= 0, int.view(fd), -1);
 	}


### PR DESCRIPTION
Add getpid and open a file for append.  Our lab's version of Wizard needs them, and perhaps they were on a trajectory for addition anyway.