### PR TITLE
explicit simple fun body ret type

### DIFF
--- a/aeneas/src/vst/Parser.v3
+++ b/aeneas/src/vst/Parser.v3
@@ -513,7 +513,13 @@ component Parser {
 			var str = "this", pt = Parser.optKeyword(p, str);
 			if (pt != null) rettype = ReturnType.This(Token.new(p.fileName, str, loc.0, loc.1));
 			else rettype = ReturnType.Explicit(Parser.parseTypeRef(p));
-			body = if(p.curByte == ';', EmptyStmt.new(p.token(1)), Parser.parseBlockStmt(p));
+			if (Debug.UNSTABLE && p.enableSimpleBodies && (start = p.optN("=>")) >= 0) {
+				var expr = parseExpr(p);
+				if (isDef) p.req1(';');
+				body = ReturnStmt.new(p.tokenAt(start, start + 2).range(), expr); // XXX: rangeAt() ?
+			} else {
+				body = if(p.curByte == ';', EmptyStmt.new(p.token(1)), Parser.parseBlockStmt(p));
+			}
 		} else if (Debug.UNSTABLE && p.enableSimpleBodies && (start = p.optN("=>")) >= 0) {
 			var expr = parseExpr(p);
 			rettype = ReturnType.Implicit(expr);

--- a/test/funexpr/parser/fun_ret_explicit01.v3
+++ b/test/funexpr/parser/fun_ret_explicit01.v3
@@ -1,0 +1,6 @@
+//@parse
+def test1 = fun (x: int) -> int => x + 1;
+def test2 = fun (a: int, b: int) -> bool => a > b;
+def test3 = fun (x: string) -> string => x;
+def test4 = fun (arr: Array<int>) -> Array<int> => arr;
+def test5 = fun () -> void => ();

--- a/test/funexpr/parser/simple_body13.v3
+++ b/test/funexpr/parser/simple_body13.v3
@@ -1,0 +1,8 @@
+//@parse
+def m1() -> int => 0;
+def m2() -> int => 0 + 0;
+def m3() -> int => m1();
+def m4() void -> int => m2;
+def m5() int => if(false, 1, 1);
+def m6() -> (int, int) => (88, 99);
+def m7() -> Array<int> => [99, 100];

--- a/test/funexpr/parser/simple_body13.v3
+++ b/test/funexpr/parser/simple_body13.v3
@@ -2,7 +2,7 @@
 def m1() -> int => 0;
 def m2() -> int => 0 + 0;
 def m3() -> int => m1();
-def m4() void -> int => m2;
-def m5() int => if(false, 1, 1);
+def m4() -> (void -> int) => m2;
+def m5() -> int => if(false, 1, 1);
 def m6() -> (int, int) => (88, 99);
 def m7() -> Array<int> => [99, 100];

--- a/test/funexpr/parser/simple_body14.v3
+++ b/test/funexpr/parser/simple_body14.v3
@@ -1,0 +1,5 @@
+//@parse
+def m1(p: int) -> int => 0;
+def m2(p: (int, int), q: bool) -> int => 0;
+def m3(p: (int, int) -> int) -> int => 0;
+def m4(p: Array<int>) -> int => 0;

--- a/test/funexpr/parser/simple_body15.v3
+++ b/test/funexpr/parser/simple_body15.v3
@@ -1,0 +1,4 @@
+//@parse = ParseError @ 3:28
+class C {
+	def m1(p: int) -> int => 0
+}

--- a/test/funexpr/parser/simple_body16.v3
+++ b/test/funexpr/parser/simple_body16.v3
@@ -1,0 +1,4 @@
+//@parse = ParseError @ 3:28
+component C {
+	def m1(p: int) -> int => 0
+}

--- a/test/funexpr/parser/simple_body17.v3
+++ b/test/funexpr/parser/simple_body17.v3
@@ -1,0 +1,4 @@
+//@parse
+class X {
+	private def m() -> int => 0;
+}

--- a/test/funexpr/parser/simple_body18.v3
+++ b/test/funexpr/parser/simple_body18.v3
@@ -1,0 +1,4 @@
+//@parse
+component X {
+	private def m() -> int => 0;
+}

--- a/test/funexpr/parser/simple_body19.v3
+++ b/test/funexpr/parser/simple_body19.v3
@@ -1,0 +1,2 @@
+//@parse = ParseError @ 2:10
+def var m() -> int => 0;

--- a/test/funexpr/parser/simple_body20.v3
+++ b/test/funexpr/parser/simple_body20.v3
@@ -1,0 +1,6 @@
+//@parse
+def m1() -> int => 0;
+def m2() -> bool => true;
+def m3() -> (int, bool) => (42, false);
+def m4() -> Array<int> => [1, 2, 3];
+def m5() -> void => ();

--- a/test/funexpr/parser/simple_body21.v3
+++ b/test/funexpr/parser/simple_body21.v3
@@ -1,0 +1,5 @@
+//@parse
+def m1(x: int) -> int => x + 1;
+def m2(x: bool, y: int) -> bool => x && (y > 0);
+def m3<T>(x: T) -> T => x;
+def m4<T, U>(x: T, f: T -> U) -> U => f(x);

--- a/test/funexpr/parser/simple_body22.v3
+++ b/test/funexpr/parser/simple_body22.v3
@@ -1,0 +1,5 @@
+//@parse
+def identity<T>(x: T) -> T => x;
+def first<A, B>(a: A, b: B) -> A => a;
+def compose<X, Y, Z>(f: X -> Y, g: Y -> Z) -> (X -> Z) => fun (x: X) => g(f(x));
+def curry<A, B, C>(f: (A, B) -> C) -> (A -> (B -> C)) => fun (a: A) => fun (b: B) => f(a, b);

--- a/test/funexpr/seman/fun_ret_explicit01.v3
+++ b/test/funexpr/seman/fun_ret_explicit01.v3
@@ -1,0 +1,10 @@
+//@execute 0=6; 1=1; 2=42
+def add = fun (x: int, y: int) -> int => x + y;
+def isPositive = fun (x: int) -> bool => x > 0;
+def getFirst = fun (arr: Array<int>) -> int => arr[0];
+
+def main(a: int) -> int {
+    if (a == 0) return add(2, 4);
+    if (a == 1) return if(isPositive(5), 1, 0);
+    return getFirst([42, 99]);
+}

--- a/test/funexpr/seman/simple_body16.v3
+++ b/test/funexpr/seman/simple_body16.v3
@@ -1,0 +1,3 @@
+//@seman
+def add(x: int, y: int) -> int => x + y;
+def test: int = add(5, 7);

--- a/test/funexpr/seman/simple_body17.v3
+++ b/test/funexpr/seman/simple_body17.v3
@@ -1,0 +1,4 @@
+//@seman
+def getFirst<T>(arr: Array<T>) -> T => arr[0];
+def testInt: int = getFirst([1, 2, 3]);
+def testBool: bool = getFirst([true, false]);

--- a/test/funexpr/seman/simple_body18.v3
+++ b/test/funexpr/seman/simple_body18.v3
@@ -1,0 +1,3 @@
+//@seman = TypeError @ 2:37
+def wrongType(x: int) -> bool => x + 1;
+def test = wrongType(5);

--- a/test/funexpr/seman/simple_body19.v3
+++ b/test/funexpr/seman/simple_body19.v3
@@ -1,0 +1,15 @@
+//@execute 0=42; 1=42; 2=12
+def identity<T>(x: T) -> T => x;
+def multiply(a: int, b: int) -> int => a * b;
+def compose<A, B, C>(f: A -> B, g: B -> C) -> (A -> C) => fun (x: A) => g(f(x));
+def inc = fun (x: int) -> int => x + 1;
+def double = fun (x: int) -> int => x * 2;
+def incDouble = compose(inc, double);
+def test1: int = identity(42);
+def test2: int = multiply(6, 7);
+def test3: int = incDouble(5);
+def main(a: int) -> int {
+    if (a == 0) return test1;
+    if (a == 1) return test2;
+    return test3;
+}

--- a/test/funexpr/seman/simple_body20.v3
+++ b/test/funexpr/seman/simple_body20.v3
@@ -1,0 +1,7 @@
+//@seman
+def getTuple() -> (int, bool, string) => (42, true, "hello");
+def getArray() -> Array<int> => [1, 2, 3, 4];
+def getVoid() -> void => ();
+def testTuple = getTuple();
+def testArray = getArray();
+def testVoid = getVoid();

--- a/test/funexpr/seman/simple_body21.v3
+++ b/test/funexpr/seman/simple_body21.v3
@@ -1,0 +1,9 @@
+//@seman
+class TestClass<T> {
+    def getValue(x: T) -> T => x;
+    def transform<U>(x: T, f: T -> U) -> U => f(x);
+}
+def obj = TestClass<int>.new();
+def test1: int = obj.getValue(100);
+def toString(x: int) -> string => "converted";
+def test2: string = obj.transform(42, toString);

--- a/test/funexpr/seman/simple_body22.v3
+++ b/test/funexpr/seman/simple_body22.v3
@@ -1,0 +1,3 @@
+//@seman = TypeError @ 2:38
+def mismatchedReturn() -> Array<string> => [1, 2, 3];
+def test = mismatchedReturn();

--- a/test/funexpr/seman/simple_body23.v3
+++ b/test/funexpr/seman/simple_body23.v3
@@ -1,0 +1,3 @@
+//@seman
+def recursive<T>(x: T, count: int) -> T => if (count <= 0, x, recursive(x, count - 1));
+def testRecursive: int = recursive(42, 3);


### PR DESCRIPTION
Adds support for explicitly typing the return in simple fn bodies:
```scala
def pop_i32() => stack.pop().unbox_i32();
def pop_i32() -> TypeVar.I32 => stack.pop().unbox_i32();
```
It's a bit ugly but I'd like it for CBD stuff where there are a lot of simple functions where the types can be a bit confusing without annotations.

It can also help when inference is too precise, this is a contrived example but I ran into it before somewhere I can't remember:
```scala
type SomeADT {
	case X;
	case Y;
}

def foo() => SomeADT.X; // foo inferred as void -> SomeADT.X
// def foo() -> SomeADT => SomeADT.X; // would typecheck properly

def main() {
	var a = foo();
	System.puts(if(a == SomeADT.X, "x", "y"));
	System.ln();
	a = SomeADT.Y; // type error
	System.puts(if(a == SomeADT.Y, "y", "x"));
	System.ln();
}
```

It might look cleaner with a colon
```scala
def pop_i32(): TypeVar.I32 => stack.pop().unbox_i32();
```

It would also be nice to have this for funexprs.