### PR TITLE
Implement wfts (wrapped function type subsumption)

### DIFF
--- a/aeneas/src/core/Eval.v3
+++ b/aeneas/src/core/Eval.v3
@@ -39,9 +39,13 @@ component Eval {
 			CLASS_CAST, VARIANT_CAST => {
 				if (val == null) return ok;
 				if (tt.open()) return throw;
-				if (!Record.?(val) || !TypeSystem.isSubtype(Record.!(val).rtype, tt))
-					return throw;
-				return ok;
+				if (Record.?(val) && TypeSystem.isSubtype(Record.!(val).rtype, tt))
+					return ok;
+				if (Address<Record>.?(val)) {
+					var rval = Address<Record>.!(val).val;
+					if (TypeSystem.isSubtype(rval.rtype, tt)) return ok;
+				}
+				return throw;
 			}
 			INT_VIEW_I => {
 				return (true, doIntView(IntType.!(ft), IntType.!(tt), val));
@@ -303,7 +307,10 @@ def evalOp(op: Operator, args: Arguments) -> Result {
 		BoolOr => return Bool.box(args.z(0) || args.z(1));
 		BoolNot => return Bool.box(!args.z(0));
 //----------------------------------------------------------------------------
-		OverloadedEq, IntEq, VariantEq, RefEq => return Bool.box(Values.equal(args.vals[0], args.vals[1]));
+		OverloadedEq, IntEq, VariantEq, RefEq => {
+			var v0 = args.vals[0], v1 = args.vals[1];
+			return Bool.box(Values.equal(v0, v1));
+		}
 //----------------------------------------------------------------------------
 		DefaultValue => return args.getProgram().getDefaultValue(args.getTypeArg(0));
 //----------------------------------------------------------------------------
@@ -794,7 +801,8 @@ def evalOp(op: Operator, args: Arguments) -> Result {
 		}
 //----------------------------------------------------------------------------
 		TypeCast(cast) => {
-			var val = args.vals[0], r = Eval.doCast(cast, args.getTypeArg(0), args.getTypeArg(1), val);
+			var val = args.vals[0];
+			var r = Eval.doCast(cast, args.getTypeArg(0), args.getTypeArg(1), val);
 			if (r.0) return r.1;
 			return args.throw(V3Exception.TypeCheck, null);
 		}
@@ -804,7 +812,8 @@ def evalOp(op: Operator, args: Arguments) -> Result {
 		}
 		TypeSubsume => {
 			// XXX: factor out nop subsumes from non-throwing conversions
-			var val = args.vals[0], r = Eval.doCast0(args.getTypeArg(0), args.getTypeArg(1), val);
+			var val = args.vals[0];
+			var r = Eval.doCast0(args.getTypeArg(0), args.getTypeArg(1), val);
 			if (r.0) return r.1;
 			return args.throw(V3Exception.InternalError, "subsume should never fail");
 		}

--- a/aeneas/src/core/Program.v3
+++ b/aeneas/src/core/Program.v3
@@ -148,6 +148,50 @@ class Program {
 		}
 		return true;
 	}
+
+	// Hash set of (wrappee func type, wrapper func type)
+	//   used (during reachability analysis) to indicate that a mapper is required
+	//   does not require normalization
+	def functionTypeMapperRequests = TypeUtil.newTypePairMap<void>();
+
+	// Vector of (wrappee func type, wrapper func type)
+	//   used to iterate over mapper requests
+	//   does not require normalization
+	def functionTypeMapperRequestsVec = Vector<(Type, Type)>.new();
+
+	// This needs to be here because requests can happen early in compilation
+	def requestMapper(ft: Type, tt: Type) {
+		if (CLOptions.PRINT_WRAP.get()) {
+			Terminal.buf.purple().puts("requestMapper:").end()
+				.put2(" ft %q  tt %q", ft.render, tt.render).outln();
+		}
+		var ftCanon = Function.funcRefType(ft);
+		var ttCanon = Function.funcRefType(tt);
+		if (!functionTypeMapperRequests.has((ftCanon, ttCanon))) {
+			if (CLOptions.PRINT_WRAP.get()) {
+				Terminal.buf.purple().puts("requestMapper: adding request for").end()
+					.put2(" ft %q  tt %q", ftCanon.render, ttCanon.render).outln();
+			}
+			functionTypeMapperRequests[(ftCanon, ttCanon)] = ();
+			functionTypeMapperRequestsVec.put((ftCanon, ttCanon));
+		}
+
+		// check for nested subsumptions
+		var fsig = FuncType.!(Function.funcRefType(ft)).sig();
+		var tsig = FuncType.!(Function.funcRefType(tt)).sig();
+		for (i = 0; i < fsig.paramTypes.length && i < tsig.paramTypes.length; ++i) {
+			var tpt = tsig.paramTypes[i];
+			if (!Function_TypeCon.?(tpt.typeCon)) continue;
+			var fpt = fsig.paramTypes[i];
+			if (tpt != fpt) requestMapper(tpt, fpt);  // args are contravariant
+		}
+		for (i = 0; i < fsig.returnTypes.length && i < tsig.returnTypes.length; ++i) {
+			var trt = tsig.returnTypes[i];
+			if (!Function_TypeCon.?(trt.typeCon)) continue;
+			var frt = fsig.returnTypes[i];
+			if (trt != frt) requestMapper(frt, trt);  // results are covariant
+		}
+	}
 }
 // Representation of the program appropriate for the target, e.g. a machine.
 class TargetProgram(prog: Program) {

--- a/aeneas/src/ir/Facts.v3
+++ b/aeneas/src/ir/Facts.v3
@@ -17,6 +17,10 @@ enum Fact {
 	M_INLINE,		// method should be inlined whenever possible
 	M_NEVER_INLINE,		// method should never be inlined
 	M_EMPTY,		// method has no body (should throw)
+	M_NORM,			// method is normalized
+	M_WRAPPER,		// method is a function subsumption wrapper
+	M_MAPPER,		// method is a wrapper mapper
+	M_UNMAPPER,		// method is a wrpper unmapper
 	// facts for classes
 	C_ALLOCATED,		// the class is allocated dynamically
 	C_HEAP,			// exists live in the heap
@@ -60,6 +64,8 @@ component Facts {
 	def O_NO_NAN_CHECK = Fact.O_NO_NULL_CHECK;
 	// facts for a safe shift
 	def O_SAFE_SHIFT = Fact.O_NO_SHIFT_CHECK | Fact.O_PURE;
+	// facts for involved in mapping
+	def M_MAP_UNMAP = Fact.M_MAPPER | Fact.M_UNMAPPER;
 
 	def isLive(ic: IrClass) -> bool {
 		return (ic.facts & (Fact.C_ALLOCATED | Fact.C_HEAP)) != NONE;

--- a/aeneas/src/ir/Ir.v3
+++ b/aeneas/src/ir/Ir.v3
@@ -19,7 +19,7 @@ class IrClass extends IrItem {
 	def typeArgs: TypeArgs;			// type arguments
 	def parent: IrClass;			// parent class if any
 	def fields: Array<IrField>;		// fields, including super fields
-	def methods: Array<IrMethod>;		// method dispatch table, #0 = constructor
+	var methods: Array<IrMethod>;		// method dispatch table, #0 = constructor
 	var minClassId: int;
 	var maxClassId: int;
 	var machSize: int = -1;
@@ -89,9 +89,10 @@ class IrMethod extends IrMember {
 	def render(buffer: StringBuilder) -> StringBuilder {
 		if (source == null) {
 			buffer.putc('m').putd(uid);
+			if (CLOptions.PRINT_ID.val) buffer.putc('@').putd(index);
 		} else {
 			source.render(buffer);
-			if (CLOptions.PRINT_ID.val) buffer.putc('#').putd(uid);
+			if (CLOptions.PRINT_ID.val) buffer.putc('@').putd(index).putc('#').putd(uid);
 		}
 		if (typeArgs != null) typeArgs.render(buffer);
 		return buffer;

--- a/aeneas/src/ir/IrOpMethodBuilder.v3
+++ b/aeneas/src/ir/IrOpMethodBuilder.v3
@@ -3,6 +3,21 @@
 
 def INITIAL_MSIZE = 16;
 
+def opHash(op: Operator) -> int {
+	var hash = int.!(op.opcode.tag);
+	for (i < op.typeArgs.length) {
+		hash = hash * 37 + op.typeArgs[i].hash;
+	}
+	hash = hash * 37 + op.sig.hash();
+	return hash;
+}	
+
+def opEquals(op: Operator, other: Operator) -> bool {
+	return op.equals(other) && op.sig.equals(other.sig);
+}
+
+def opMethodCache = HashMap<Operator, IrSpec>.new(opHash, Operator.equals);
+
 // Creates methods to wrap operators so they can be used as closures
 class IrOpMethodBuilder(prog: Program) {
 	var closures: Array<IrClass>;
@@ -15,6 +30,8 @@ class IrOpMethodBuilder(prog: Program) {
 			op = op.subst(abstracter.substitute);
 			typeArgs = abstracter.getTypeArgs();
 		}
+		var cacheable = Opcode.CallClassMethod.?(op.opcode);
+		if (cacheable && opMethodCache.has(op)) return opMethodCache[op];
 		// build SSA params and types
 		def receiver = createGlobalIrClass();
 		var context = SsaContext.new(compiler, prog);
@@ -32,7 +49,9 @@ class IrOpMethodBuilder(prog: Program) {
 		context.printSsa("Generated");
 		// create the IrSpec
 		var ta = if(typeArgs != null, Arrays.prepend(receiver, typeArgs.types), [receiver]);
-		return IrSpec.new(receiver, ta, meth);
+		var spec = IrSpec.new(receiver, ta, meth);
+		if (cacheable) opMethodCache[op] = spec;
+		return spec;
 	}
 	// build an operator capable of creating a closure for the given operator and args
 	def buildOpClosure(context: SsaContext, ssa: SsaBuilder, op: Operator, args: Array<SsaInstr>, indexMap: Array<int>) -> SsaInstr {
@@ -151,6 +170,7 @@ class IrOpMethodBuilder(prog: Program) {
 	}
 	def createIrMethod(receiver: Type, typeArgs: TypeArgs, sig: Signature) -> IrMethod {
 		// XXX: ugly hack; add another method to an existing IrClass by recreating it if necessary
+		// For other reasons, method vector is now mutable, so it can simply be grown ...
 		var ic = prog.ir.getIrClass(receiver);
 		var m = IrMethod.new(receiver, typeArgs, sig);
 		// search for an empty slot
@@ -158,8 +178,7 @@ class IrOpMethodBuilder(prog: Program) {
 		for (i = 1; i < length; i++) {
 			if (ic.methods[i] == null) return setIrMethod(ic, i, m);
 		}
-		ic = IrClass.new(receiver, ic.typeArgs, ic.parent, ic.fields, Arrays.grow(ic.methods, length * 4));
-		prog.ir.classMap[receiver] = ic;
+		ic.methods = Arrays.grow(ic.methods, length * 4);
 		return setIrMethod(ic, length, m);
 	}
 	private def setIrMethod(ic: IrClass, i: int, m: IrMethod) -> IrMethod {

--- a/aeneas/src/ir/Normalization.v3
+++ b/aeneas/src/ir/Normalization.v3
@@ -14,6 +14,9 @@ class NormalizerConfig {
 	var NonRefClosureReceiver: bool;
 	var AnyRefOverflow: bool;
 	var NormalizeRange: bool;
+	var WrapFuncTypeSubsume: bool;
+	var ExplicitRefTypeCast: bool;
+	var FunctionCallReceiverTypeCast: bool;
 
 	var GetScalar: (Compiler, Program, Type) -> Scalar.set = defaultGetScalar;
 	var GetBitWidth: (Compiler, Program, Type) -> byte = defaultGetBitWidth;
@@ -39,12 +42,16 @@ def defaultGetBitWidth(compiler: Compiler, prog: Program, t: Type) -> byte {
 	}
 }
 
+def printWrap()      -> TerminalBuffer { return Reachability.printWrap(); }
+def printWrapExtra() -> TerminalBuffer { return Reachability.printWrapExtra(); }
+
 // Normalizes a program based on the results of reachability analysis.
-def TRANSFERRABLE_FACTS = (Fact.M_ABSTRACT | Fact.M_INLINE | Fact.M_ENUM_INIT | Fact.M_NEW | Fact.M_EMPTY | Fact.M_EQUALS);
+def TRANSFERRABLE_FACTS = (Fact.M_ABSTRACT | Fact.M_INLINE | Fact.M_ENUM_INIT | Fact.M_NEW | Fact.M_EMPTY | Fact.M_EQUALS | Fact.M_WRAPPER | Fact.M_MAPPER | Fact.M_UNMAPPER);
 class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer) {
 	def liveClasses = Vector<RaClass>.new();
 	def context = SsaContext.new(ra.compiler, ra.prog);
 	def typeMap = TypeUtil.newTypeMap<TypeNorm>();
+	def normQueue = WorkQueue.new();
 	var recordMap = V3.newRecordMap<Record>(); // XXX: canonicalize equivalent variant records
 	var complexRecordMap = V3.newRecordMap<Array<Val>>();
 	var newIr = IrModule.new();
@@ -58,8 +65,421 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 
 	new() { vn = VariantNormalizer.new(config, this, CLOptions.PRINT_RA.get()); }
 
+	def normWrappingTables() {
+		// maps contents of wrapping, mapping, and unmapping tables to normed keys and values
+		{
+			{
+				var newWrappers = Vector<(Type, Type, IrSpec, IrSpec)>.new().grow(ra.wrappedFunctionWrapperVec.length);
+				var newWrapperMap = TypeUtil.newTypePairMap<HashMap<IrSpec,IrSpec>>();
+				for (i < ra.wrappedFunctionWrapperVec.length) {
+					var entry = ra.wrappedFunctionWrapperVec[i];
+					var ft = entry.0, tt = entry.1, wrappee = entry.2, wrapper = entry.3;
+					var nft = ft, ntt = tt;
+					var nwrappee = normalizeMethodRef(wrappee).1;
+					var nwrapper = normalizeMethodRef(wrapper).1;
+					if (CLOptions.PRINT_WRAP.get()) {
+						printWrap().put2("normWrappingTables: old ft %q tt %q", ft.render, tt.render)
+							   .put3(" wrappee %q{%d/%d}", wrappee.render, wrappee.asMethod().index, wrappee.asMethod().uid)
+							   .put3(" wrapper %q{%d/%d}", wrapper.render, wrapper.asMethod().index, wrapper.asMethod().uid).outln();
+						printWrap().put2("normWrappingTables: new ft %q tt %q", nft.render, ntt.render)
+							   .put3(" wrappee %q{%d/%d}", nwrappee.render, nwrappee.asMethod().index, nwrappee.asMethod().uid)
+							   .put3(" wrapper %q{%d/%d}", nwrapper.render, nwrapper.asMethod().index, nwrapper.asMethod().uid).outln();
+					}
+					newWrappers.put((nft, ntt, nwrappee, nwrapper));
+					var ht = newWrapperMap[(nft, ntt)];
+					if (ht == null) {
+						newWrapperMap[(nft, ntt)] = ht = HashMap<IrSpec,IrSpec>.new(IrSpec.hash, IrSpec.equals);
+					}
+					ht[nwrappee] = nwrapper;
+				}
+				ra.wrappedFunctionWrapper = newWrapperMap;
+				ra.wrappedFunctionWrapperVec = newWrappers;
+			}
+			var newMapperMap = TypeUtil.newTypePairMap<IrSpec>();
+			var newMappers = Vector<(Type, Type, IrSpec)>.new().grow(ra.wrappedFunctionTypeMapperVec.length);
+			for (i < ra.wrappedFunctionTypeMapperVec.length) {
+				var entry = ra.wrappedFunctionTypeMapperVec[i];
+				var ft = entry.0, tt = entry.1, spec = entry.2;
+				var nft = ft, ntt = tt;
+				var nspec = normalizeMethodRef(spec).1;
+				if (CLOptions.PRINT_WRAP.get()) {
+					printWrap().put2("normWrappingTables: old mapper ft %q tt %q", ft.render, tt.render)
+						   .put3(" spec %q{%d/%d}", spec.render, spec.asMethod().index, spec.asMethod().uid)
+						   .outln();
+					printWrap().put2("normWrappingTables: new mapper ft %q tt %q", nft.render, ntt.render)
+						   .put3(" spec %q{%d/%d}", nspec.render, nspec.asMethod().index, nspec.asMethod().uid)
+						   .outln();
+				}
+				newMappers.put((nft, ntt, nspec));
+				newMapperMap[(nft, ntt)] = nspec;
+			}
+			ra.wrappedFunctionTypeMapper = newMapperMap;
+			ra.wrappedFunctionTypeMapperVec = newMappers;
+		}
+
+		{
+			var unmapperTypes = Maps.keyList(ra.unmapper);
+			var newUnmapper = TypeUtil.newTypeMap<IrSpec>();
+			var newUnmapperVec = Vector<(Type, IrSpec)>.new();
+			for (node = unmapperTypes; node != null; node = node.tail) {
+				var typ = node.head;
+				var ntyp = typ;
+				var unmapperSpec = ra.unmapper[typ];
+				var nspec = normalizeMethodRef(unmapperSpec).1;
+				newUnmapper[typ] = nspec;
+				newUnmapperVec.put((typ, nspec));
+			}
+			ra.unmapper = newUnmapper;
+			ra.unmapperVec = newUnmapperVec;
+		}
+
+		{
+			var wrapperTypes = Maps.keyList(ra.wrappers);
+			var newWrappers = TypeUtil.newTypeMap<List<IrSpec>>();
+			for (node = wrapperTypes; node != null; node = node.tail) {
+				var wrapperType = node.head;
+				var ntyp = wrapperType;
+				var wrappees = ra.wrappers[wrapperType];
+				var nwrappees: List<IrSpec>;
+				for (wnode = wrappees; wnode != null; wnode = wnode.tail) {
+					var spec = wnode.head;
+					var nspec = normalizeMethodRef(spec).1;
+					nwrappees = List.new(nspec, nwrappees);
+				}
+				newWrappers[ntyp] = nwrappees;
+			}
+			ra.wrappers = newWrappers;
+		}
+
+		{
+			var nwrappeeForWrapper = HashMap<IrSpec, IrSpec>.new(IrSpec.hash, IrSpec.equals);
+			for (wnode = Maps.keyList(ra.wrappeeForWrapper); wnode != null; wnode = wnode.tail) {
+				var wrapper = wnode.head;
+				var wrappee = ra.wrappeeForWrapper[wrapper];
+				var nwrapper = normalizeMethodRef(wrapper).1;
+				var nwrappee = normalizeMethodRef(wrappee).1;
+				if (CLOptions.PRINT_WRAP.get()) {
+					printWrap().put3("normWrappingTables: wrapper %q{%d/%d}", wrapper.render, wrapper.asMethod().index, wrapper.asMethod().uid)
+						   .put3(" => wrappee %q{%d/%d}", wrappee.render, wrappee.asMethod().index, wrappee.asMethod().uid).outln();
+					printWrap().put3("normWrappingTables: norm wrapper %q{%d/%d}", nwrapper.render, nwrapper.asMethod().index, nwrapper.asMethod().uid)
+						   .put3(" => norm wrappee %q{%d/%d}", nwrappee.render, nwrappee.asMethod().index, nwrappee.asMethod().uid).outln();
+				}
+				nwrappeeForWrapper[nwrapper] = nwrappee;
+			}
+			ra.wrappeeForWrapper = nwrappeeForWrapper;
+		}
+	}
+
+	def populateMapper(ftype: Type, ttype: Type, spec: IrSpec, pairs: Vector<(IrSpec, IrSpec)>) {
+		var ft = FuncType.!(ftype), tt = FuncType.!(ttype);
+		if (CLOptions.PRINT_WRAP.get()) {
+			printWrap().put2("populateMapper: from %q  to %q", ft.render, tt.render).outln();
+		}
+		var meth = spec.asMethod();
+		context.enterMethod(meth);
+
+		var receiver = spec.receiver;
+
+		// this block of code is from IrOpMethodBuilder.createSsa
+		var params = Array<SsaParam>.new(meth.sig.paramTypes.length + 1);
+		params[0] = SsaParam.new(0, receiver);
+		for (i = 1; i < params.length; i++) {
+			params[i] = SsaParam.new(i, meth.sig.paramTypes[i - 1]);
+		}
+		meth.ssa = SsaGraph.new(params, meth.sig.returnType());
+		context.graph = meth.ssa;
+		var block = SsaBuilder.new(context, meth.ssa, meth.ssa.startBlock);
+
+		// get wrappee / wrapper pairs
+		for (i < pairs.length) {
+			var pair = pairs[i], wrappee = pair.0, wrapper = pair.1;
+			if (CLOptions.PRINT_WRAP.get()) {
+				printWrap().put2("populateMapped: map %q to %q", wrappee.render, wrapper.render).outln();
+			}
+			var compOp = V3Op.newRefEq(ft);
+			var fconst = context.graph.valConst(ft, FuncVal.new(wrappee));
+			var args: Array<SsaInstr> = [SsaInstr.!(params[1]), fconst];
+			var comp = block.addApply(null, compOp, args);
+			var retBlock = SsaBlock.new();
+			var rest = SsaBlock.new();
+			block.addIf(comp, retBlock, rest);
+			block.set(retBlock);
+			var wrapperConst = context.graph.valConst(tt, FuncVal.new(wrapper));
+			block.addReturn([wrapperConst]);
+			block.set(rest);
+		}
+		block.addReturn([context.graph.nullConst(tt)]);
+		context.printSsa("Populate mapper");
+		context.enterMethod(null);
+	}
+
+	def genMapper(ft: Type, tt: Type) -> IrSpec {
+		if (CLOptions.PRINT_WRAP.get()) {
+			printWrap().put2("genMapper: ft %q  tt %q", ft.render, tt.render).outln();
+		}
+		def receiver = ra.prog.opBuilder.createGlobalIrClass();
+		def raClass = ra.makeClass(receiver);
+		if (!raClass.raFacts.RC_LIVE) {
+			raClass.raFacts |= RaFact.RC_LIVE;
+		}
+
+		var inner = SsaContext.new(context.compiler, context.prog);
+		def ftype = FuncType.!(ft);
+		def ttype = FuncType.!(tt);
+		def mapperType = FuncType.!(Function.newType(ftype, ttype));
+		var meth = ra.prog.opBuilder.createIrMethod(receiver, null, mapperType.sig());
+		meth.setFact(Fact.M_MAPPER);
+
+		var ta: Array<Type> = [receiver];
+		var spec = IrSpec.new(receiver, ta, meth);
+		ra.wrappedFunctionTypeMapper[(ft, tt)] = spec;
+		ra.wrappedFunctionTypeMapperVec.put(ft, tt, spec);
+		if (CLOptions.PRINT_WRAP.get()) {
+			printWrap().put2("genMapper: created mapper %q.%q", receiver.render, meth.render)
+				   .put2("{%d/%d}", meth.index, meth.uid)
+				   .put1("  with type %q", mapperType.render).outln();
+		}
+
+		var rm = ra.makeMethod(spec.typeArgs, spec.asMethod(), null);
+		ra.getMethod(null, rm);
+		return rm.getSpec();
+	}
+
+	def genUnmapper(t: Type, wrappers: List<IrSpec>) -> IrSpec {
+		def receiver = ra.prog.opBuilder.createGlobalIrClass();
+		def raClass = ra.makeClass(receiver);
+		if (!raClass.raFacts.RC_LIVE) {
+			raClass.raFacts |= RaFact.RC_LIVE;
+		}
+
+		var inner = SsaContext.new(context.compiler, context.prog);
+		def ftype = FuncType.!(t);
+		def mapperType = FuncType.!(Function.newType(ftype, AnyFunction.TYPE));
+		var meth = ra.prog.opBuilder.createIrMethod(receiver, null, mapperType.sig());
+		meth.setFact(Fact.M_UNMAPPER);
+
+		var ta: Array<Type> = [receiver];
+		var spec = IrSpec.new(receiver, ta, meth);
+		ra.unmapper[t] = spec;
+		ra.unmapperVec.put((t, spec));
+		if (CLOptions.PRINT_WRAP.get()) {
+			printWrap().put2("genUnmapper: meth %q.%q", receiver.render, meth.render)
+				   .put2("{%d/%d}", meth.index, meth.uid)
+				   .put2(" for type %q  mapper type %q", t.render, mapperType.render).outln();
+		}
+
+		var rm = ra.makeMethod(spec.typeArgs, spec.asMethod(), null);
+		ra.getMethod(null, rm);
+
+		spec = rm.getSpec();
+
+		inner.enterMethod(meth);
+
+		// this block of code is from IrOpMethodBuilder.createSsa
+		var params = Array<SsaParam>.new(meth.sig.paramTypes.length + 1);
+		params[0] = SsaParam.new(0, receiver);
+		for (i = 1; i < params.length; i++) {
+			params[i] = SsaParam.new(i, meth.sig.paramTypes[i - 1]);
+		}
+		meth.ssa = SsaGraph.new(params, meth.sig.returnType());
+		inner.graph = meth.ssa;
+		var block = SsaBuilder.new(inner, meth.ssa, meth.ssa.startBlock);
+
+		// get wrapper / wrappee pairs
+		for (node = wrappers; node != null; node = node.tail) {
+			var wrapper = node.head;
+			var wrappee = wrapper;
+			// find ultimate unwrapped version of the method
+			while (ra.wrappeeForWrapper.has(wrappee)) {
+				wrappee = ra.wrappeeForWrapper[wrappee];
+			}
+			if (CLOptions.PRINT_WRAP.get()) {
+				printWrap().put2("genUnmapper: unmap %q to %q", wrapper.render, wrappee.render).outln();
+			}
+			var compOp = V3Op.newRefEq(t);
+			var fconst = inner.graph.valConst(t, FuncVal.new(wrapper));
+			var args: Array<SsaInstr> = [SsaInstr.!(params[1]), fconst];
+			var comp = block.addApply(null, compOp, args);
+			var retBlock = SsaBlock.new();
+			var rest = SsaBlock.new();
+			block.addIf(comp, retBlock, rest);
+			block.set(retBlock);
+			var wrappeeConst = inner.graph.valConst(t, FuncVal.new(wrappee));
+			block.addReturn([wrappeeConst]);
+			block.set(rest);
+		}
+		block.addReturn([params[1]]);
+		inner.printSsa("Generate unmapper");
+		inner.enterMethod(null);
+
+		return spec;
+	}
+
+	// create requested mappers / unmappers
+	def createMappersUnmappers() {
+		var methodsWithSig: HashMap<Signature, List<IrSpec>>;
+		if (ra.prog.functionTypeMapperRequestsVec.length > 0) {
+			methodsWithSig = HashMap<Signature, List<IrSpec>>.new(Signature.hash, Signature.equals);
+			for (i < ra.liveMethods.length) {
+				// Note: spec and sig are un-normalized
+				var spec = ra.liveMethods[i].getSpec();
+				var meth = spec.asMethod();
+				var mt = spec.instantiateType(meth.getMethodType());
+				var sig = FuncType.!(Function.funcRefType(mt)).sig();
+				var lst = methodsWithSig[sig];
+				methodsWithSig[sig] = List.new(spec, lst);
+			}
+			for (i < ra.prog.functionTypeMapperRequestsVec.length) {
+				// Types are un-normalized
+				var rqst = ra.prog.functionTypeMapperRequestsVec[i];
+				var ft = rqst.0, tt = rqst.1;
+				if (CLOptions.PRINT_WRAP.get()) {
+					printWrap().put2("createMappersUnmappers: Processing mapper request: from %q to %q",
+							 ft.render, tt.render).outln();
+				}
+				var spec = genMapper(ft, tt);
+				var wrappers = Vector<(IrSpec, IrSpec)>.new();
+				for (l = methodsWithSig[FuncType.!(ft).sig()]; l != null; l = l.tail) {
+					var wrappee = l.head;
+					if (CLOptions.PRINT_WRAP.get()) {
+						printWrap().put3("createMappersUnmappers: Insuring wrapper exists for wrappee: %q{%d/%d}",
+								 wrappee.render, wrappee.asMethod().index, wrappee.asMethod().uid).outln();
+					}
+					var wrapper = ra.genWrappedFunctionRaMethod(ft, tt, wrappee, null).getSpec();
+					wrappers.put((wrappee, wrapper));
+					if (CLOptions.PRINT_WRAP.get()) {
+						printWrap().put3("createMappersUnmappers: Wrapper is %q{%d/%d}",
+								 wrapper.render, wrapper.asMethod().index, wrapper.asMethod().uid).outln();
+					}
+				}
+				populateMapper(ft, tt, spec, wrappers);
+			}
+		}
+		for (i < ra.unmapperRequestsVec.length) {
+			// Types are un-normalized
+			var typ = ra.unmapperRequestsVec[i];
+			var wrappers = ra.wrappers[typ];
+			if (wrappers == null) {
+				// no wrappers of this type, so unmapper not required
+				if (CLOptions.PRINT_WRAP.get()) {
+					printWrap().put1("createMappersUnmappers: unmapperRequest for type %q ignored: no wrappers", typ.render).outln();
+				}
+				continue;
+			}
+			var spec = genUnmapper(typ, wrappers);
+			ra.unmapper[typ] = spec;
+			ra.unmapperVec.put((typ, spec));
+		}
+	}
+	def createVirtualWrappers() {
+		// Request wrappers for method implementations whose signature
+		// does not match the root signature.  We update mtables so that
+		// the methods have a consistent type.
+		if (config.WrapFuncTypeSubsume) {
+			for (node = virtuals; node != null; node = node.tail) {
+				var virtual = node.head;
+				var mtable = virtual.mtable;
+				if (mtable == null) continue;
+				var rm = virtual.raMethod, rc = ra.getClass(rm.receiver);
+				var rootType = if(rm.spec == null, rm.orig.getMethodType(), rm.spec.getMethodType());
+				var rootSig = FuncType.!(rootType).sig();
+				// iterate similarly to layoutMtable
+				var replace = HashMap<IrSpec, IrSpec>.new(IrSpec.hash, IrSpec.equals);
+				for (l = rc.subtypes; l != null; l = l.tail) {
+					var rcThis = l.head;
+					var impl = resolveMethodImpl(rcThis, rm);
+					var orig = impl.orig;
+					var origType = if(impl.spec == null, impl.orig.getMethodType(), impl.spec.getMethodType());
+					var origSig = FuncType.!(origType).sig();
+					if (!origSig.equals(rootSig)) {
+						if (CLOptions.PRINT_WRAP.get()) {
+							printWrap().put2("createVirtualWrappers: signature %q differs from root %q",
+									 origSig.funcType().render, rootSig.funcType().render).outln();
+						}
+						var ft = origSig.funcType(), tt = rootSig.funcType();
+						var spec = impl.getSpec(); // IrSpec.new(impl.receiver, [impl.receiver], orig);
+						var wm = ra.genWrappedFunctionRaMethod(ft, tt, spec, norm(impl.receiver));
+						visitMethod(wm, rcThis);
+						if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+							printWrapExtra().put2("createVirtualWrappers: wm.orig.index %d  wm.norm.index %d",
+									      wm.orig.index, wm.norm.index)
+									.put2("  impl.orig.index %d  impl.norm.index %d",
+									      impl.orig.index, impl.norm.index)
+									.put2("  rm.orig.index %d  rm.norm.index %d",
+									      rm.orig.index, rm.norm.index)
+									.put3("  mtable size %d  rcThis orig method count %d  norm method count %d",
+									      mtable.table.length, rcThis.orig.methods.length,
+									      rcThis.normMethods.length).outln();
+						}
+						if (wm.norm.index < 0) {
+							// need a new slot; this will be beyond the end of the current method array
+							wm.norm.index = wm.normIndex = rcThis.normMethods.length;
+						}
+						if (wm.norm.index >= rc.normMethods.length) {
+							rcThis.normMethods = Arrays.grow(rcThis.normMethods, wm.norm.index + 1);
+						}
+						// swap impl and wm
+						var wslot = wm.norm.index;
+						var islot = impl.norm.index;
+						rcThis.normMethods[wslot] = impl.norm;
+						rcThis.normMethods[islot] = wm.norm;
+						impl.norm.index = impl.normIndex = wslot;
+						wm.norm.index = wm.normIndex = islot;
+						var wsrc = wm.orig.source;
+						var isrc = impl.orig.source;
+						wm.orig.source = isrc;
+						impl.orig.source = wsrc;
+						wsrc = wm.norm.source;
+						isrc = impl.norm.source;
+						wm.norm.source = isrc;
+						impl.norm.source = wsrc;
+
+						if (rm.norm.facts.M_OVERRIDE) wm.norm.facts |= Fact.M_OVERRIDE;
+						if (rm.norm.facts.M_OVERRIDDEN) wm.norm.facts |= Fact.M_OVERRIDDEN;
+						impl.norm.facts -= Fact.M_OVERRIDE;
+						impl.norm.facts -= Fact.M_OVERRIDDEN;
+
+						var index = l.head.minClassId - mtable.rootId;
+						if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+							printWrapExtra().put3("createVirtualMappers: mtable %q  wm.normIndex %d  wm.norm.index %d",
+									      mtable.render, wm.normIndex, wm.norm.index)
+									.put1(" slot %d", index).outln();
+						}
+						rcThis.replaceRaMethod(impl, wm);
+						mtable.table[index] = wm.norm;
+						// as in layoutMtable
+						var ta = Arrays.replace(impl.getSpec().typeArgs, 0, impl.norm.receiver);
+						var oldSpec = IrSpec.new(ta[0], ta, impl.norm);
+						var wta = Arrays.replace(wm.getSpec().typeArgs, 0, wm.norm.receiver);
+						var wspec = IrSpec.new(wta[0], wta, wm.norm);
+						replace[oldSpec] = wspec;
+					}
+				}
+				if (mtable.record != null) {
+					var vals = mtable.record.values;
+					for (i < vals.length) {
+						var val = vals[i];
+						if (val != null) {
+							var spec = FuncVal.!(val).memberRef;
+							if (replace.has(spec)) {
+								vals[i] = FuncVal.new(replace[spec]);
+								if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+									printWrapExtra().put2("createVirtualMappers: updated mtable record slot %d to hold %q",
+											      i, mtable.render).outln();
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
 	def normalize() {
 		if (CLOptions.PRINT_DEAD_CODE.get()) DeadCodeAnalyzer.new(ra).report();
+
+		createMappersUnmappers();
+
 		ra.prog.resetComponentRecords();
 		// layout fields into classes
 		ra.arrays.apply(visitArrayType);
@@ -70,7 +490,15 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 		}
 		ra.classes.apply(layoutVtable);
 		Lists.apply(virtuals, layoutMtable);
+
+		createVirtualWrappers();
+
 		ra.classes.apply(createIrClass);
+		var classesVisited = ra.classes.length;
+
+		// normalize mapping info before normalizing code
+		normWrappingTables();
+
 		// create new roots for the new IrModule
 		var old = ra.oldIr.roots;
 		newIr.roots.grow(old.length);
@@ -81,8 +509,13 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 		}
 		ra.prog.ir = newIr;
 		// do remaining work; normalize record instances
-		ra.queue.drain();
-		ra.liveMethods.apply(normCode);
+		normQueue.drain();
+		// normalize code; may generate more wrappers, etc.
+		for (i < ra.liveMethods.length) {
+			var rm = ra.liveMethods[i];
+			normCode(rm);
+		}
+		normQueue.drain();  // may run wrapper/mapper normalization updates
 		if (ovfAlloc != null) allocOverflowFieldRecord();
 	}
 	def visitClassType(rc: RaClass) {
@@ -103,9 +536,10 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			if (rc.instances != null) {
 				// normalize component record
 				var oldRecord = rc.instances.head;
-				newRecord = ra.prog.newRecord(tn.newType, rc.liveFields.length);
+				// New type is "void" for components, so use old type
+				newRecord = ra.prog.newRecord(rc.oldType, rc.liveFields.length);
 				complexRecordMap[oldRecord] = NO_VALUES;
-				ra.queue.add(normClassRecord, (rc, oldRecord, newRecord)); // XXX: inline normClassRecord
+				normQueue.add(normClassRecord, (rc, oldRecord, newRecord)); // XXX: inline normClassRecord
 			}
 			ra.prog.setComponentRecord(comp, newRecord);
 		} else if (!rc.isUnboxed()) {
@@ -113,7 +547,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			for (l = rc.instances; l != null; l = l.tail) {
 				var oldRecord = l.head, newRecord = ra.prog.newRecord(tn.newType, rc.liveFields.length);
 				recordMap[oldRecord] = newRecord;
-				ra.queue.add(normClassRecord, (rc, oldRecord, newRecord)); // XXX: inline normClassRecord
+				normQueue.add(normClassRecord, (rc, oldRecord, newRecord)); // XXX: inline normClassRecord
 			}
 		} else {
 			// synthesize a component type for flattened data types and variants
@@ -126,21 +560,22 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 		}
 		for (ml in rc.methods) {
 			// Create IrMethods for all methods
-			for (l = ml; l != null; l = l.tail) {
-				var rm = l.head, m = rm.orig;
-				if (rm.norm != null) continue; // already done
-				var ftype = if(rm.spec == null, m.sig.funcType(), rm.spec.getMethodType());
-				if (rc.isUnboxed()) {
-					// move flattened data type receiver to function sig
-					ftype = Function.prependParamTypes(rc.variantNorm.sub, ftype);
-				}
-				rm.funcNorm = FuncNorm.!(norm(ftype));
-				var typeParams = if(rm.spec != null, rm.spec.getTypes().methodTypeArgs);
-				rm.norm = IrMethod.new(rc.newIrType, typeParams, rm.funcNorm.sig());
-				rm.norm.facts = m.facts & TRANSFERRABLE_FACTS;
-				rm.norm.source = m.source;
-			}
+			for (l = ml; l != null; l = l.tail) visitMethod(l.head, rc);
 		}
+	}
+	def visitMethod(rm: RaMethod, rc: RaClass) {
+		var m = rm.orig;
+		if (rm.norm != null) return; // already done
+		var ftype = rm.getSpec().getMethodType();
+		if (rc.isUnboxed()) {
+			// move flattened data type receiver to function sig
+			ftype = Function.prependParamTypes(rc.variantNorm.sub, ftype);
+		}
+		rm.funcNorm = FuncNorm.!(norm(ftype));
+		var typeParams = if(rm.spec != null, rm.spec.getTypes().methodTypeArgs);
+		rm.norm = IrMethod.new(rc.newIrType, typeParams, rm.funcNorm.sig());
+		rm.norm.facts = (m.facts & TRANSFERRABLE_FACTS) | Fact.M_NORM;
+		rm.norm.source = m.source;
 	}
 	def visitArrayType(rt: RaArray) {
 		var tn = ArrayNorm.!(norm(rt.oldType));
@@ -149,7 +584,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			for (l = rt.instances; l != null; l = l.tail) {
 				var newRecord = ra.prog.newRecord(tn.newType, l.head.values.length);
 				recordMap[l.head] = newRecord;
-				ra.queue.add(normMixedArrayRecord, (tn, l.head, newRecord));
+				normQueue.add(normMixedArrayRecord, (tn, l.head, newRecord));
 			}
 			return;
 		}
@@ -157,7 +592,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 		// map complex arrays to arrays of records
 		for (l = rt.instances; l != null; l = l.tail) {
 			var newRecords = createComplexArrayRecord(l.head, tn);
-			ra.queue.add(normComplexArrayRecord, (tn, l.head, newRecords));
+			normQueue.add(normComplexArrayRecord, (tn, l.head, newRecords));
 		}
 	}
 	def createComplexArrayRecord(r: Record, rt: ArrayNorm) -> Array<Record> {
@@ -227,6 +662,13 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 				var ta = [ft, AnyRef.TYPE];
 				tn = FuncNorm.new(t, Tuple.newType(Lists.cons2(ft, AnyRef.TYPE)), pt.1, rt.1, ta);
 			}
+			FUNCREF => {
+				var pt = limit(Function.getParamType(t), config.MaxParams);
+				var rt = limit(Function.getReturnType(t), config.MaxReturnValues);
+				var ft = Function.FUNCREF.create(Lists.cons2(pt.0, rt.0));
+				var ta = [ft];
+				tn = FuncNorm.new(t, Tuple.newType(Lists.cons1(ft)), pt.1, rt.1, ta);
+			}
 			TUPLE => {
 				// flatten tuples
 				var seq = NormFlattener.new(context, norm);
@@ -254,12 +696,17 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 				tn = TypeNorm.new(t, t, null);
 			}
 		}
-		if (CLOptions.PRINT_RA.get()) {
-			if (tn == null) Terminal.put1("normalize: %q\n", t.render);
-			else Terminal.put1("normalize: %q\n", tn.render);
-		}
 		typeMap[t] = tn;
 		return tn;
+	}
+	def renderTypes(buffer: StringBuilder, types: Array<Type>) -> StringBuilder {
+		buffer.putc('[');
+		for (i < types.length) {
+			if (i > 0) buffer.puts(", ");
+			buffer.put1("%q", types[i].render);
+		}
+		buffer.putc(']');
+		return buffer;
 	}
 	def limit(t: Type, len: int) -> (Type, Array<Type>) {
 		var tn = norm(t);
@@ -427,7 +874,7 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			var rf = rfs[i];
 			if (rf != null && rf.normIndices.0 >= 0) {
 				var v = oldVals[i];
-				if (rf.fieldType == null) newVals[rf.normIndices.0] = normSimpleVal(null, v);
+				if (rf.fieldType == null) newVals[rf.normIndices.0] = normSimpleVal(null, rf.getClosedType(), v);
 				else normValIntoArray(v, rf.typeNorm, newVals, rf.normIndices.0);
 			}
 		}
@@ -439,25 +886,34 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 	}
 	// normalize the live instances of a complex (i.e. size-N element) array type
 	def normComplexArrayRecord(rt: ArrayNorm, oldRecord: Record, newRecords: Array<Record>) {
-		var etn = norm(V3Array.elementType(rt.oldType));
+		var enorm = norm(V3Array.elementType(rt.oldType));
 		var old = oldRecord.values;
 		var temp = Array<Val>.new(newRecords.length);
 		for (i < old.length) {
 			for (j < temp.length) temp[j] = null; // XXX: must clear temp array first
-			normValIntoArray(old[i], etn, temp, 0);
+			normValIntoArray(old[i], enorm, temp, 0);
 			for (j < newRecords.length) {
 				newRecords[j].values[i] = temp[j];
 			}
 		}
 	}
 	// map a record 1-1
-	def normSimpleVal(tn: TypeNorm, v: Val) -> Val {
+	def normSimpleVal(tn: TypeNorm, t: Type, v: Val) -> Val {
+		var tt = if(tn == null, t, tn.newType);
 		match (v) {
 			x: Record => {
 				var r = recordMap[x];
 				if (r != null) return r;
 				if (VariantNorm.?(tn)) return normVariantRecord(VariantNorm.!(tn), x)[0];
 				return x;
+			}
+			x: Closure => {
+				var fval = FuncVal.!(normalizeFuncRef(tn, x.memberRef));
+				return if(fval.memberRef == x.memberRef, v, Closure.new(x.val, fval.memberRef));
+			}
+			x: FuncVal => {
+				var fval = normalizeFuncRef(tn, x.memberRef); // maybe wrap function
+				return fval;
 			}
 			_ => return v;
 		}
@@ -478,6 +934,16 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			for (l = ml; l != null; l = l.tail) addMethod(vtable, rc, l.head);
 		}
 		rc.normMethods = vtable.extract();
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			printWrapExtra().put2("layoutVtable: class %q  size %d", rc.orig.ctype.render, rc.normMethods.length).ln();
+			for (i < rc.normMethods.length) {
+				var m = rc.normMethods[i];
+				printWrapExtra().put1("layoutVtable:  entry %d", i);
+				if (m == null) Terminal.buf.puts("  null");
+				else Terminal.put3("  %q{%d/%d}", m.render, m.index, m.uid);
+				Terminal.buf.outln();
+			}
+		}
 	}
 	def addMethod(vtable: Vector<IrMethod>, rc: RaClass, rm: RaMethod) {
 		var m = rm.orig;
@@ -523,6 +989,10 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 				var impl = resolveMethodImpl(l.head, rm);
 				var index = l.head.minClassId - mtable.rootId;
 				mtable.table[index] = impl.norm;
+				if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+					printWrapExtra().put3("layoutMtable: slot %d  class %q  subclass %q", index, rc.orig.ctype.render, l.head.orig.ctype.render)
+							.put3("  impl %q{%d/%d}", impl.norm.render, impl.norm.index, impl.norm.uid).outln();
+				}
 				if (mtable.record != null) {
 					var ta = Arrays.replace(impl.getSpec().typeArgs, 0, impl.norm.receiver);
 					var spec = IrSpec.new(ta[0], ta, impl.norm);
@@ -560,15 +1030,21 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 					for (i < result.length) array[index + i] = result[i];
 				} else {
 					var result = complexRecordMap[x];
+					// The Record itself will be processed as an instance of some type,
+					// so we do not need to recurse into it.
 					if (result == null) array[index] = x; // assume 1-1
 					else for (i < result.length) array[index + i] = result[i]; // complex array
 				}
 			}
 			x: Closure => {
 				// normalize closure value as (funcval, val...) pair
-				var ref = normalizeMethodRef(x.memberRef).1;
-				array[index] = FuncVal.new(ref);
-				normValIntoArray(x.val, norm(ref.receiver), array, index + 1);
+				var fval = normalizeFuncRef(tn, x.memberRef);
+				if (CLOptions.PRINT_WRAP.get()) {
+					printWrap().put3("normValIntoArray: Closure tn %q spec %q fval %q",
+							 tn.render, x.memberRef.asMethod().render, V3.render(fval)).outln();
+				}
+				array[index] = fval;
+				normValIntoArray(x.val, norm(x.memberRef.receiver), array, index + 1);
 			}
 			x: BoxVal => {
 				// tuple: recursively normalize all of the sub
@@ -589,16 +1065,79 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 				normValIntoArray(x.array, an, array, index);
 				array[index + an.size] = ArrayRangeStart.new(x.offset, V3.arrayByteType);
 			}
+			x: FuncVal => {
+				var fn = normalizeFuncRef(tn, x.memberRef);  // maybe wrap function
+				if (index < array.length) array[index] = fn;
+			}
 			_ => if (index < array.length) array[index] = v;
 		}
+	}
+	// Note: here, spec is the un-normalized IrSpec of the function
+	def normalizeFuncRef(tn: TypeNorm, spec: IrSpec) -> Val {
+		if (config.WrapFuncTypeSubsume) {
+			var ftn = FuncNorm.!(tn);
+			var oldType = ftn.oldType;
+			var newType = ftn.newType;
+			var tt: Type = if(oldType.typeCon.kind == Kind.CLOSURE, Function.funcRefType(oldType), oldType);
+			var nt: Type = if(newType.typeCon.kind == Kind.TUPLE, newType.nested.head, newType);
+			var meth = spec.asMethod();
+			var ft = Function.funcRefType(meth.getMethodType());  // actual type of method
+			def inMeth = context.method;
+			def inMapper = (inMeth != null) && (inMeth.facts & Facts.M_MAP_UNMAP) != Facts.NONE;
+			if (!inMapper && // don't wrap references in mappers/unmappers
+			    TypeSystem.computeConversion(ft, tt) == Conversion.SUBSUME_FUNCTION) {
+				var normed = normalizeMethodRef(spec);  // need to look up normed version
+				spec = ra.getWrappedFunction(ft, tt, normed.1);
+				if (spec == null) {
+					spec = ra.genWrappedFunction(ft, tt, normed.1, norm(normed.0.receiver));
+					if (CLOptions.PRINT_WRAP.get()) {
+						printWrap().put2("normalizeFuncRef: ft = %q  tt = %q", ft.render, tt.render)
+								.put3("  meth = %q{%d/%d}", meth.render, meth.index, meth.uid)
+								.outln();
+					}
+					// insure the wrapper is visited, etc.
+					var rm = ra.makeMethod(spec.typeArgs, IrMethod.!(spec.member), null);
+					var rc = ra.getClass(rm.receiver);
+					ra.getMethod(null, rm);
+					visitMethod(rm, rc);
+					if (rm.norm.index < 0) {
+						// need to add to vtable
+						var oldVtable = rc.normMethods;
+						rm.norm.index = oldVtable.length;
+						rc.normMethods = Arrays.append(rm.norm, oldVtable);
+						if (rc.normClass != null) {
+							// must add to normed class methods as well
+							var nc = rc.normClass;
+							if (rm.norm.index >= nc.methods.length) {
+								nc.methods = Arrays.grow(nc.methods, rm.norm.index + 1);
+							}
+							nc.methods[rm.norm.index] = rm.norm;
+						}
+					}
+				}
+			}
+		}
+		var normed = normalizeMethodRef(spec);
+		return FuncVal.new(normed.1);
 	}
 	def normalizeMethodRef(spec: IrSpec) -> (RaMethod, IrSpec) {
 		// XXX: canonicalize normalized IrSpecs
 		var rm = spec.asMethod().raMethod;
 		var ta = spec.typeArgs;
 		if (rm == null) {
-			var rc = ra.getClass(spec.receiver);
-			rm = rc.findMethod(spec.member.index, ta);
+			var receiver = spec.receiver;
+			var rc = ra.getClass(receiver);
+			var meth = spec.asMethod();
+			if (rc == null) rc = ra.makeClass(receiver);
+			if (meth.facts.M_NORM) {
+				rm = rc.findNormedMethod(meth);
+			} else {
+				rm = rc.findMethod(spec.member.index, ta);
+				if (rm == null) {
+					rm = ra.makeMethod(ta, meth, null);
+					visitMethod(rm, rc);
+				}
+			}
 			if (rm == null) return V3.fail1("ReachabilityError: method %q not found", spec.render);
 		}
 		ta = Arrays.replace(ta, 0, rm.norm.receiver);

--- a/aeneas/src/ir/Reachability.v3
+++ b/aeneas/src/ir/Reachability.v3
@@ -20,6 +20,18 @@ enum RaFact {
 	RC_BOXED,
 }
 
+component Reachability {
+	def printWrap() -> TerminalBuffer {
+		return Terminal.buf.purple().puts("Wrapping: ").end();
+	}
+	def printWrapExtra() -> TerminalBuffer {
+		return Terminal.buf.red().puts("Wrapping: ").end();
+	}
+}
+
+def printWrap()      -> TerminalBuffer { return Reachability.printWrap(); }
+def printWrapExtra() -> TerminalBuffer { return Reachability.printWrapExtra(); }
+
 def DUMP: Terminal;
 def NONE: RaFact.set;
 def countVals(facts: RaFact.set) -> int {
@@ -47,6 +59,7 @@ class ReachabilityAnalyzer(compilation: Compilation) {
 	def arrays = Vector<RaArray>.new();
 	var defaultValues: HashMap<Type, Val>;
 	var liveMethods = Vector<RaMethod>.new();
+	var normalizer: ReachabilityNormalizer;
 
 	// perform the analysis, starting from the roots
 	def analyze() {
@@ -58,7 +71,10 @@ class ReachabilityAnalyzer(compilation: Compilation) {
 		queue.drain(); // do all work
 	}
 	def transform(config: NormalizerConfig) {
-		ReachabilityNormalizer.new(config, this).normalize();
+		// make normalizer object available during normalization
+		normalizer = ReachabilityNormalizer.new(config, this);
+		normalizer.normalize();
+		normalizer = null;
 	}
 	def dump() {
 		liveMethods.apply(dumpMethod);
@@ -299,9 +315,9 @@ class ReachabilityAnalyzer(compilation: Compilation) {
 	// analyze an operator
 	def analyzeOp(op: SsaApplyOp, context: IrSpec) {
 		match (op.op.opcode) {
-			OverloadedEq,
-			RefEq,
 			VariantEq => getEquality(mono(op.op.typeArgs[0], context), context);
+			OverloadedEq,
+			RefEq => getRefEquality(op, mono(op.op.typeArgs[0], context), context);
 			DefaultValue => {
 				var t = mono(op.op.typeArgs[0], context);
 				var v = prog.getDefaultValue(t);
@@ -309,8 +325,19 @@ class ReachabilityAnalyzer(compilation: Compilation) {
 				if (defaultValues == null) defaultValues = TypeUtil.newTypeMap();
 				defaultValues[t] = v;
 			}
-			ArrayAlloc,
-			ArrayInit => allocation(makeType(mono(op.op.typeArgs[0], context)));
+			ArrayAlloc => allocation(makeType(mono(op.op.typeArgs[0], context)));
+			ArrayInit => {
+				var typ = mono(op.op.typeArgs[0], context);
+				allocation(makeType(typ));
+				if (op.inputs != null) {
+					var inputs = op.inputs;
+					for (i < inputs.length) {
+						var input = inputs[i];
+						var ft = mono(input.getDest().getType(), context);
+						getTypeCast(op, ft, typ);
+					}
+				}
+			}
 			ClassAlloc(method) => {
 				var rm = opMethod(op, method, context);
 				if (rm != null) getMethod(op, rm);
@@ -351,6 +378,419 @@ class ReachabilityAnalyzer(compilation: Compilation) {
 			PtrAtComponentField(field) => if (op.useList != null) getPointerAtField(makeField(op, field, context), op, true);
 			PtrAtUnboxedObjectField(specs) => if (op.useList != null) getPointerAtUnboxedField(op, specs, context);
 			PtrAtUnboxedComponentField(specs) => if (op.useList != null) getPointerAtUnboxedField(op, specs, context);
+			TypeSubsume, TypeCast => {
+				if (compiler.NormConfig.WrapFuncTypeSubsume) {
+					var ft = mono(op.op.typeArgs[0], context);
+					var tt = mono(op.op.typeArgs[1], context);
+					return getTypeCast(op, ft, tt);
+				}
+			}
+			_ => ;
+		}
+	}
+
+	// Function subsumption wrapping / mapping tables, then functions
+	//
+	//   When a function type F1 id a subtype of function type F2, but not the
+	//   same type, F2 subsumes F1.  Some targets do not allow treating F1 instances
+	//   as F2 instances in their run-times, because of stricter type rules.  In
+	//   this case f of type F1 requires a wrapper, e.g., wf, of type F2 that just
+	//   turns around and calls f.  Example: class B extends class A, F1 is void -> A
+	//   and F2 is void -> B.  Let f: void -> B in a context that wants a function
+	//   of type void -> A.  We can create internally a wrapper equivalent to:
+	//   def wf() -> A { return f(); }.  This generalizes, with some care to handle
+	//   nested subsmptions when argument / result types are themselves function
+	//   types.
+	//
+	//   In the case where var v: F1, that is, an unknown function, we require a
+	//   *mapper* that takes in a *function* of type F1 and returns a wrapped
+	//   version of type F2.  This requires generating a wrapper for *every* function
+	//   of type F1, and generating the mapper as well.
+	//
+	//   If function values are compared (== or !=) other than against null, we need
+	//   to ensure that we compare a canonical version of the functions as opposed to
+	//   possibly different wrappers for the same underlying function.  In this case,
+	//   if required, we generate an *unmapper* that takes in a function are returns
+	//   its (fully) unwrapped version.  Those may then me compared.
+	//
+
+	// (wrappee func type, wrapper func type) => (wrappee => wrapper)
+	//   used to find wrapper for a given wrappee subsumption
+	//   requires normalization
+	var wrappedFunctionWrapper = TypeUtil.newTypePairMap<HashMap<IrSpec,IrSpec>>();
+
+	// Vector of (wrappee func type, wrapper func type, wrappee, wrapper)
+	//   used to iterate and build mappers
+	//   requires normalization
+	var wrappedFunctionWrapperVec = Vector<(Type, Type, IrSpec, IrSpec)>.new();
+
+	// (wrappee func type, wrapper func type) => mapper method
+	//   used to find mapper for a given func type subsumption
+	//   requires normalization
+	var wrappedFunctionTypeMapper = TypeUtil.newTypePairMap<IrSpec>();
+
+	// Vector of (wrappee func type, wrapper func type, mapper method)
+	//   used to iterate over mappers
+	//   requires normalization
+	var wrappedFunctionTypeMapperVec = Vector<(Type, Type, IrSpec)>.new();
+
+	// Set of (wrapped func type)
+	//   used (during reachability analysis) to indicate possible need for an unmapper
+	//   does not require normalization
+	var unmapperRequests = TypeUtil.newTypeMap<void>();
+
+	// Vector of (wrapped func type)
+	//   used to iterate over unmapper requests
+	//   does not require normalization
+	var unmapperRequestsVec = Vector<Type>.new();
+
+	// Func type => unmapper for that type
+	//   used to find unmapper in normalization
+	//   requires normalization
+	var unmapper = TypeUtil.newTypeMap<IrSpec>();
+
+	// Vector of (func type, unmapper for that type)
+	//   used to iterate over unmappers
+	//   requires normalization
+	var unmapperVec = Vector<(Type, IrSpec)>.new();
+
+	// Type -> List of wrappers that have that type
+	//   used to build unmappers
+	//   requires normalization
+	var wrappers = TypeUtil.newTypeMap<List<IrSpec>>();
+
+	// wrapper => wrappee
+	//   used to build unmappers
+	//   requires normalization
+	var wrappeeForWrapper = HashMap<IrSpec, IrSpec>.new(IrSpec.hash, IrSpec.equals);
+
+	// End of wrapping / mapping tables
+
+	// Note: ft, tt, and spec are always un-normalized, as is the result
+	def getWrappedFunction(ft: Type, tt: Type, spec: IrSpec) -> IrSpec {
+		if (CLOptions.PRINT_WRAP.get()) {
+			printWrap().put2("getWrappedFunction: input types ft %q (open %z)", ft.render, ft.open())
+				   .put2("  tt %q (open %z)", tt.render, tt.open()).outln();
+			printWrap().put3("getWrappedFunction: spec %q  method receiver %q  open %z",
+					 spec.render, spec.asMethod().receiver.render, spec.asMethod().receiver.open()).outln();
+		}
+		var ftCanon = Function.funcRefType(ft);
+		var ttCanon = Function.funcRefType(tt);
+		var m = spec.asMethod();
+		if (!wrappedFunctionWrapper.has((ftCanon, ttCanon))) {
+			if (CLOptions.PRINT_WRAP.get()) {
+				printWrap().put3("getWrappedFunction: a FuncVal of %q{%d/%d} not found",
+						 m.render, m.index, m.uid)
+					   .put3("; ft %q  tt %q  M_NORM %z", ftCanon.render, ttCanon.render, m.facts.M_NORM).outln();
+			}
+			return null;
+		}
+		if (CLOptions.PRINT_WRAP.get()) {
+			printWrap().put1("getWrappedFunction: lookup spec is %q; ", spec.render)
+				   .put3("method %q{%d/%d}", m.render,
+					 m.index, m.uid).outln();
+		}
+		var nspec = wrappedFunctionWrapper[(ftCanon, ttCanon)][spec];
+		if (nspec == null) {
+			if (CLOptions.PRINT_WRAP.get()) {
+				printWrap().put3("getWrappedFunction(2): a FuncVal of %q{%d/%d} not found", spec.asMethod().render,
+						 spec.asMethod().index, spec.asMethod().uid).outln();
+			}
+			return null;
+		}
+		if (CLOptions.PRINT_WRAP.get()) {
+			var nm = nspec.asMethod();
+			printWrap().put3("getWrappedFunction: looked up %q{%d/%d}, ", m.render, m.index, m.uid)
+				   .put3("returning %q{%d/%d}", nm.render, nm.index, nm.uid).outln();
+		}
+		return nspec;
+	}
+	// generate a wrapper for a function so it can appear as a supertype
+	def genWrappedFunction(ft: Type, tt: Type, spec: IrSpec, rnorm: TypeNorm) -> IrSpec {
+		// rnorm may be null, but if not, indicates the eventual normed receiver type
+
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			printWrapExtra().put2("genWrappedFunction: ft %q  tt %q", ft.render, tt.render).outln();
+		}
+		var nspec = getWrappedFunction(ft, tt, spec);
+		if (nspec != null) return nspec;
+		var ftCanon = Function.funcRefType(ft);
+		var ttCanon = Function.funcRefType(tt);
+
+		if (!wrappedFunctionWrapper.has((ftCanon, ttCanon))) {
+			wrappedFunctionWrapper[(ftCanon, ttCanon)] = HashMap<IrSpec,IrSpec>.new(IrSpec.hash,IrSpec.equals);
+		}
+		var ht = wrappedFunctionWrapper[(ftCanon, ttCanon)];
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			printWrapExtra().put3("genWrappedFunction: a FuncVal of %q{%d/%d}", spec.asMethod().render,
+					 spec.asMethod().index, spec.asMethod().uid).outln();
+		}
+
+		// build SSA params and types
+		def orig = spec.asMethod();
+		var receiver = spec.receiver;
+		if (receiver.open()) receiver = spec.instantiateType(spec.receiver);
+		if (rnorm != null) receiver = rnorm.oldType;
+		def ftype = FuncType.!(ft);
+		def ttype = FuncType.!(tt);
+		def fsig = ftype.sig();
+		var tsig = ttype.sig();
+		def mtype = spec.getBoundType();
+		if (mtype.typeCon.kind == Kind.CLOSURE) {
+			tsig = Signature.new(null, tsig.paramTypes, tsig.returnTypes);
+			if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+				printWrapExtra().put1("genWrappedFunction: bound type %q is a closure", mtype.render)
+						.outln();
+			}
+		}
+
+		// We create the method here
+		var typeArgs = orig.typeArgs;
+		var ntypeArgs = if (typeArgs == null, null, TypeArgs.new(typeArgs.typeEnv, [receiver]));
+		var meth = prog.opBuilder.createIrMethod(spec.asMethod().receiver, ntypeArgs, tsig);
+		var vstFunc = VstFunc.new(null, ReturnType.Void, null);
+		var oldSrc = spec.asMethod().source;
+		var oldName = if(oldSrc == null, "m", oldSrc.name());
+		var name = StringBuilder.new().put2("%s$w%d", oldName, meth.uid).extract();
+		var source = if(oldSrc == null, VstMethod.new(false, Token.new(null, name, 0, 0), null, vstFunc),
+				VstMethod.new(oldSrc.isPrivate, oldSrc.token.copy(name), oldSrc.typeParams, vstFunc));
+		meth.source = source;
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			printWrapExtra().put2("genWrappedFunction: ft %q tt %q", ftype.render, ttype.render)
+					.put1(" bound type %q", spec.getBoundType().render)
+					.put1(" method type %q", spec.asMethod().getMethodType().render)
+					.outln();
+			Terminal.buf.put1("   wrappee is %q", receiver.render)
+				.put3(".%q{%d/%d}", spec.render, orig.index, orig.uid)
+				.put1(" with type %q", spec.getBoundType().render).outln();
+			Terminal.buf.put1("   wrapper is %q", meth.receiver.render)
+				.put3(".%q{%d/%d}", meth.render, meth.index, meth.uid)
+				.put3(" with type %q (tsig %q fsig %q)", meth.getMethodType().render, tsig.funcType().render, fsig.funcType().render).outln();
+			if (typeArgs == null) {
+				Terminal.buf.puts("   orig typeArgs is null").outln();
+			} else {
+				Terminal.buf.put1("   orig typeArgs %q", orig.typeArgs.render).outln();
+			}
+			if (meth.typeArgs == null) {
+				Terminal.buf.puts("   meth typeArgs is null").outln();
+			} else {
+				Terminal.buf.put1("   meth typeArgs %q", meth.typeArgs.render).outln();
+			}
+		}
+
+		meth.setFact(Fact.M_WRAPPER);
+		var inner = SsaContext.new(Aeneas.compiler, prog);
+		inner.enterMethod(meth);
+		var block = prog.opBuilder.createSsa(inner, receiver, meth);
+		// build block
+		var args = Arrays.map(meth.ssa.params, SsaInstr.!<SsaParam>);
+		for (i = 1; i < args.length; ++i) {
+			if (tsig.paramTypes[i-1] != fsig.paramTypes[i-1]) {
+				args[i] = block.opTypeSubsume0(tsig.paramTypes[i-1], fsig.paramTypes[i-1], args[i], this);
+				var op: SsaApplyOp;
+				if (SsaApplyOp.?(args[i]) &&
+				    (op = SsaApplyOp.!(args[i])).op.opcode == Opcode.TypeSubsume) {
+					analyzeOp(op, null);  // may request a mapper
+				}
+			}
+		}
+		var apply: SsaInstr;
+		var op: Operator;
+		var nonClass = (rnorm != null && !V3.isClass(rnorm.newType));
+		if (V3.isComponent(receiver) || nonClass) {
+			op = V3Op.newCallMethod(spec);
+			if (!nonClass) args[0] = inner.graph.nullReceiver();
+		} else {
+			op = V3Op.newCallClassMethod(spec);
+		}
+		apply = block.addApply(null, op, args);
+		if (ftype.returnType() != ttype.returnType()) {
+			if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+				printWrapExtra().puts("genWrappedFunction: wrapper includes return subsume").outln();
+			}
+			apply = block.opTypeSubsume0(ftype.returnType(), ttype.returnType(), apply, this);
+		}
+		block.addReturn([apply]);
+		inner.printSsa("Generated wrapper");
+		inner.enterMethod(null);
+
+		// create the IrSpec
+		var wrapper = IrSpec.new(spec.receiver, spec.typeArgs, meth);
+
+		ht[spec] = wrapper;
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			printWrapExtra().put1("genWrappedFunction: wrapper stored under spec %q", spec.render).outln();
+		}
+		wrappedFunctionWrapperVec.put((ftCanon, ttCanon, spec, wrapper));
+		wrappers[ttCanon] = List.new(wrapper, wrappers[ttCanon]);
+		wrappeeForWrapper[wrapper] = spec;
+		if (CLOptions.PRINT_WRAP.get()) {
+			printWrap().puts("genWrappedFunction:").outln()
+				   .cyan().puts("    from type ").end().put1("%q", ft.render)
+				   .cyan().puts("  to type ").end().put1("%q", tt.render).outln()
+				   .cyan().puts("    from canoncial type ").end().put1("%q", ftCanon.render)
+				   .cyan().puts("  to canonical type ").end().put1("%q", ttCanon.render).outln()
+				   .cyan().puts("    wrappee ").end().put3("%q{%d/%d}", spec.render, spec.asMethod().index, spec.asMethod().uid)
+				   .cyan().puts("  wrapper ").end().put3("%q{%d/%d}", wrapper.render, wrapper.asMethod().index, wrapper.asMethod().uid).outln()
+				   .cyan().puts("    wrappee rcvr ").end().put1("%q", spec.receiver.render)
+				   .cyan().puts(" type ").end().put1("%q", spec.asMethod().sig.funcType().render).outln()
+				   .cyan().puts("    wrapper rcvr ").end().put1("%q", wrapper.receiver.render)
+				   .cyan().puts(" type ").end().put1("%q", wrapper.asMethod().sig.funcType().render).outln();
+		}
+		return wrapper;
+	}
+	// obtains a wrapper for a function and creates an RaMethod for it
+	def genWrappedFunctionRaMethod(ft: Type, tt: Type, spec: IrSpec, rnorm: TypeNorm) -> RaMethod {
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			var m = spec.asMethod();
+			printWrapExtra().put3("genWrappedFunctionRaMethod: method %q{%d/%d} not found",
+					      spec.render, m.index, m.uid).outln();
+		}
+		var nspec = getWrappedFunction(ft, tt, spec);
+		if (nspec == null) nspec = genWrappedFunction(ft, tt, spec, rnorm);
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			printWrapExtra().put1("genWrappedFunctionRaMethod: nspec null %z", nspec == null).outln();
+		}
+		var rm = makeMethod(nspec.typeArgs, nspec.asMethod(), nspec);
+		if (!rm.setFact(RaFact.RM_LIVE)) {
+			if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+				printWrapExtra().put1("genWrappedFunctionRaMethod: adding orig %q to liveMethods", rm.orig.render).outln();
+			}
+			liveMethods.put(rm);
+		}
+		var raSpec = rm.getSpec();
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			var m = spec.asMethod();
+			printWrapExtra().put3("genWrappedFunctionRaMethod: returning %q{%d/%d",
+					      raSpec.render, raSpec.asMethod().index, raSpec.asMethod().uid)
+					.put1("/%d}", rm.uid)
+					.put3(" nspec %q{%d/%d}", nspec.render,
+					      nspec.asMethod().index, nspec.asMethod().uid).outln();
+		}
+		return rm;
+	}
+	// obtains a wrapper for a function and return the IrSpec for the RaMethod for that wrapper
+	def genWrappedFunctionRASpec(ft: Type, tt: Type, spec: IrSpec) -> IrSpec {
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			var m = spec.asMethod();
+			printWrapExtra().put3("genWrappedFunctionRASpec: method %q{%d/%d}",
+					      spec.render, m.index, m.uid).outln();
+		}
+		var rm = genWrappedFunctionRaMethod(ft, tt, spec, null);
+		var raSpec = rm.getSpec();
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			var m = spec.asMethod();
+			printWrapExtra().put3("genWrappedFunctionRASpec: returning %q{%d/%d",
+					      raSpec.render, raSpec.asMethod().index, raSpec.asMethod().uid)
+					.put1("/%d}", rm.uid).outln();
+		}
+		return raSpec;
+	}
+	def getMapper(ft: Type, tt: Type) -> IrSpec {
+		var ftCanon = Function.funcRefType(ft);
+		var ttCanon = Function.funcRefType(tt);
+		if (!wrappedFunctionTypeMapper.has((ftCanon, ttCanon))) {
+			if (CLOptions.PRINT_WRAP.get()) {
+				printWrap().put2("getMapper: ft %q  tt %q  mapper not found", ft.render, tt.render).outln();
+			}
+			return null;
+		}
+		var mapper = wrappedFunctionTypeMapper[(ftCanon, ttCanon)];
+		if (CLOptions.PRINT_WRAP.get()) {
+			printWrap().put3("getMapper: ft %q  tt %q  mapper %q", ft.render, tt.render, mapper.render).outln();
+		}
+		return mapper;
+	}
+	def requestUnmapper(t: Type) {
+		var canon = Function.funcRefType(t);
+		if (!unmapperRequests.has(canon)) {
+			if (CLOptions.PRINT_WRAP.get()) {
+				printWrap().put1("requestUnmapper: adding request for t %q", canon.render).outln();
+			}
+			unmapperRequests[canon] = ();
+			unmapperRequestsVec.put(canon);
+		}
+	}
+	def getUnmapper(t: Type) -> IrSpec {
+		var canon = Function.funcRefType(t);
+		if (!unmapper.has(canon)) {
+			if (CLOptions.PRINT_WRAP.get()) {
+				printWrap().put1("getUnmapper: unmapper for %q not found", t.render).outln();
+			}
+			return null;
+		}
+		var um = unmapper[canon];
+		if (CLOptions.PRINT_WRAP.get()) {
+			printWrap().put2("getUnmapper: unmapper for %q is %q", t.render, um.render).outln();
+		}
+		return um;
+	}
+	def getFuncTypeCast(op: SsaInstr, ft: Type, tt: Type) {
+		if (!compiler.NormConfig.WrapFuncTypeSubsume) return;
+		if (ft == tt) return;
+		if (CLOptions.PRINT_WRAP.get()) {
+			if (op == null) {
+				printWrap().put2("getFuncTypeCast: ft %q  tt %q  op null", ft.render, tt.render).outln();
+			} else {
+				printWrap().put3("getFuncTypeCast: ft %q  tt %q  op.getType() %q", ft.render, tt.render, op.getType().render).outln();
+			}
+		}
+		var cast = TypeSystem.newTypeCast(ft, tt);
+		if (CLOptions.PRINT_WRAP.get()) {
+			printWrap().put1("getFuncTypeCast: cast is %s", cast.name);
+			if (op != null) Terminal.buf.put1("  is SsaConst %z", SsaConst.?(op));
+			Terminal.buf.outln();
+		}
+		if (cast != TypeCast.UNKNOWN_CAST && SsaConst.?(op)) {
+			var sc = SsaConst.!(op);
+			var r = Eval.doCast(cast, ft, tt, sc.val);
+			if (r.0) {
+				var val = sc.val;
+				var fv = FuncVal.!(val);
+				var spec = fv.memberRef;
+				genWrappedFunctionRaMethod(ft, tt, spec, null);
+			}
+			return;
+		}
+		if (cast == TypeCast.TRUE) {
+			// make a reasonable effort to find a constant and avoid a mapper
+			var arg = op;
+			if (SsaApplyOp.?(op)) {
+				if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+					printWrapExtra().puts("getFuncTypeCast: op is SsaApplyop").outln();
+				}
+				var apply = SsaApplyOp.!(op);
+				arg = op.inputs[0].getDest();
+				if (tt == arg.getType()) return;  // no-work subsume
+				if (SsaApplyOp.?(arg)) {
+					if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+						printWrapExtra().puts("getFuncTypeCast: first arg is SsaApplyOp").outln();
+					}
+					var sa = SsaApplyOp.!(arg);
+					if (Opcode.CreateClosure.?(sa.op.opcode)) {
+						if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+							printWrapExtra().puts("getFuncTypeCast: first arg is CreateClosure").outln();
+						}
+						var opcode = Opcode.CreateClosure.!(sa.op.opcode);
+						var meth = opcode.method;
+						var spec = V3Op.extractIrSpec(sa.op, opcode.method);
+						genWrappedFunctionRaMethod(ft, tt, spec, null);
+						return;
+					}
+				}
+			}
+			if (tt == arg.getType()) return;  // no-work subsume
+			prog.requestMapper(ft, tt);
+		}
+	}
+	def getTypeCast(op: SsaInstr, ft: Type, tt: Type) {
+		match (tt.typeCon.kind) {
+			TUPLE => {
+				var fts = Tuple.toTypeArray(ft), tts = Tuple.toTypeArray(tt);
+				if (fts.length != tts.length) return;  // cast will always fail
+				for (i < fts.length) getTypeCast(op, fts[i], tts[i]);
+			}
+			FUNCREF, CLOSURE => getFuncTypeCast(op, ft, tt);
 			_ => ;
 		}
 	}
@@ -386,6 +826,24 @@ class ReachabilityAnalyzer(compilation: Compilation) {
 			_ => for (l = t.nested; l != null; l = l.tail) getEquality(l.head, context);
 		}
 	}
+	// analyze a reference equality comparison
+	def getRefEquality(op: SsaApplyOp, t: Type, context: IrSpec) {
+		if (compiler.NormConfig.WrapFuncTypeSubsume &&
+		    (t.typeCon.kind == Kind.CLOSURE || t.typeCon.kind == Kind.FUNCREF)) {
+			var x = op.inputs[0].dest;
+			var y = op.inputs[1].dest;
+			var xconst = SsaConst.?(x);
+			var yconst = SsaConst.?(y);
+			// Two known functions can be compared at compile time
+			// so do not need a run-time unmapper
+			if (xconst && yconst) { }
+			// Comparison with null does not require unmapping
+			else if (xconst && (SsaConst.!(x).val == null)) { }
+			else if (yconst && (SsaConst.!(y).val == null)) { }
+			else requestUnmapper(t);
+		}
+		getEquality(t, context);
+	}
 	// analyze an access of a field
 	def analyzeGetField(receiver: RaClass, rf: RaField) {
 		for (t = receiver.subtypes; t != null; t = t.tail) { // for all live subtypes
@@ -408,6 +866,55 @@ class ReachabilityAnalyzer(compilation: Compilation) {
 		var rc = makeClass(rm.receiver);
 		for (l = rc.subtypes; l != null; l = l.tail) {
 			analyzeVirtual(l.head, rm);
+		}
+	}
+	private def flattenTypes(input: Array<Type>, context: IrSpec) -> Vector<Type> {
+		var flat = Vector<Type>.new();
+		var stack = ArrayStack<Type>.new();
+		for (i = input.length; --i >= 0; ) {
+			var typ = input[i];
+			if (context != null) typ = context.instantiateType(typ);
+			stack.push(typ);
+		}
+		while (!stack.empty()) {
+			var types = Tuple.toTypeArray(stack.pop());
+			match (types.length) {
+				0 => continue;
+				1 => {
+					if (types[0] == Void.TYPE) continue;
+					flat.put(types[0]);
+				}
+				_ => {
+					for (i = types.length; --i >= 0; ) stack.push(types[i]);
+				}
+			}
+		}
+		return flat;
+	}
+	def getCall(rm: RaMethod, op: SsaApplyOp, context: IrSpec) {
+		if (true) return;
+		var mtype = FuncType.!(rm.spec.getBoundType());
+		var sig = mtype.sig();
+		var atype = FuncType.!(op.op.sig.funcType());
+		var asig = atype.sig();
+		// flatten tuple types
+		def flatParams = flattenTypes(sig.paramTypes, rm.spec);
+		def argTypes = asig.paramTypes;
+		def flatArgs = flattenTypes(argTypes, context);
+		def offset = flatParams.length - flatArgs.length;
+		for (i < flatParams.length) {
+			var paramType = flatParams[i];
+			var argType = flatArgs[i];
+			if (argType == paramType || argType == null) continue;
+			getTypeCast(null, argType, paramType);
+		}
+		var callTypes = flattenTypes([op.getType()], context);
+		var retTypes = flattenTypes(sig.returnTypes, context);
+		for (i < retTypes.length) {
+			var returnType = retTypes[i];
+			var callType = callTypes[i];
+			if (callType == returnType || callType == null) continue;
+			getTypeCast(null, returnType, callType);
 		}
 	}
 	def getMethod(op: SsaApplyOp, rm: RaMethod) {
@@ -545,7 +1052,14 @@ class ReachabilityAnalyzer(compilation: Compilation) {
 	}
 	def opMethod(op: SsaApplyOp, m: IrMethod, context: IrSpec) -> RaMethod {
 		if (m == null) return null;
-		return makeMethod(op.op.typeArgs, m, context);
+		var rm = makeMethod(op.op.typeArgs, m, context);
+		if (rm != null && compiler.NormConfig.WrapFuncTypeSubsume) {
+			match (op.op.opcode) {
+				CallMethod, CallClassMethod => getCall(rm, op, context);
+				_ => ;
+			}
+		}
+		return rm;
 	}
 	def makeMethod(typeArgs: Array<Type>, m: IrMethod, context: IrSpec) -> RaMethod {
 		var rm = m.raMethod;
@@ -709,6 +1223,34 @@ class RaClass extends RaType {
 	def findRaMethod(rm: RaMethod) -> RaMethod {
 		return findMethod(rm.orig.index, if(rm.spec == null, MONO_TYPEARGS, rm.spec.typeArgs));
 	}
+	def replaceRaMethod(rm: RaMethod, rmNew: RaMethod) {
+		var index = rm.orig.index;
+		var typeArgs = if(rm.spec == null, MONO_TYPEARGS, rm.spec.typeArgs);
+		if (index >= methods.length) return;
+		var prevs: List<RaMethod>;
+		for (l = methods[index]; l != null; l = l.tail) {
+			if (l.head == rm) {
+				var newList = List<RaMethod>.new(rmNew, l.tail);
+				while (prevs != null) {
+					newList = List<RaMethod>.new(prevs.head, newList);
+					prevs = prevs.tail;
+				}
+				methods[index] = newList;
+				return;
+			}
+			prevs = List<RaMethod>.new(l.head, prevs);
+		}
+		if (parent == null) return;
+		parent.replaceRaMethod(rm, rmNew);
+	}
+	def findNormedMethod(meth: IrMethod) -> RaMethod {
+		for (i < methods.length) {
+			for (l = methods[i]; l != null; l = l.tail) {
+				if (l.head.norm == meth) return l.head;
+			}
+		}
+		return null;
+	}
 	def compareTypeArgs(rm: RaMethod, typeArgs: Array<Type>) -> bool {
 		if (rm.spec == null) return typeArgs.length == 1;
 		var mtypeArgs = rm.spec.typeArgs;
@@ -786,6 +1328,9 @@ class RaField(receiver: Type, orig: IrField, fieldType: Type) extends RaItem {
 		return if(fieldType == null, orig.fieldType, fieldType);
 	}
 }
+component RaMethods {
+	var uid = 0;
+}
 // Information about a method, including any specialization, whether it is reusable
 // across normalization, etc.
 class RaMethod(receiver: Type, orig: IrMethod, spec: IrSpec) extends RaItem {
@@ -794,6 +1339,7 @@ class RaMethod(receiver: Type, orig: IrMethod, spec: IrSpec) extends RaItem {
 	var normIndex = -1;
 	var virtual: RaVirtual;
 	private var cachedSpec: IrSpec;
+	def uid = RaMethods.uid++;
 
 	def getSpec() -> IrSpec {
 		if (cachedSpec != null) return cachedSpec;
@@ -898,7 +1444,7 @@ class VariantComparatorGen(context: SsaContext, root: IrClass, receiver: IrClass
 			b.addIf(cmp, eqTag, falseBlock);
 			b = newBuilder(eqTag);
 		}
-		p1 = b.opTypeSubsume(root.ctype, receiver.ctype, p1); // safe cast
+		p1 = b.opTypeSubsume0(root.ctype, receiver.ctype, p1, null); // safe cast
 		p1.setFact(Fact.O_NO_NULL_CHECK | Fact.V_NON_ZERO);
 		genFieldComparisons(b, falseBlock);
 	}

--- a/aeneas/src/ir/SsaNormalizer.v3
+++ b/aeneas/src/ir/SsaNormalizer.v3
@@ -2,6 +2,8 @@
 // Copyright 2020 Ben L. Titzer. All rights reserved.
 // See LICENSE for details of Apache 2.0 license.
 
+def printWrap() -> TerminalBuffer { return Reachability.printWrap(); }
+
 // Normalizes SSA code by performing polymorphic specialization and expanding all
 // tuples. Note that SSA form supports returns with multiple values.
 class SsaRaNormalizer extends SsaRebuilder {
@@ -131,8 +133,8 @@ class SsaRaNormalizer extends SsaRebuilder {
 		params.put(i_new);
 		map1(i_old, i_new);
 	}
-	def genSimpleVal(tn: TypeNorm, v: Val) -> Val {
-		return norm.normSimpleVal(tn, v);
+	def genSimpleVal(tn: TypeNorm, t: Type, v: Val) -> Val {
+		return norm.normSimpleVal(tn, t, v);
 	}
 	def genValN(i_old: SsaConst, tn: TypeNorm, vec: Vector<SsaInstr>) {
 		vec.puta(mapValueN(i_old, i_old.val, tn));
@@ -142,7 +144,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 		if (tn.sub == null) {
 			// simple normalization
 			if (tn.size == 0) map0(i_old); // void
-			else map1(i_old, val = newGraph.valConst(tn.newType, norm.normSimpleVal(tn, v)));
+			else map1(i_old, val = newGraph.valConst(tn.newType, norm.normSimpleVal(tn, null, v)));
 		} else {
 			// complex normalization
 			mapValueN(i_old, v, tn);
@@ -252,6 +254,10 @@ class SsaRaNormalizer extends SsaRebuilder {
 				var t = extractMethodRef(orig, method), funcNorm = t.0, m = t.1;
 				var newOp = V3Op.newCallMethod(m);
 				var ai_new = normArgs(funcNorm, genRefs(i_old.inputs));
+				if (method.facts.M_NORM && V3.isComponent(method.receiver)) {
+					// add back void for component
+					ai_new = Arrays.prepend(context.graph.nullConst(m.receiver), ai_new);
+				}
 				if (V3.isVariant(rc.oldType)) {
 					if (rc.isUnboxed()) {
 						// flattened data type becomes component call and needs new receiver
@@ -264,6 +270,10 @@ class SsaRaNormalizer extends SsaRebuilder {
 				var t = extractMethodRef(orig, method), funcNorm = t.0, m = t.1;
 				var newOp = V3Op.newCallClassMethod(m);
 				var ai_new = normArgs(funcNorm, genRefs(i_old.inputs));
+				if (method.facts.M_NORM && V3.isComponent(method.receiver)) {
+					// add back void for component
+					ai_new = Arrays.prepend(context.graph.nop(), ai_new);
+				}
 				var i = normCall(i_old, funcNorm, newOp, ai_new);
 				if (ai_new[0].facts.V_NON_ZERO) i.setFact(Fact.O_NO_NULL_CHECK);
 			}
@@ -612,6 +622,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 			var ovfRets = Arrays.range(vals, maxR, vals.length);
 			vals = Arrays.range(vals, 0, maxR);
 			var funcNorm = normFuncType(context.method.sig.funcType());
+			var ftype = context.method.sig.funcType();
 			var nullConst = newGraph.nullConst(funcNorm.ovfReturnFields[0].receiver);
 			for (i < ovfRets.length) {
 				curBlock.opComponentSetField(funcNorm.ovfReturnFields[i], nullConst, ovfRets[i]);
@@ -636,7 +647,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 			var nullConst = newGraph.nullConst(funcNorm.ovfReturnFields[0].receiver);
 			for (i < funcNorm.ovfReturnTypes.length) {
 				var load = curBlock.opGetField(funcNorm.ovfReturnFields[i], nullConst);
-				var cast = curBlock.opTypeSubsume(funcNorm.ovfReturnFields[i].getFieldType(), funcNorm.ovfReturnTypes[i], load);
+				var cast = curBlock.opTypeSubsume0(funcNorm.ovfReturnFields[i].getFieldType(), funcNorm.ovfReturnTypes[i], load, norm.ra);
 				rvals.put(cast);
 			}
 			mapN(i_old, rvals.extract());
@@ -663,7 +674,8 @@ class SsaRaNormalizer extends SsaRebuilder {
 		var atn = normTypeArg(op, 0), rtn = normTypeArg(op, 1);
 		if (rtn.sub == null) {
 			// common case 1-1 mapping
-			return map1(i_old, curBlock.opTypeSubsume(atn.newType, rtn.newType, genRef1(i_old.inputs[0])));
+			var i_new = curBlock.opTypeSubsume0(atn.newType, rtn.newType, genRef1(i_old.inputs[0]), norm.ra);
+			return map1(i_old, i_new);
 		}
 		var width = rtn.size;
 		if (width > 0) {
@@ -672,7 +684,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 			var vals = Array<SsaInstr>.new(width);
 			for (i < width) {
 				var ft = if(atn.sub == null, atn.newType, atn.sub[i]);
-				vals[i] = curBlock.opTypeSubsume(ft, rtn.sub[i], ai_new[i]);
+				vals[i] = curBlock.opTypeSubsume0(ft, rtn.sub[i], ai_new[i], norm.ra);
 			}
 			mapNnf(i_old, vals);
 		}
@@ -689,6 +701,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 	}
 	def normEqual1(i_old: SsaApplyOp, t: Type, x: SsaInstr, y: SsaInstr) -> SsaInstr {
 		if (V3.isVariant(t)) return normVariantEqual(i_old, t, x, y);
+		if (t.typeCon.kind == Kind.FUNCREF) return normSimpleEqualOp0(i_old, null, t, x, y);
 		return curBlock.opEqual(t, x, y);
 	}
 	def normEqual(i_old: SsaApplyOp, tn: TypeNorm, refs: Array<SsaInstr>) -> SsaInstr {
@@ -702,10 +715,86 @@ class SsaRaNormalizer extends SsaRebuilder {
 		}
 		return expr;
 	}
+	private def getWrappee(x: SsaInstr, val: Val) -> SsaInstr {
+		if (FuncVal.?(val)) {
+			var spec = FuncVal.!(val).memberRef;
+			if (spec.asMethod().facts.M_WRAPPER) {
+				var wrappee = spec;
+				while (norm.ra.wrappeeForWrapper.has(wrappee))
+					wrappee = norm.ra.wrappeeForWrapper[wrappee];
+				if (CLOptions.PRINT_WRAP.get()) {
+					printWrap().put3("substituting wrappee %q{%d/%d}", wrappee.render,
+							 wrappee.asMethod().index, wrappee.asMethod().uid)
+						   .put3(" for %q{%d/%d}", spec.render, spec.asMethod().index, spec.asMethod().uid).outln();
+				}
+				return funcRef(wrappee);
+			}
+		}
+		return x;
+	}
+	def normSimpleEqualOp0(i_old: SsaApplyOp, op: Operator, t: Type, x: SsaInstr, y: SsaInstr) -> SsaInstr {
+		if (norm.config.WrapFuncTypeSubsume&&
+		    t.typeCon.kind == Kind.FUNCREF &&
+		    (norm.context.method.facts & Facts.M_MAP_UNMAP) == Facts.NONE) {
+			if (CLOptions.PRINT_WRAP.get()) {
+				printWrap().put1("normalizing function comparison @%d", i_old.uid).outln();
+				SsaPrinter.new().printInstrLn(x).printInstrLn(y).buf.outln();
+			}
+			// unmap any constant arguments
+			var xconst = SsaConst.?(x);
+			var xval = if(xconst, SsaConst.!(x).val, null);
+			var xnull = xconst && xval == null;
+
+			var yconst = SsaConst.?(y);
+			var yval = if(yconst, SsaConst.!(y).val, null);
+			var ynull = yconst && yval == null;
+
+			if (xconst && !xnull) x = getWrappee(x, xval);
+			if (yconst && !ynull) y = getWrappee(y, yval);
+
+			var unmapper: IrSpec;
+			// Two known functions do not need a run-time unmapper
+			if (xconst && yconst) {
+				if (CLOptions.PRINT_WRAP.get()) {
+					printWrap().puts("Comparing two known functions, no unmapper needed");
+				}
+			}
+			// Comparison with null does not require unmapping
+			else if (xnull || ynull) {
+				if (CLOptions.PRINT_WRAP.get()) {
+					printWrap().puts("Comparing with null, no unmapper needed");
+				}
+			}
+			else if ((unmapper = norm.ra.getUnmapper(t)) != null) {
+				// insert unmapping for non-const argument(s)
+				// (if unmapper is null, unmapping is not needed for this type)
+				if (!xconst) {
+					if (CLOptions.PRINT_WRAP.get()) {
+						printWrap().puts("first comparand needs unmapping");
+					}
+					var op = V3Op.newCallMethod(unmapper);
+					var args = [curBlock.graph.nullReceiver(), x];
+					x = curBlock.addApply(null, op, args);
+				}
+				if (!yconst) {
+					if (CLOptions.PRINT_WRAP.get()) {
+						printWrap().puts("second comparand needs unmapping");
+					}
+					var op = V3Op.newCallMethod(unmapper);
+					var args = [curBlock.graph.nullReceiver(), y];
+					y = curBlock.addApply(null, op, args);
+				}
+				return curBlock.opEqualOf(V3Op.newRefEq(AnyFunction.TYPE), x, y);
+			}
+		}
+		if (op == null) op = V3Op.newEqual(t);
+		return curBlock.opEqualOf(op, x, y);
+	}
 	def normSimpleEqualOp(i_old: SsaApplyOp, op: Operator) {
 		var refs = genRefs(i_old.inputs);
-		var tn = normTypeArg(op, 0), size = if(tn == null, 1, tn.size);
-		return map1(i_old, curBlock.opEqualOf(op, refs[0], refs[size]));
+		var tn = normTypeArg(op, 0);
+		var i_new = normSimpleEqualOp0(i_old, op, tn.newType, refs[0], refs[tn.size]);
+		return map1(i_old, i_new);
 	}
 	def normVariantEqual(i_old: SsaApplyOp, t: Type, x: SsaInstr, y: SsaInstr) -> SsaInstr {
 		var rc = norm.ra.getClass(t);
@@ -721,6 +810,11 @@ class SsaRaNormalizer extends SsaRebuilder {
 		if (t.1) {
 			newOp = V3Op.newCallVariantSelector(m);
 		} else {
+			if (tn.newType != m.receiver) {
+				// for some targets, the type must match
+				var subsumeOp = V3Op.newTypeSubsume(tn.newType, m.receiver);
+				x = curBlock.addApply(i_old.source, subsumeOp, [x]);
+			}
 			newOp = V3Op.newCallMethod(m);
 			facts |= Fact.O_NO_NULL_CHECK;
 		}
@@ -804,12 +898,34 @@ class SsaRaNormalizer extends SsaRebuilder {
 	def normTypeCastRec(ai_old: Array<SsaInstr>, offset: int, atn: TypeNorm, rtn: TypeNorm, result: Vector<SsaInstr>) {
 		match (TypeSystem.newTypeCast(atn.oldType, rtn.oldType)) {
 			TRUE => {
+				if (atn != rtn && FuncType.?(atn.oldType) && context.compiler.NormConfig.WrapFuncTypeSubsume) {
+					// Leave incoming function type as un-normalized FuncRef type so that mapping works
+					if (atn.sub == null) result.put(curBlock.opNormFuncTypeSubsume(atn.oldType, rtn.oldType, atn.newType, rtn.newType, ai_old[offset], norm.ra));
+					else for (i < rtn.size) {
+						if (FuncType.?(atn.sub[i])) {
+							result.put(curBlock.opNormFuncTypeSubsume(atn.oldType, rtn.oldType, atn.sub[i], rtn.sub[i], ai_old[offset + i], norm.ra));
+						} else {
+							result.put(curBlock.opTypeSubsume0(atn.sub[i], rtn.sub[i], ai_old[offset + i], norm.ra));
+						}
+					}
+					return;
+				}
+				if (atn != rtn && context.compiler.NormConfig.ExplicitRefTypeCast) {
+					match (atn.oldType.typeCon.kind) {
+						ARRAY, CLASS, VARIANT, ANYREF => {
+							// assumes rtn.size is 1
+							result.put(curBlock.opTypeCast0(atn.newType, rtn.newType, ai_old[offset], norm.ra));
+							return;
+						}
+						_ => ;
+					}
+				}
 				for (i < rtn.size) result.put(ai_old[offset + i]);
 				return;
 			}
 			SUBSUME => {
-				if (atn.sub == null) result.put(curBlock.opTypeSubsume(atn.newType, rtn.newType, ai_old[offset]));
-				else for (i < rtn.size) result.put(curBlock.opTypeSubsume(atn.sub[i], rtn.sub[i], ai_old[offset + i]));
+				if (atn.sub == null) result.put(curBlock.opTypeSubsume0(atn.newType, rtn.newType, ai_old[offset], norm.ra));
+				else for (i < rtn.size) result.put(curBlock.opTypeSubsume0(atn.sub[i], rtn.sub[i], ai_old[offset + i], norm.ra));
 				return;
 			}
 			TUPLE_CAST => {
@@ -866,9 +982,9 @@ class SsaRaNormalizer extends SsaRebuilder {
 			_ => ; // break
 		}
 		if (atn.size > 1) {
-			for (i < atn.size) result.put(curBlock.opTypeCast(atn.sub[i], rtn.sub[i], ai_old[offset + i]));
+			for (i < atn.size) result.put(curBlock.opTypeCast0(atn.sub[i], rtn.sub[i], ai_old[offset + i], norm.ra));
 		} else {
-			result.put(curBlock.opTypeCast(atn.newType, rtn.newType, ai_old[offset]));
+			result.put(curBlock.opTypeCast0(atn.newType, rtn.newType, ai_old[offset], norm.ra));
 		}
 	}
 	def normTypeCast(i_old: SsaApplyOp, op: Operator) {
@@ -1429,7 +1545,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 			}
 		}
 		if (newType == AnyRef.TYPE) return i_scalar;
-		return curBlock.opTypeSubsume(oldType, newType, i_scalar);
+		return curBlock.opTypeSubsume0(oldType, newType, i_scalar, norm.ra);
 	}
 	def normVariantAlloc(i_old: SsaInstr, op: Operator) {
 		var ai_inputs = genRefs(i_old.inputs);

--- a/aeneas/src/ir/TypeNorm.v3
+++ b/aeneas/src/ir/TypeNorm.v3
@@ -83,6 +83,22 @@ class ArrayNorm extends TypeNorm {
 	def isMixed() -> bool {
 		return enorm != null && enorm.size > 1;
 	}
+	def render(buf: StringBuilder) -> StringBuilder {
+		buf.put3("%q ## %q |%d|", oldType.render, newType.render, size);
+		if (sub != null) {
+			buf.puts(" [");
+			for (i < sub.length) {
+				if (i > 0) buf.csp();
+				sub[i].render(buf);
+			}
+			buf.puts("]");
+		}
+		buf.put1(" primitive: %z", primitive);
+		if (enorm != null) {
+			buf.put1(" enorm: %q", enorm);
+		}
+		return buf;
+	}
 }
 // Ranges are normalized to a tuple. This class caches the array norm as well.
 class RangeNorm extends TypeNorm {
@@ -116,6 +132,34 @@ class FuncNorm extends TypeNorm {
 		super(oldType, newType, sub) { }
 	def sig() -> Signature {
 		return FuncType.!(sub[0]).sig();
+	}
+	def render(buf: StringBuilder) -> StringBuilder {
+		buf.put3("%q ## %q |%d|", oldType.render, newType.render, size);
+		if (sub != null) {
+			buf.puts(" [");
+			for (i < sub.length) {
+				if (i > 0) buf.csp();
+				sub[i].render(buf);
+			}
+			buf.puts("]");
+		}
+		if (ovfParamTypes != null && ovfParamTypes.length > 0) {
+			buf.puts(" ovf params[");
+			for (i < ovfParamTypes.length) {
+				if (i > 0) buf.csp();
+				ovfParamTypes[i].render(buf);
+			}
+			buf.puts("]");
+		}
+		if (ovfReturnTypes != null && ovfReturnTypes.length > 0) {
+			buf.puts(" ovf returns[");
+			for (i < ovfReturnTypes.length) {
+				if (i > 0) buf.csp();
+				ovfReturnTypes[i].render(buf);
+			}
+			buf.puts("]");
+		}
+		return buf;
 	}
 }
 // A flattened sequence of types.

--- a/aeneas/src/jvm/JvmTarget.v3
+++ b/aeneas/src/jvm/JvmTarget.v3
@@ -34,8 +34,10 @@ class JvmTarget extends Target {
 		norm.MixedArrays = false;
 		norm.NonRefClosureReceiver = false;
 		norm.NormalizeRange = false;
-//		norm.setSignatureLimits(10000, 1);
+//		norm.setSignatureLimits(10000, 10000);
+		norm.MaxReturnValues = 10000;
 		norm.GetScalar = getScalar;
+		norm.WrapFuncTypeSubsume = true;
 	}
 	private def isRefType(t: Type) -> bool {
 		match (t) {

--- a/aeneas/src/jvm/SsaJvmGen.v3
+++ b/aeneas/src/jvm/SsaJvmGen.v3
@@ -152,7 +152,12 @@ class SsaJvmGen(jprog: JvmProgram, context: SsaContext, jsig: JvmSig, code: JvmC
 				if (tt.width > 32) { lcmp = true; op = JvmBytecode.IFEQ; }
 				else op = JvmBytecode.IF_ICMPEQ;
 			}
-			RefEq => op = JvmBytecode.IF_ACMPEQ;
+			RefEq => {
+				match (i.op.typeArgs[0].typeCon.kind) {
+					FUNCREF, ANYFUNC, CLOSURE => ;
+					_ => op = JvmBytecode.IF_ACMPEQ;
+				}
+			}
 			IntLt => {
 				var t = i.op.sig.paramTypes[0];
 				match (IntType.!(t).rank) {
@@ -380,7 +385,9 @@ class SsaJvmGen(jprog: JvmProgram, context: SsaContext, jsig: JvmSig, code: JvmC
 			}
 			RefEq => {
 				var t = op.typeArgs[0];
-				if (t.typeCon.kind == Kind.FUNCREF) {
+				if (t.typeCon.kind == Kind.FUNCREF ||
+				    t.typeCon.kind == Kind.ANYFUNC ||
+				    t.typeCon.kind == Kind.CLOSURE) {
 					code.invokesystem("equals", JvmTypes.SIG_EQUALS);
 				} else {
 					branchValue(JvmBytecode.IF_ACMPEQ);

--- a/aeneas/src/mach/MachBackend.v3
+++ b/aeneas/src/mach/MachBackend.v3
@@ -971,7 +971,7 @@ class SsaMachGen(context: SsaContext, mach: MachProgram, regSet: MachRegSet, w: 
 		match (o) {
 			Use(vreg, constraint) => return vreg;
 			Def(vreg, constraint) => return vreg;
-			_ => context.fail("expected immediate");
+			_ => context.fail("expected vreg");
 		}
 		return null;
 	}

--- a/aeneas/src/mach/MachLowering.v3
+++ b/aeneas/src/mach/MachLowering.v3
@@ -12,6 +12,7 @@ enum ArithWidth(subword: bool, width: byte) {
 	Exactly64(false, 64)
 }
 class MachLoweringConfig {
+	var MachLoweringFactory = MachLowering.new;	// supprots subclassing
 	var IntDivZeroTraps = true;	 // int division traps on zero
 	var IntDivOverflowMinint = true; // int division overflow is minint
 	var Int8Arith = false;		 // native support for int8 arithmetic
@@ -273,7 +274,8 @@ class SsaGraphNormalizer(context: SsaContext) {
 // Lowers Virgil code to machine level in-place by replacing object-level operations
 // with loads and stores. Introduces truncations and wrapping for integer operations
 // according to the {config}.
-class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringConfig) extends SsaGraphNormalizer(SsaContext.new(compiler, mach.prog)) {
+class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringConfig) extends SsaGraphNormalizer {
+	new() super(SsaContext.new(compiler, mach.prog)) { }
 	var maybeDead: List<SsaInstr>;
 	def doMethod(method: IrMethod) {
 		context.enterMethod(method);
@@ -439,6 +441,10 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		return mach.intNorm.normType(t);
 	}
 	def genApplyOp(i_old: SsaApplyOp) {
+		// coded so that subclass can selectively override what this does and then call genApplyOp0
+		genApplyOp0(i_old);
+	}
+	def genApplyOp0(i_old: SsaApplyOp) {
 		var i_new: SsaInstr;
 		match(i_old.op.opcode) {
 			// Simple operators require no conversion other than normalization
@@ -540,11 +546,7 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 			CallClassMethod(selector) => 	return genCallClassMethod(i_old, selector);
 			CallClassSelector(selector) => 	return genCallClassSelector(i_old, selector);
 			CallVariantSelector(selector) => 	return genCallVariantSelector(i_old, selector);
-			CallFunction => {
-				var funcRep = mach.getFuncRep(i_old.op.typeArgs[0]);
-				call(i_old, funcRep, normRefs(i_old.inputs));
-				return;
-			}
+			CallFunction => return void(genCallFunction(i_old));
 			VariantGetTag => {
 				var i_obj = normRef1(i_old.inputs[0]);
 				i_new = genIfNull(i_old, i_old.op.sig.returnType(), i_obj, null, genVariantGetTag(i_old, _));
@@ -1381,7 +1383,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		mapN(i_old, normRefs(i_old.inputs));  // always a no-op at the machine level
 	}
 	def genArrayAlloc(i_old: SsaApplyOp) -> SsaInstr {
-		if (config.ObjectSystem) return normId(i_old);
 		var olen = i_old.inputs[0], arrayType = i_old.op.typeArgs[0];
 		var hsize = mach.getArrayElemOffset(arrayType, 0), scale = mach.getArrayElemScale(arrayType);
 		if (SsaConst.?(olen.dest)) {
@@ -1438,7 +1439,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		}
 	}
 	def genArrayInit(i_old: SsaApplyOp) -> SsaInstr {
-		if (config.ObjectSystem) return normId(i_old);
 		var arrayType = i_old.op.typeArgs[0];
 		var offset = mach.getArrayElemOffset(arrayType, 0), scale = mach.getArrayElemScale(arrayType);
 		var narr = genArrayAllocWithSize(i_old.source, arrayType, offset, i_old.inputs.length, scale);
@@ -1453,7 +1453,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		return narr;
 	}
 	def genArrayTupleInit(i_old: SsaApplyOp, elems: int, length: int) -> SsaInstr {
-		if (config.ObjectSystem) return normId(i_old);
 		var arrayType = i_old.op.typeArgs[0];
 		var arrayRep = mach.arrayRep(arrayType);
 		var narr = genArrayAllocWithSize(i_old.source, arrayType, arrayRep.headerSize, length, arrayRep.elemScale);
@@ -1469,7 +1468,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		return narr;
 	}
 	def genArrayGetElem(i_old: SsaApplyOp, elem: int) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var inputs = normRefs(i_old.inputs);
 		var narr = inputs[0], nindex = inputs[1], arrayType = i_old.op.typeArgs[0];
 		var nullity = context.compiler.nullity(i_old, narr);
@@ -1482,7 +1480,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		mapN(i_old, loads);
 	}
 	def genArraySetElem(i_old: SsaApplyOp, elem: int) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var inputs = normRefs(i_old.inputs);
 		var narr = inputs[0], nindex = inputs[1], arrayType = i_old.op.typeArgs[0];
 		var nullity = context.compiler.nullity(i_old, narr);
@@ -1496,7 +1493,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		i_old.remove();
 	}
 	def genNormRangeGetElem(i_old: SsaApplyOp, elem: int) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var inputs = normRefs(i_old.inputs);
 		var narr = inputs[0], rangeStart = inputs[1], nindex = inputs[2], rangeType = i_old.op.typeArgs[0];
 		var arrayRep = mach.arrayRep(rangeType);
@@ -1507,7 +1503,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		mapN(i_old, loads);
 	}
 	def genNormRangeSetElem(i_old: SsaApplyOp, elem: int) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var inputs = normRefs(i_old.inputs);
 		var narr = inputs[0], rangeStart = inputs[1], nindex = inputs[2], rangeType = i_old.op.typeArgs[0];
 		var arrayRep = mach.arrayRep(rangeType);
@@ -1622,13 +1617,11 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		}
 	}
 	def genArrayGetLength(i_old: SsaApplyOp) -> SsaInstr {
-		if (config.ObjectSystem) return normId(i_old);
 		var oarr = i_old.inputs[0], narr = normRef1(oarr);
 		var nullity = context.compiler.nullity(i_old, null);
 		return refLoad(nullity, Int.TYPE, i_old, oarr, narr, mach.getArrayLengthOffset(i_old.op.typeArgs[0]));
 	}
 	def genClassAlloc(i_old: SsaApplyOp, method: IrMethod) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var classType = i_old.getType();
 		var size = mach.getObjectSize(classType, null);
 		// allocate the object
@@ -1647,7 +1640,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		return map1(i_old, nobj);
 	}
 	def genVariantAlloc(i_old: SsaApplyOp) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var classType = i_old.getType();
 		var size = mach.getObjectSize(classType, null);
 		// allocate the object
@@ -1668,7 +1660,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		return map1(i_old, i_new);
 	}
 	def genClassGetField(isVariant: bool, i_old: SsaApplyOp, field: IrField) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var fieldRef = V3Op.extractIrSpec(i_old.op, field);
 		var oobj = i_old.inputs[0], nobj = normRef1(oobj);
 		var machType = mach.machType(fieldRef.getFieldType());
@@ -1703,7 +1694,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		}
 	}
 	def genClassSetField(i_old: SsaApplyOp, field: IrField, init: bool) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var inputs = normRefs(i_old.inputs);
 		var fieldRef = V3Op.extractIrSpec(i_old.op, field), nobj = inputs[0];
 		var offset = mach.classFieldOffset(fieldRef);
@@ -1714,27 +1704,23 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		i_old.remove();
 	}
 	def genClassGetMethod(i_old: SsaApplyOp, method: IrMethod) -> SsaInstr {
-		if (config.ObjectSystem) return normId(i_old);
 		var methodRef = V3Op.extractIrSpec(i_old.op, method);
 		var funcRep = mach.funcRep(methodRef);
 		genNullCheck(i_old);
 		return context.graph.valConst(funcRep.machType, mach.getCodeAddress(methodRef));
 	}
 	def genClassGetSelector(i_old: SsaApplyOp, selector: IrSelector) -> SsaInstr {
-		if (config.ObjectSystem) return normId(i_old);
 		var methodRef = V3Op.extractIrSpec(i_old.op, selector);
 		var funcRep = mach.funcRep(methodRef);
 		var oobj = i_old.inputs[0], nobj = normRef1(oobj);
 		return genMtableLookup(i_old, oobj, nobj, funcRep, methodRef);
 	}
 	def genVariantGetMethod(i_old: SsaApplyOp, method: IrMethod) -> SsaInstr {
-		if (config.ObjectSystem) return normId(i_old);
 		var methodRef = V3Op.extractIrSpec(i_old.op, method);
 		var funcRep = mach.funcRep(methodRef);
 		return context.graph.valConst(funcRep.machType, mach.getCodeAddress(methodRef));
 	}
 	def genVariantGetSelector(i_old: SsaApplyOp, selector: IrSelector) -> SsaInstr {
-		if (config.ObjectSystem) return normId(i_old);
 		var methodRef = V3Op.extractIrSpec(i_old.op, selector);
 		var funcRep = mach.funcRep(methodRef);
 		var oobj = i_old.inputs[0], nobj = normRef1(oobj);
@@ -1749,7 +1735,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		return ptrLoad(funcRep.machType, ptrAdd(mtbl, tid), 0);
 	}
 	def genComponentGetField(i_old: SsaApplyOp, field: IrField) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var fieldRef = V3Op.extractIrSpec(i_old.op, field);
 		var fieldType = mach.machType(fieldRef.getFieldType());
 		var ptr = componentFieldPtr(fieldRef);
@@ -1757,7 +1742,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		mapN(i_old, loads);
 	}
 	def genComponentSetField(i_old: SsaApplyOp, field: IrField) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var fieldRef = V3Op.extractIrSpec(i_old.op, field);
 		var inputs = normRefs(i_old.inputs);
 		var machType = mach.machType(fieldRef.getFieldType());
@@ -1793,7 +1777,10 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 			if (!nullity.O_NO_NULL_CHECK) genNullCheck0(i_old.source, narr);
 			return (context.graph.nullConst(Void.TYPE), nullity | Fact.O_NO_NULL_CHECK);
 		}
-		if (config.ObjectSystem) return (normId(i_old), nullity);
+		return genBoundsCheck0(i_old, nullity, narr);
+	}
+	def genBoundsCheck0(i_old: SsaApplyOp, nullity: Fact.set, narr: SsaInstr) -> (SsaInstr, Fact.set) {
+		var oarr = i_old.inputs[0];
 		// load length
 		// XXX: CSE the array length if possible
 		var len = refLoad(nullity, Int.TYPE, i_old, oarr, narr, mach.getArrayLengthOffset(i_old.op.typeArgs[0]));
@@ -1805,7 +1792,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		return (index, nullity | Fact.O_NO_NULL_CHECK);
 	}
 	def genCallMethod(i_old: SsaApplyOp, method: IrMethod) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var methodRef = V3Op.extractIrSpec(i_old.op, method);
 		var funcRep = mach.funcRep(methodRef);
 		var func = context.graph.valConst(funcRep.machType, mach.getCodeAddress(methodRef));
@@ -1813,7 +1799,6 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		call(i_old, funcRep, args);
 	}
 	def genCallClassMethod(i_old: SsaApplyOp, method: IrMethod) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var methodRef = V3Op.extractIrSpec(i_old.op, method);
 		if (!i_old.facts.O_NO_NULL_CHECK) genNullCheck(i_old);
 		var funcRep = mach.funcRep(methodRef);
@@ -1822,21 +1807,23 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 		call(i_old, funcRep, args);
 	}
 	def genCallClassSelector(i_old: SsaApplyOp, selector: IrSelector) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var func = genClassGetSelector(i_old, selector);
 		var methodRef = V3Op.extractIrSpec(i_old.op, selector);
 		var args = Arrays.prepend(func, normRefs(i_old.inputs));
 		call(i_old, mach.funcRep(methodRef), args);
 	}
 	def genCallVariantSelector(i_old: SsaApplyOp, selector: IrSelector) {
-		if (config.ObjectSystem) return void(normId(i_old));
 		var func = genVariantGetSelector(i_old, selector);
 		var methodRef = V3Op.extractIrSpec(i_old.op, selector);
 		var args = Arrays.prepend(func, normRefs(i_old.inputs));
 		call(i_old, mach.funcRep(methodRef), args);
 	}
+	def genCallFunction(i_old: SsaApplyOp) {
+		var funcRep = mach.getFuncRep(i_old.op.typeArgs[0]);
+		call(i_old, funcRep, normRefs(i_old.inputs));
+		return;
+	}
 	def genVariantGetTag(i_old: SsaApplyOp, nobj: SsaInstr) -> SsaInstr {
-		if (config.ObjectSystem) return normId(i_old);
 		var val = ptrLoad(mach.tagType, nobj, 0);
 		var root = V3.getRootType(i_old.op.typeArgs[0]);
 		var min = mach.classIdRange(root).0;
@@ -1882,7 +1869,7 @@ class MachLowering(mach: MachProgram, compiler: Compiler, config: MachLoweringCo
 
 	def call(i_old: SsaApplyOp, funcRep: Mach_FuncRep, args: Array<SsaInstr>) {
 		if (curBlock.end) return;
-		var i_new = apply(i_old.source, if(config.ObjectSystem, i_old.op, V3Op.newCallAddress(funcRep)), args);
+		var i_new = apply(i_old.source, V3Op.newCallAddress(funcRep), args);
 		i_new.facts = i_new.facts | i_old.facts;
 		var tn = normType(i_old.op.sig.returnType());
 		mapMultiReturn(i_old, i_new, tn);

--- a/aeneas/src/main/Aeneas.v3
+++ b/aeneas/src/main/Aeneas.v3
@@ -7,6 +7,7 @@
 component Aeneas {
 	var targets: List<Target>;
 	var startup: void -> void;
+	var compiler: Compiler;
 
 	def main(args: Array<string>) -> int {
 		args = CLOptions.options.parse(args);
@@ -27,7 +28,7 @@ component Aeneas {
 	def compileMultiple(args: Array<string>) -> bool {
 		var failed = false;
 		var progress = ProgressPrinter.new(args.length);
-		var compiler = Compiler.new(CLOptions.TARGET.get());
+		compiler = Compiler.new(CLOptions.TARGET.get());
 		for (i < args.length) {
 			progress.begin(args[i]);
 			var prog = makeProgram(compiler, [args[i]]);
@@ -76,13 +77,13 @@ component Aeneas {
 		prog.inputs = Array.new(prog.files.length);
 	}
 	def compile(args: Array<string>) -> Program {
-		var compiler = Compiler.new(CLOptions.TARGET.get());
+		compiler = Compiler.new(CLOptions.TARGET.get());
 		var prog = makeProgram(compiler, args);
 		Compilation.new(compiler, prog).compile();
 		return prog;
 	}
 	def compileAndRun(args: Array<string>) -> int {
-		var compiler = Compiler.new(CLOptions.TARGET.get());
+		compiler = Compiler.new(CLOptions.TARGET.get());
 		var prog = makeProgram(compiler, args);
 		var compilation = Compilation.new(compiler, prog);
 		var after: void -> void;

--- a/aeneas/src/main/CLOptions.v3
+++ b/aeneas/src/main/CLOptions.v3
@@ -101,6 +101,10 @@ component CLOptions {
 		"Print register allocation.");
 	def PRINT_PACKING	= debugOpt.newBoolOption("print-packing", false,
 		"Print unboxing and packing information.");
+	def PRINT_WRAP		= debugOpt.newBoolOption("print-wrap", false,
+		"Print function wrapping information");
+	def PRINT_WRAP_EXTRA	= debugOpt.newBoolOption("print-wrap-extra", false,
+		"Print very detailed function wrapping information");
 	def FATAL		= debugOpt.newBoolOption("fatal", false,
 		"Treat program errors as fatal errors and exit with a compiler stacktrace.");
 	def START_UID		= debugOpt.newIntOption("start-uid", 0,
@@ -160,6 +164,8 @@ component CLOptions {
 		"Generate mixed arrays for arrays of tuples, rather than tuples of arrays.");
 	def NR			= sharedOpt.newBoolOption("nr", true,
 		"Normalize ranges using RangeStart's to support off-heap ranges.");
+	def WFTS		= sharedOpt.newBoolOption("wfts", false,
+		"Wrap function type subsumptions.");
 	def SET_EXEC		= compileOpt.newBoolOption("set-exec", true,
 		"Automatically set execute permission for compiled binaries.");
 	def USE_GLOBALREGALLOC	= compileOpt.newMatcherOption("global-regalloc",

--- a/aeneas/src/main/Compiler.v3
+++ b/aeneas/src/main/Compiler.v3
@@ -117,10 +117,16 @@ class Compiler(target: Target) {
 		NormConfig.MaxFlatDataValues		= CLOptions.MAXD.get();
 		NormConfig.MaxFlatVariantValues		= CLOptions.MAXV.get();
 		NormConfig.NonRefClosureReceiver	= true;
-		NormConfig.AnyRefOverflow		= true;
 		NormConfig.NormalizeRange		= CLOptions.NR.get();
+		NormConfig.WrapFuncTypeSubsume		= CLOptions.WFTS.get();
+		NormConfig.AnyRefOverflow		= !CLOptions.WFTS.get();  // turn off when WFTS is on
+		NormConfig.ExplicitRefTypeCast		= CLOptions.WFTS.get();   // turn on when WFTS is on
+		NormConfig.FunctionCallReceiverTypeCast = false;
+
 		// target configures the compiler only once
 		if (target != null) target.configureCompiler(this);
+
+		Aeneas.compiler = this;
 	}
 
 	def getOutputFileName(fileName: string, ext: string) -> string {
@@ -248,6 +254,25 @@ class Compilation(compiler: Compiler, prog: Program) {
 		}
 		return true;
 	}
+	private def printWrappedFunctionTypeInfo(pair: (Type, Type), mapper: IrSpec) {
+		Terminal.buf.purple().puts("Wrapped function type mapper:").end()
+			.put2(" from: %q  to: %q ", pair.0.render, pair.1.render);
+		if (mapper == null) Terminal.put("(null)");
+		else Terminal.put1("%q", mapper.render);
+		Terminal.ln();
+	}
+	private def printFunctionAndWrapped(func: IrSpec, wrapped: IrSpec) {
+		Terminal.buf.purple().puts("    Wrapping:").end()
+			.put1(" orig: %q  to: ", func.asMethod().render);
+		if (wrapped == null) Terminal.put("(null)");
+		else Terminal.put1("%q", wrapped.asMethod().render);
+		Terminal.ln();
+	}
+	private def printWrappedFunctionInfo(pair: (Type, Type), map: PartialMap<IrSpec, IrSpec>) {
+		Terminal.buf.purple().puts("Wrapped function info:").end()
+			.put2(" from: %q  to %q", pair.0.render, pair.1.render).ln();
+		map.apply(printFunctionAndWrapped);
+	}
 	def reachability() -> bool {
 		var main = prog.getMain();
 		if (compiler.target != null) compiler.target.addRoots(compiler, prog);
@@ -255,6 +280,11 @@ class Compilation(compiler: Compiler, prog: Program) {
 		ra.analyze();
 		if (CLOptions.PRINT_RA.get()) ra.dump();
 		ra.transform(compiler.NormConfig);
+		if (CLOptions.PRINT_WRAP.get()) {
+			Terminal.buf.purple().puts("Wrapped functions and function types report:").end().ln();
+			ra.wrappedFunctionWrapper.apply(printWrappedFunctionInfo);
+			ra.wrappedFunctionTypeMapper.apply(printWrappedFunctionTypeInfo);
+		}
 		return prog.ERROR.noErrors;
 	}
 	def emit() -> bool {

--- a/aeneas/src/ssa/SsaBuilder.v3
+++ b/aeneas/src/ssa/SsaBuilder.v3
@@ -12,6 +12,7 @@ def checkNoTypeVars(t: Type) {
 def checkInputs(inputs: Array<SsaInstr>) {
 	for (i in inputs) if (i == null) return V3.fail("null input");
 }
+def printWrapExtra() -> TerminalBuffer { return Reachability.printWrapExtra(); }
 
 def N = Facts.NONE;
 // Support class for constructing SSA instruction-by-instruction.
@@ -450,17 +451,90 @@ class SsaBuilder {
 	}
 	// TypeCast<F, T>(x)
 	def opTypeCast(ft: Type, tt: Type, x: SsaInstr) -> SsaInstr {
+		return opTypeCast0(ft, tt, x, null);
+	}
+	// opTypeCast0 allows indication of whether we are normalizing;
+	// when normalizing, we may request function wrappers / mappers
+	def opTypeCast0(ft: Type, tt: Type, x: SsaInstr, analyzer: ReachabilityAnalyzer) -> SsaInstr {
+		var oldType = ft;
+		if (ft != null && FuncType.?(ft) && context.compiler.NormConfig.WrapFuncTypeSubsume) {
+			ft = x.getType();
+		}
 		if (ft == tt) return x; // fold TypeCast<T, T>
 		if (tt == x.getType()) return x; // fold TypeCast<F, T>(x: T)
-		var cast = TypeSystem.newTypeCast(ft, tt);
+		var cast = TypeSystem.newTypeCast(ft, tt);	
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			printWrapExtra()
+				.put3("opTypeCast0: from %q  to %q  arg %q", ft.render, tt.render, x.getType().render)
+				.put2("  cast %s  analyzer null %z", cast.name, analyzer == null).ln().puts("   ").outt();
+			SsaPrinter.new().printInstrLn(x).flush();
+		}
 		if (cast != TypeCast.UNKNOWN_CAST && SsaConst.?(x)) {
 			var r = Eval.doCast(cast, ft, tt, SsaConst.!(x).val);
-			if (r.0) return graph.valConst(tt, r.1);
+			if (r.0) {
+				if (context.compiler.NormConfig.WrapFuncTypeSubsume) {
+					if (analyzer != null && analyzer.normalizer != null) {
+						match (tt.typeCon.kind) {
+							FUNCREF => {
+								var val = SsaConst.!(x).val;
+								if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+									printWrapExtra()
+										.put1("opTypeCast0: FUNCREF val %q", V3.render(val)).outln();
+								}
+								if (val != null) {
+									var fv = FuncVal.!(val);
+									var spec = fv.memberRef;
+									spec = analyzer.genWrappedFunction(ft, tt, spec, null);
+									return graph.valConst(tt, FuncVal.new(spec));
+								}
+							}
+							CLOSURE => {
+								var val = Closure.!(SsaConst.!(x).val);
+								if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+									printWrapExtra()
+										.put1("opTypeCast0: CLOSURE val %q", V3.render(val)).outln();
+								}
+								if (val != null) {
+									var spec = analyzer.genWrappedFunction(ft, tt, val.memberRef, null);
+									return graph.valConst(tt, Closure.new(val.val, spec));
+								}
+							}
+							_ => ;
+						}
+					} else {
+						return add(V3Op.newTypeCast(ft, tt), [x], x.facts);
+					}
+				}
+				return graph.valConst(tt, r.1);
+			}
 			else return addThrow(source, V3Exception.TypeCheck);
 		}
 
 		match (cast) {
-			TRUE => return x; // fold TypeCast
+			TRUE => {
+				if (cast != TypeCast.UNKNOWN_CAST &&
+				    context.compiler.NormConfig.WrapFuncTypeSubsume) {
+					var kind = tt.typeCon.kind;
+					if (kind == Kind.CLOSURE || (kind == Kind.FUNCREF && analyzer == null)) {
+						// we're early in the process, so request a mapper
+						context.prog.requestMapper(ft, tt);
+						// and insert a TypeCast
+						return add(V3Op.newTypeCast(ft, tt), [x], x.facts);
+					}
+					if (kind == Kind.FUNCREF) {
+						// convert to call to mapper
+						var spec = analyzer.getMapper(ft, tt);
+						var op = V3Op.newCallMethod(spec);
+						var args = [graph.nullReceiver(), x];
+						return addApply(null, op, args);
+					}
+					if (analyzer == null) {
+						// if early in the process, make cast explicit
+						return add(V3Op.newTypeCast(ft, tt), [x], x.facts);
+					}
+				}
+				return x; // fold TypeCast
+			}
 			THROW => {
 				return addThrow(source, V3Exception.TypeCheck); // fold TypeCast
 			}
@@ -493,6 +567,63 @@ class SsaBuilder {
 			}
 			ENUM_TO_SET => {
 				return EnumSetType.!(tt).genEnumToSet(x, this);
+			}
+			_ => {
+				var facts = if(x.facts.V_NON_ZERO, Fact.O_NO_NULL_CHECK, Facts.NONE);
+				return add(V3Op.newTypeCast(ft, tt), [x], facts);
+			}
+		}
+	}
+	def opNormFuncTypeCast(ft: Type, tt: Type, ftn: Type, ttn: Type, x: SsaInstr, analyzer: ReachabilityAnalyzer) -> SsaInstr {
+		if (ft == tt) return x; // fold TypeCast<T, T>
+		var cast = TypeSystem.newTypeCast(ft, tt);
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			printWrapExtra()
+				.put3("opNormFuncTypeCast: from %q  to %q  cast %s", ft.render, tt.render, cast.name).outln();
+		}
+		if (cast != TypeCast.UNKNOWN_CAST && SsaConst.?(x)) {
+			var r = Eval.doCast(cast, ftn, ttn, SsaConst.!(x).val);
+			if (r.0) {
+				match (ttn.typeCon.kind) {
+					FUNCREF => {
+						var val = SsaConst.!(x).val;
+						var fv = FuncVal.!(val);
+						if (fv != null) {
+							var spec = fv.memberRef;
+							spec = analyzer.genWrappedFunction(ft, tt, spec, null);
+							return graph.valConst(ttn, FuncVal.new(spec));
+						}
+					}
+					_ => ;
+				}
+				return graph.valConst(ttn, r.1);
+			}
+			else return addThrow(source, V3Exception.TypeCheck);
+		}
+		match (cast) {
+			TRUE => {
+				if (cast != TypeCast.UNKNOWN_CAST &&
+				    context.compiler.NormConfig.WrapFuncTypeSubsume) {
+					match (ttn.typeCon.kind) {
+						FUNCREF => {
+							var spec = analyzer.getMapper(ft, tt);
+							var op = V3Op.newCallMethod(spec);
+							var args = [graph.nullReceiver(), x];
+							return addApply(null, op, args);
+						}
+						_ => ;
+					}
+				}
+				return x; // fold TypeCast
+			}
+			THROW => {
+				return addThrow(source, V3Exception.TypeCheck); // fold TypeCast
+			}
+			THROW_IF_NOT_NULL => {
+				// TypeCast -> ConditionalThrow(x != null)
+				var cmp = opNotEqual(ft, x, graph.nullConst(ft));
+				opConditionalThrow(V3Exception.TypeCheck, cmp);
+				return graph.nullConst(tt);
 			}
 			_ => {
 				var facts = if(x.facts.V_NON_ZERO, Fact.O_NO_NULL_CHECK, Facts.NONE);
@@ -534,6 +665,19 @@ class SsaBuilder {
 	}
 	// TypeSubsume<F, T>(x)
 	def opTypeSubsume(ft: Type, tt: Type, x: SsaInstr) -> SsaInstr {
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			printWrapExtra()
+				.put2("opTypeSubsume: ft %q  tt %q", ft.render, tt.render).outln();
+		}
+		return opTypeSubsume0(ft, tt, x, null);
+	}
+	// opTypeSubsume0 allows indication of whether we are normalizing;
+	// when normalizing, we may request function wrappers / mappers
+	def opTypeSubsume0(ft: Type, tt: Type, x: SsaInstr, analyzer: ReachabilityAnalyzer) -> SsaInstr {
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			printWrapExtra()
+				.put2("opTypeSubsume0: ft %q  tt %q", ft.render, tt.render).outln();
+		}
  		if (ft == tt) return x; // fold TypeSubsume<T, T>(x)
  		if (tt == x.getType()) return x; // fold TypeSubsume<F, T>(x: T)
 		match (tt.typeCon.kind) {
@@ -542,24 +686,44 @@ class SsaBuilder {
 				if (TypeSystem.isSubtype(ft, tt)) return x; // remove redundant subsume of class
 			}
 			INT => {
-				if (ft.typeCon.kind != Kind.VARIANT && ft.typeCon.kind != Kind.ENUM) return opTypeCast(ft, tt, x);
+				if (ft.typeCon.kind != Kind.VARIANT && ft.typeCon.kind != Kind.ENUM) return opTypeCast0(ft, tt, x, null);
 			}
 			TUPLE => {
-				return opTypeCast(ft, tt, x);
+				return opTypeCast0(ft, tt, x, analyzer);
 			}
 			ENUM_SET => {
 				return EnumSetType.!(tt).genEnumToSet(x, this);
 			}
 			FLOAT => {
-				return opTypeCast(ft, tt, x);
+				return opTypeCast0(ft, tt, x, null);
 			}
 			RANGE => {
-				return opTypeCast(ft, tt, x);
+				return opTypeCast0(ft, tt, x, null);
+			}
+			FUNCREF, CLOSURE => {
+				if (context.compiler.NormConfig.WrapFuncTypeSubsume && ft != Null.TYPE) return opTypeCast0(ft, tt, x, analyzer);
 			}
 			_ => ;
 		}
 		if (SsaConst.?(x)) return graph.valConst(tt, SsaConst.!(x).val); // fold TypeSubsume(K)
  		return add(V3Op.newTypeSubsume(ft, tt), [x], x.facts);
+	}
+	// Version used when function wrapping/mapping may occur
+	def opNormFuncTypeSubsume(ft: Type, tt: Type, ftn: Type, ttn: Type, x: SsaInstr, analyzer: ReachabilityAnalyzer) -> SsaInstr {
+		if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+			printWrapExtra()
+				.put2("opNormFuncTypeSubsume: ft %q  tt %q", ft.render, tt.render)
+				.put2("  ftn %q  ttn %q", ftn.render, ttn.render).outln();
+		}
+ 		if (ft == tt) return x; // fold TypeSubsume<T, T>(x)
+		match (tt.typeCon.kind) {
+			FUNCREF, CLOSURE => {
+				if (ft != Null.TYPE) return opNormFuncTypeCast(ft, tt, ftn, ttn, x, analyzer);
+			}
+			_ => ;
+		}
+		if (SsaConst.?(x)) return graph.valConst(ttn, SsaConst.!(x).val); // fold TypeSubsume(K)
+ 		return add(V3Op.newTypeSubsume(ftn, ttn), [x], x.facts);
 	}
 	// ConditionalThrow(exception, cond)
 	def opConditionalThrow(ex: string, x: SsaInstr) -> SsaInstr {

--- a/aeneas/src/ssa/SsaOptimizer.v3
+++ b/aeneas/src/ssa/SsaOptimizer.v3
@@ -3,6 +3,9 @@
 
 // Coordinates optimizations of SSA graphs, blocks, and individual instructions.
 // Provides a facade to the outside that hides details of reduction, analysis, etc.
+
+def printWrapExtra() -> TerminalBuffer { return Reachability.printWrapExtra(); }
+
 class SsaOptimizer(context: SsaContext) {
 	var marker = SsaInternalMarker.new();
 	def iopt = SsaInstrReducer.new(context);
@@ -675,7 +678,7 @@ class SsaInstrReducer(context: SsaContext) extends SsaInstrMatcher {
 				if (ft == tt) return x; // fold TypeSubsume<T, T>(x)
 				if (tt == x.getType()) return x; // fold TypeSubsume<F, T>(x: T)
 				match (tt.typeCon.kind) {
-					CLASS => {
+					CLASS, VARIANT => {
 						if (ft == Null.TYPE) return graph.nullConst(tt);
 						if (TypeSystem.isSubtype(ft, tt)) return x; // remove redundant subsume of class
 					}
@@ -692,6 +695,11 @@ class SsaInstrReducer(context: SsaContext) extends SsaInstrMatcher {
 			TypeCast => {
 				var ft = i.op.sig.paramTypes[0], tt = i.op.sig.returnType();
 				var cast = TypeSystem.newTypeCast(ft, tt);
+				if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+					printWrapExtra()
+						.put3("SsaOptimizer TypeCast from %q  to %q  cast %s", ft.render, tt.render, cast.name)
+						.put2("  xconst %z  # inputs %d", xconst, i.inputs.length).outln();
+				}
 				if (i.inputs.length == 0) {
 					// special cast of casting void -> X
 					if (cast == TypeCast.THROW) return addThrow(i.source, V3Exception.TypeCheck); // fold TypeCast
@@ -705,7 +713,11 @@ class SsaInstrReducer(context: SsaContext) extends SsaInstrMatcher {
 				}
 
 				match (cast) {
-					TRUE, SUBSUME => return x; // fold TypeCast
+					TRUE, SUBSUME => {
+						if (ft != tt && context.compiler.NormConfig.WrapFuncTypeSubsume &&
+						    Function_TypeCon.?(tt.typeCon)) return i;
+						return x; // fold TypeCast
+					}
 					THROW => {
 						return addThrow(i.source, V3Exception.TypeCheck); // fold TypeCast
 					}
@@ -775,7 +787,13 @@ class SsaInstrReducer(context: SsaContext) extends SsaInstrMatcher {
 				if (!i.facts.O_PURE) return i;
 				var yval = norm_binop(i);
 				// ArrayGetElem(#array, #index) => K
-				if (fold) return graph.valConst(i.getType(), Record.!(xval).values[V3.unboxI32(yval)]);
+				var values: Array<Val>;
+				match (xval) {
+					x: Record => values = x.values;
+					x: Address<Record> => values = x.val.values;
+					_ => ;
+				}
+				if (fold) return graph.valConst(i.getType(), values[V3.unboxI32(yval)]);
 			}
 			ArraySetElem => {
 				var receiver = boundscheck(i);
@@ -1070,6 +1088,38 @@ class SsaInstrReducer(context: SsaContext) extends SsaInstrMatcher {
 					if (d == null) return addThrow(i.source, V3Exception.NullCheck);
 					// CallFunction(#K) => CallMethod
 					var inputs = copyInputs(i, null, 1);
+
+					var ftype = i.op.typeArgs[0];
+					var fsig = FuncType.!(ftype).sig();
+					var xtype = Function.prependParamType(AnyRef.TYPE, d.memberRef.getMethodType());
+					var xsig = FuncType.!(xtype).sig();
+					var rcvr = d.memberRef.asMethod().receiver;
+					var in0 = inputs[0], in0type = in0.getType();
+					if (CLOptions.PRINT_WRAP_EXTRA.get()) {
+						printWrapExtra()
+							.put3("SsaOptimizer: CallFunction const type %q.%q  arg type %q", rcvr.render, xtype.render, in0type.render)
+							.put2("  call type %q.%q", AnyRef.TYPE.render, ftype.render).outln();
+					}
+					if (context.compiler.NormConfig.FunctionCallReceiverTypeCast &&
+					    rcvr != AnyRef.TYPE && !V3.isComponent(rcvr) && in0type != rcvr) {
+						if (TypeSystem.isSubtype(in0type, rcvr))
+							inputs[0] = add(i.source, V3Op.newTypeSubsume(in0type, rcvr), [in0]);
+						else inputs[0] = add(i.source, V3Op.newTypeCast(in0type, rcvr), [in0]);
+					}
+					if (xtype != ftype) {
+						var inputs = Ssa.inputs(i);
+						for (j = 1; j < xsig.paramTypes.length; ++j) {
+							var input = inputs[j];
+							var ft = fsig.paramTypes[j], tt = xsig.paramTypes[j], atype = input.getType();
+							if (SsaConst.?(input)) atype = SsaConst.!(input).vtype;
+							if (ft != tt && atype != tt) {
+								if (TypeSystem.isSubtype(atype, tt))
+									inputs[j] = add(i.source, V3Op.newTypeSubsume(atype, tt), [input]);
+								else inputs[j] = add(i.source, V3Op.newTypeCast(atype, tt), [input]);
+							}
+						}
+						i.setInputs(inputs);
+					}
 					return add(i.source, V3Op.newCallMethod(d.memberRef), inputs).setFact(Fact.O_NO_NULL_CHECK);
 				}
 			}
@@ -1231,7 +1281,11 @@ class SsaInstrReducer(context: SsaContext) extends SsaInstrMatcher {
 		// Compute the constant length of the array if possible.
 		var length = -1;
 		if (xconst) {
-			length = Record.!(xval).values.length;
+			match (xval) {
+				x: Record => length = x.values.length;
+				x: Address<Record> => length = x.val.values.length;
+				_ => return receiver;
+			}
 		} else if (x.optag() == Opcode.ArrayAlloc.tag) {
 			var l = x.inputs[0].dest;
 			if (!SsaConst.?(l)) return receiver;

--- a/aeneas/src/ssa/SsaPrinter.v3
+++ b/aeneas/src/ssa/SsaPrinter.v3
@@ -38,7 +38,9 @@ class SsaPrinter {
 		for (v in values) {
 			if (v == null) continue;
 			buf.putref(v);
-			buf.puthashv(v.val, v.getType()).end();
+			buf.outt();
+			buf.puthashv(v.val, v.getType());
+			buf.put1(":%q", v.getType().render).end();
 			buf.sp();
 		}
 		ln();

--- a/aeneas/src/ssa/SsaRebuilder.v3
+++ b/aeneas/src/ssa/SsaRebuilder.v3
@@ -257,14 +257,14 @@ class SsaRebuilder(context: SsaContext) {
 		var tn = normType(i_old.vtype), val: SsaConst;
 		if (tn == null) {
 			// No normalization.
-			var val = newGraph.valConst(i_old.vtype, genSimpleVal(tn, i_old.val));
+			var val = newGraph.valConst(i_old.vtype, genSimpleVal(tn, i_old.vtype, i_old.val));
 			map1(i_old, val);
 			return val;
 		}
 		if (tn.size != 1) context.fail1("expected 1-1 val mapping for: #%d", i_old.uid);
 		if (tn.sub == null) {
 			// Simple 1-1 normalization.
-			var val = newGraph.valConst(tn.newType, genSimpleVal(tn, i_old.val));
+			var val = newGraph.valConst(tn.newType, genSimpleVal(tn, null, i_old.val));
 			map1(i_old, val);
 			return val;
 		}
@@ -281,14 +281,14 @@ class SsaRebuilder(context: SsaContext) {
 		var tn = normType(i_old.vtype);
 		if (tn == null) {
 			// No normalization.
-			var val = newGraph.valConst(i_old.vtype, genSimpleVal(tn, i_old.val));
+			var val = newGraph.valConst(i_old.vtype, genSimpleVal(tn, i_old.vtype, i_old.val));
 			map1(i_old, val);
 			vec.put(val);
 			return;
 		}
 		if (tn.sub == null) {
 			// 1-1 normalization.
-			var val = newGraph.valConst(tn.newType, genSimpleVal(tn, i_old.val));
+			var val = newGraph.valConst(tn.newType, genSimpleVal(tn, null, i_old.val));
 			map1(i_old, val);
 			vec.put(val);
 			return;
@@ -301,7 +301,7 @@ class SsaRebuilder(context: SsaContext) {
 		// 1-N normalization.
 		genValN(i_old, tn, vec);
 	}
-	def genSimpleVal(tn: TypeNorm, v: Val) -> Val {
+	def genSimpleVal(tn: TypeNorm, t: Type, v: Val) -> Val {
 		return v;
 	}
 	def mapEdge(edge: SsaCfEdge) -> SsaBlock {

--- a/aeneas/src/v3/TypeSystem.v3
+++ b/aeneas/src/v3/TypeSystem.v3
@@ -592,7 +592,7 @@ component TypeSystem {
 		if (V3.isRef(fromType)) {
 			if (isSubtype(fromType, toType)) return TypeCast.TRUE;
 		}
-		if (AnyRefType.?(fromType)) {
+		if (AnyRefType.?(fromType) || AnyFuncType.?(fromType)) {
 			match (toType) {
 				y: FuncType => {
 					if(y.typeCon.kind == Kind.FUNCREF) return TypeCast.TRUE; // TODO: funcref cast

--- a/aeneas/src/v3/V3Range.v3
+++ b/aeneas/src/v3/V3Range.v3
@@ -59,7 +59,7 @@ class PointerRangeStart(start: Addr) extends Val {
 		return start.hash() * 65;
 	}
 }
-// The type of the start of a range (either the range of an array of a pointer); used after normalization.
+// The type of the start of a range (either the range of an array or a pointer); used after normalization.
 class RangeStartType extends Type {
 	new(typeCon: TypeCon) super(typeCon.uid, typeCon, null) { }
 }

--- a/aeneas/test/MachStackifierTest.v3
+++ b/aeneas/test/MachStackifierTest.v3
@@ -13,14 +13,14 @@ def ARCH_TEE = 5;
 def ARCH_POP = 6;
 def ARCH_CONST = 7;
 
-def prog = Program.new();
+def prog = Program.new(null);
 def global_context = SsaContext.new(null, prog);
 
 def SPACE = AddressSpace.new("mem", false, 32, 4, Alignment.new(4096), Alignment.new(4));
 class Generator extends SsaMachGen {
 	def p0 = SsaParam.new(0, Int.TYPE);
 	def p1 = SsaParam.new(1, Int.TYPE);
-	new() super(global_context, MachProgram.new(Program.new(), SPACE, SPACE, null), null, null) {
+	new() super(global_context, MachProgram.new(Program.new(null), SPACE, SPACE, null), null, null) {
 		var graph = SsaGraph.new([p0, p1], Int.TYPE);
 		reset(graph, null, null);
 		cursor = ArchInstr.new(ArchInstrs.ARCH_END, ArchInstrs.NO_OPERANDS);
@@ -81,7 +81,7 @@ class StackOpInstrBuffer extends ArchInstrBuffer {
 	new(codegen: SsaMachGen, prog: Program, regSet: MachRegSet) super(codegen, prog, regSet) { }
 	def putArchInstr(indent: int, i: ArchInstr) -> int {
 		var opcode = int.view(i.opcode()), a = i.operands;
-		var name = WasmOpNames.array[opcode];
+//		var name = WasmOpNames.array[opcode];
 		match (opcode) {
 			ARCH_OP => puts("op ");
 			ARCH_LOAD => puts("load ");

--- a/aeneas/test/SsaInstrReducerTest.v3
+++ b/aeneas/test/SsaInstrReducerTest.v3
@@ -33,9 +33,9 @@ def X_ = void(
 );
 
 private class SsaInstrReducerTester(t: Tester) {
-	def prog = Program.new();
+	def prog = Program.new(Compiler.new(null));
 	def graph = SsaGraph.new([SsaParam.new(0, Int.TYPE)], Int.TYPE);
-	def context = SsaContext.new(null, prog);
+	def context = SsaContext.new(prog.compiler, prog);
 	var optimize_loads: bool;	// activates load elimination
 	var optimize_nullchecks: bool;	// activates null check elimination
 	var optimize_inits: bool;	// activates init elimination
@@ -213,7 +213,7 @@ private class SsaInstrReducerTester(t: Tester) {
 		return graph.valConst(rtype, r);
 	}
 	def failInstr(i: SsaInstr, j: SsaInstr) {
-		def prog = Program.new();
+		def prog = Program.new(Compiler.new(null));
 		var p = SsaPrinter.new();
 		p.buf.puts("\nexpected: ");
 		p.printInstr(i, true, true, true, false);

--- a/aeneas/test/SsaSplitCritEdgeTest.v3
+++ b/aeneas/test/SsaSplitCritEdgeTest.v3
@@ -6,7 +6,7 @@ def X_ = void(
 def empty = StringBuilder.puts(_, "empty");
 
 def test_diamond0(t: Tester) {
-	var prog = Program.new();
+	var prog = Program.new(null);
 	var context = SsaContext.new(null, prog);
 	var p0 = SsaParam.new(0, Int.TYPE);
 	var graph = context.graph = SsaGraph.new([p0], Int.TYPE);
@@ -27,7 +27,7 @@ def test_diamond0(t: Tester) {
 }
 
 def test_diamond1(t: Tester) {
-	var prog = Program.new();
+	var prog = Program.new(null);
 	var context = SsaContext.new(null, prog);
 	var p0 = SsaParam.new(0, Int.TYPE);
 	var graph = context.graph = SsaGraph.new([p0], Int.TYPE);

--- a/aeneas/test/Utils.v3
+++ b/aeneas/test/Utils.v3
@@ -357,7 +357,7 @@ class SsaInstrTester(t: Tester) {
 		return false;
 	}
 	def failInstr(i: SsaInstr, j: SsaInstr) {
-		def prog = Program.new();
+		def prog = Program.new(null);
 		var p = SsaPrinter.new();
 		p.buf.puts("\nexpected: ");
 		p.printInstr(i, true, true, true, false);

--- a/test/core/delegate_comp10.v3
+++ b/test/core/delegate_comp10.v3
@@ -1,4 +1,4 @@
-//@execute 0=false; 1=false; 2=false; 3=false; 4=false; 5=false; 6=false
+//@execute 0=true; 1=true; 2=true; 3=true; 4=true; 5=true; 6=false
 class delegate_comp10_a {
 	def c();
 	def d();


### PR DESCRIPTION
Suppose `B` is a subclass of `A` and there is a variable `f: void -> A`.
Further suppose `g` is a function of type `void -> B`.  By Virgil's rules
it is fine to assign `g` to `f`, but some targets, namely virtual machines
with their own subclass / type-checking rules, disallow this.  We can
work around the restriction by coding a _wrapper_ `w`:
```
def w() -> A {
  return g();
}
```
and assigning `w` to `f` instead.  A number of similar cases arise,
which can involve types of arguments to function as well as types
of results, nested use of function types, etc.  Further, assignments
between variables of function types (and implicit assignments in
passing arguments, returning results, etc.) imply the need to figure
out the wrapper to use at run time.  We do this my generating  a
_mapper_, which compares it argument (a function to wrap) against
all possible such functions and returning the wrapper for the matching
one.  Lastly, we also need _un_mappers to go from wrappers to their
underlying functions, in order to implement function comparison
correctly.  These mechanisms are _required_ for the Wasm GC target.
They also are required for the JVM target to support function
comparison.

From the standpoint of compiler internals, a key difference is making
sure that `TypeSubsume` (and `TypeCast`) operators that would normally
be considered no-ops are retained and suitable code is generated.