### PR TITLE
WIP: Basic algorithm for printing floats with %f

### DIFF
--- a/lib/util/Floats.v3
+++ b/lib/util/Floats.v3
@@ -1,0 +1,220 @@
+// Credit to the ryu algorithm: https://dl.acm.org/doi/pdf/10.1145/3192366.3192369
+
+component Floats {
+	private def FLOAT_EXP_WIDTH: byte = 8;
+	private def FLOAT_SIGN_WIDTH: byte = 1;
+	private def FLOAT_MANTISSA_BITS: byte = 23;
+	private def FLOAT_BIAS: byte = 127;
+
+	private def DEBUG: bool = true;
+
+    def renderFloat(val: float, a: Array<byte>, pos: int) -> int {
+		var length: int = 0;
+        if (u32.view(val) >> byte.!(FLOAT_MANTISSA_BITS + FLOAT_EXP_WIDTH) == 1u) {
+			a[pos++] = '-';
+			return 1 + renderPosFloat(val, a, pos);
+		}
+		return renderPosFloat(val, a, pos);
+    }
+	
+
+	def renderPosFloat(val: float, a: Array<byte>, pos: int) -> int {
+		var bits = u32.view(val);
+		var exponent: u32 = (bits >> FLOAT_MANTISSA_BITS) & ((1u << FLOAT_EXP_WIDTH) - 1);
+		var mantissa: u32 = bits & ((1u << FLOAT_MANTISSA_BITS) - 1);
+
+		if (DEBUG)
+			System.puts(Strings.format2("Exponent: %d | Mantissa: %d \n", exponent, mantissa));
+
+		if (exponent == u32.view(0b11111111) || (exponent == 0 && mantissa == 0)) {
+			return renderFloatSpecial(exponent, mantissa, a, pos);
+		}
+
+		return renderPosFloatNaive(exponent, mantissa, a, pos);
+	}
+
+
+	def renderFloatSpecial(exponent: u32, mantissa: u32, a: Array<byte>, pos: int) -> int {
+		if (mantissa != 0) {
+			a[pos++] = 'N';
+			a[pos++] = 'a';
+			a[pos] = 'N';
+			return 3;
+		}
+		if (exponent != 0) {
+			a[pos++] = 'I';
+			a[pos++] = 'n';
+			a[pos++] = 'f';
+			a[pos++] = 'i';
+			a[pos++] = 'n';
+			a[pos++] = 'i';
+			a[pos++] = 't';
+			a[pos] = 'y';
+			return 8;
+		}
+		a[pos] = '0';
+		return 1;
+	}
+
+	def renderPosFloatNaive(exponent: u32, mantissa: u32, arr: Array<byte>, pos: int) -> int {
+		// Step 1: Decode
+		var e_f: int;
+		var m_f: u32;
+
+		if (exponent == 0) {
+			m_f = mantissa;
+			e_f = int.!(1 - FLOAT_BIAS - FLOAT_MANTISSA_BITS);
+		}
+		else {
+			m_f = (1u << FLOAT_MANTISSA_BITS) + mantissa;
+			e_f = int.!(exponent) - FLOAT_BIAS - FLOAT_MANTISSA_BITS;
+		}
+
+		if (DEBUG)
+			System.puts(Strings.format2("m_f & e_f: %d * 2^%d \n", m_f, e_f));
+
+		var e_2: int = e_f - 2;
+
+		// Step 2: Determine interval of information preserving outputs
+		var v: u32 = 4u * m_f;
+		var w: u32 = 4u * m_f + 2u;
+		var u: u32 = 4u * m_f;
+		if (mantissa == 0 && exponent > 1)
+			u -= 1u;
+		else
+			u -= 2u;
+		
+		// Step 3: Convert (u,v,w) * 2^(e_2) to a decimal power base.
+
+		var e_10: int;
+        var a: u64;
+        var b: u64;
+        var c: u64;
+
+        if (e_2 >= 0) {
+            e_10 = 0;
+            var exp: u64 = u64.!(1) << byte.!(e_2);
+            a = u64.!(u) * exp;
+            b = u64.!(v) * exp;
+            c = u64.!(w) * exp;
+        }
+        else {
+            e_10 = e_2;
+            var exp: u64 = pow5(u32.!(-e_2));
+            a = u64.!(u) * exp;
+            b = u64.!(v) * exp;
+            c = u64.!(w) * exp;
+        }
+
+        System.puts(Strings.format2("v: %d, e_2: %d \n", v, e_2));
+        System.puts(Strings.format2("b: %d, e_10: %d \n", b, e_10));
+
+		var acceptLarger: bool = mantissa % 2 == 0;
+		var acceptSmaller: bool = acceptLarger;
+
+		var t = computeShortest(a, b, c, acceptSmaller, acceptLarger);
+		System.puts(Strings.format2("d_0: %d, e_0: %d \n", t.0, t.1));
+
+		return renderFloatingDecimal(t.0, t.1 + e_10, arr, pos);
+	}
+
+	// O(n) naive operation
+	def pow5(n: u32) -> u64 {
+		var result: u64 = 1;
+		for (i = 0; i < n; i++)
+			result = (result << 2) + result;
+		return result;
+	}
+
+	def computeShortest(a: u64, b: u64, c: u64, acceptSmaller: bool, acceptLarger: bool) -> (u64, int) {
+		var i: int = 0;
+		if (!acceptLarger)
+			c -= 1;
+		var all_a_zero: bool = true;
+		var all_b_zero: bool = true;
+		var digit: u64 = 0;
+
+		
+		while (a / 10 < c / 10) {
+			all_a_zero = all_a_zero && (a % 10 == 0);
+			a = a / 10;
+			c = c / 10;
+
+			digit = b % 10;
+			all_b_zero = all_b_zero && digit == 0;
+			b = b / 10;
+
+			i += 1;
+		}
+		if (acceptSmaller && all_a_zero) {
+			while (a % 10 == 0) {
+				a = a / 10;
+				c = c / 10;
+				i += 1;
+
+				digit = b % 10;
+				all_b_zero = all_b_zero && digit == 0;
+				b = b / 10;
+			}
+		}
+
+		var break_tie_down = (b % 2 == 0);
+		var is_tie: bool = (digit == 5) && all_b_zero;
+		var want_round_down: bool = (digit < 5) || (is_tie && break_tie_down);
+		var round_down: bool = (want_round_down && (a != b || all_a_zero)) || (b + 1 > c);
+
+		if (round_down)
+			return (b, i);
+		return (b + 1, i);
+	}
+
+	def renderFloatingDecimal(d: u64, e: int, a: Array<byte>, pos: int) -> int {
+		var digitWidth: int = 1;
+		var t = getLastPosDecimalDigit(d);
+		while (t.0 != 0) {
+			t = getLastPosDecimalDigit(t.0);
+			digitWidth += 1;
+		}
+		var length: int = 0;
+		var isZeroPointX: bool = false;
+		if (e >= 0) {
+			length = digitWidth + e;
+		} else {
+			length = digitWidth + 1; // add the decimal point
+			if (digitWidth + e < 0) {
+				isZeroPointX = true;
+				length += 1 + -(digitWidth + e);
+			}
+		}
+
+		pos += length - 1; // start from to right, move to left
+
+		// render trailing zeros
+		for (i = 0; i < e; i++)
+			a[pos--] = '0';
+		
+		var n: u64 = d;
+		for (i = 0; i < digitWidth; i++) {
+			var t = getLastPosDecimalDigit(n);
+			a[pos--] = byte.!(t.1 + '0');
+			n = t.0;
+		}
+
+		// render leading zeros after decimal point
+		for (i = digitWidth + e; i < 0; i++)
+			a[pos--] = '0';
+		
+		// render 0.
+		if (isZeroPointX) {
+			a[pos--] = '.';
+			a[pos--] = '0';
+		}
+
+		return length;
+	}
+
+	def getLastPosDecimalDigit(d: u64) -> (u64, int) {
+		return (d / 10, int.view(d) % 10);
+	}
+}
+

--- a/lib/util/StringBuilder.v3
+++ b/lib/util/StringBuilder.v3
@@ -351,6 +351,11 @@ class StringBuilder {
 		return (-1, offset);
 	}
 
+	def putf(f: float) -> this {
+		acquire(16);
+		length += Floats.renderFloat(f, buf, length);
+	}
+
 }
 def cast<F, T>(p: F) -> T {
 	return T.!(p);

--- a/test/lib/StringBuilderTest.v3
+++ b/test/lib/StringBuilderTest.v3
@@ -10,6 +10,7 @@ def X = [
 	T("putd", test_putd),
 	T("putx", test_putx),
 	T("putc", test_putc),
+	T("putf", test_putf),
 	T("put1", test_put1),
 	T("put2", test_put2),
 	T("put3", test_put3),
@@ -235,6 +236,19 @@ def test_putc(t: LibTest) {
 	ok('\r', "\r");
 	ok('\n', "\n");
 	ok('\\', "\\");
+}
+
+def test_putf(t: LibTest) {
+	def ok = assertOk(t, StringBuilder.putf, _, _);
+	ok(float.view(0x7fc00000), "NaN");
+	ok(float.view(0xffc00000), "-NaN");
+	ok(float.view(0x7f800000), "Infinity");
+	ok(float.view(0xff800000), "-Infinity");
+	ok(float.view(0x449a4000), "1234");
+	ok(float.view(0xc5870800), "-4321");
+	ok(float.view(0x4b6b9498), "15439000");
+	ok(float.view(0x3dfbe76d), "0.123");
+	// ok(float.view(0x40B570A4), "5.67");
 }
 
 def p1<T>(t: LibTest, fmt: string, arg: T, expected: string) {


### PR DESCRIPTION
[Issue #74](#74)
This is as WIP pull request that aims to enable string formatting of strings. I implemented the "basic conversion algorithm" outlined in the [Ryu paper](https://dl.acm.org/doi/pdf/10.1145/3192366.3192369). A future port to Ryu, the improved algorithm, can be planned in the future once the existing code is stable

The major additions are:
- Created [lib/util/Floats.v3](lib/util/Floats.v3) for core floating rendering code
- Modified [test/lib/StringBuilderTest.v3](test/lib/StringBuilderTest.v3) for %f tests