### PR TITLE
method rephints

### DIFF
--- a/aeneas/src/vst/Parser.v3
+++ b/aeneas/src/vst/Parser.v3
@@ -506,13 +506,14 @@ component Parser {
 		var token = Token.new(p.fileName, "new", start.beginLine, start.beginColumn);
 		return VstNew.new(isPrivate, token, params, superclause, body);
 	}
-	def parseReturnTypeAndBody(p: ParserState, isDef: bool) -> (ReturnType, Stmt) {
-		var rettype: ReturnType, body: Stmt, start: int;
+	def parseReturnTypeAndBody(p: ParserState, isDef: bool) -> (ReturnType, Stmt, List<VstRepHint>) {
+		var rettype: ReturnType, body: Stmt, start: int, rephints: List<VstRepHint>;
 		if (p.optN("->") >= 0) {
 			var loc = (p.curLine, p.curCol);
 			var str = "this", pt = Parser.optKeyword(p, str);
 			if (pt != null) rettype = ReturnType.This(Token.new(p.fileName, str, loc.0, loc.1));
 			else rettype = ReturnType.Explicit(Parser.parseTypeRef(p));
+			rephints = Parser.parseRepHints(p);
 			if (Debug.UNSTABLE && p.enableSimpleBodies && (start = p.optN("=>")) >= 0) {
 				var expr = parseExpr(p);
 				if (isDef) p.req1(';');
@@ -526,10 +527,11 @@ component Parser {
 			if (isDef) p.req1(';');
 			body = ReturnStmt.new(p.tokenAt(start, start + 2).range(), expr); // XXX: rangeAt() ?
 		} else {
+			rephints = Parser.parseRepHints(p);
 			rettype = ReturnType.Void;
 			body = if(p.curByte == ';', EmptyStmt.new(p.token(1)), Parser.parseBlockStmt(p));
 		}
-		return (rettype, body);
+		return (rettype, body, rephints);
 	}
 	def parseOptionalParams(p: ParserState, func: ParserState -> ParamDecl) -> VstList<ParamDecl> {
 		return if(p.curByte == '(', Parser.parseList(0, p, '(', Parser.COMMA, ')', func));
@@ -1478,6 +1480,7 @@ class VarDefParser(isPrivate: bool, writability: Writability) {
 			var params = Parser.parseTypedMethodParams(p);
 			var t = Parser.parseReturnTypeAndBody(p, true);
 			var m = VstMethod.new(isPrivate, id.name, id.list(), VstFunc.new(params, t.0, t.1));
+			m.repHints = t.2;
 			m.importName = importName;
 			return List.new(m, prev);
 		}

--- a/aeneas/src/vst/VstPrinter.v3
+++ b/aeneas/src/vst/VstPrinter.v3
@@ -53,6 +53,12 @@ class Printer(printer: VstPrinter) {
 				printTypeRef(tref);
 			}
 		}
+		if (mdecl.repHints != null) {
+			Terminal.sp();
+			Terminal.put("(");
+			printCommaList<VstRepHint>(mdecl.repHints, printRepHint);
+			Terminal.put(")");
+		}
 		printer.printVstMethod(mdecl);
 	}
 	def printNew(cdecl: VstNew) {

--- a/test/core/parser/rephint10.v3
+++ b/test/core/parser/rephint10.v3
@@ -1,3 +1,3 @@
-//@parse = ParseError @ 2:9
+//@parse
 def m() #rephint {
 }


### PR DESCRIPTION
This is pretty straightforward but `test/variants/parser/unboxed16.v3` now passes:

```
//@parse = ParseError @ 3:9
type X {
	def m() #unboxed { }
}
```

I'm not sure if this should be a parse error now? Or maybe a warning somewhere else?