### PR TITLE
[x86-64] Fix improper instruction selection for subtraction

### DIFF
--- a/aeneas/src/x86-64/SsaX86_64Gen.v3
+++ b/aeneas/src/x86-64/SsaX86_64Gen.v3
@@ -123,7 +123,10 @@ class SsaX86_64Gen extends SsaMachGen {
 			}
 			IntSub => {
 				var yval = m.intbinop(i);
-				if (MATCH_NEG && m.xconst && m.xint == 0) return emit1(I_NEGQ | (AM_OP << AM_SHIFT), ovwReg(i, m.y));
+				if (MATCH_NEG && m.xconst) {
+					if (m.inttype.width <= 32 && m.xint == 0) return emit1(I_NEGQ | (AM_OP << AM_SHIFT), ovwReg(i, m.y));
+					if (m.inttype.width > 32 && m.xlong == 0) return emit1(I_NEGQ | (AM_OP << AM_SHIFT), ovwReg(i, m.y));
+				}
 				emitIntBinop(I_SUBD, i);
 			}
 			IntMul => {

--- a/aeneas/src/x86-64/SsaX86_64Gen.v3
+++ b/aeneas/src/x86-64/SsaX86_64Gen.v3
@@ -123,9 +123,9 @@ class SsaX86_64Gen extends SsaMachGen {
 			}
 			IntSub => {
 				var yval = m.intbinop(i);
-				if (MATCH_NEG && m.xconst) {
-					if (m.inttype.width <= 32 && m.xint == 0) return emit1(I_NEGQ | (AM_OP << AM_SHIFT), ovwReg(i, m.y));
-					if (m.inttype.width > 32 && m.xlong == 0) return emit1(I_NEGQ | (AM_OP << AM_SHIFT), ovwReg(i, m.y));
+				if (MATCH_NEG && m.xconst && 
+						((m.inttype.width <= 32 && m.xint == 0) || (m.inttype.width > 32 && m.xlong == 0))) {
+					return emit1(I_NEGQ | (AM_OP << AM_SHIFT), ovwReg(i, m.y));
 				}
 				emitIntBinop(I_SUBD, i);
 			}

--- a/test/core/int_sub05.v3
+++ b/test/core/int_sub05.v3
@@ -1,0 +1,6 @@
+//@execute 0=1; 1=0
+component int_sub05 {
+	def main(a: int) -> int {
+		return 1 - a;
+	}
+}

--- a/test/core/long_sub01.v3
+++ b/test/core/long_sub01.v3
@@ -1,0 +1,4 @@
+//@execute (0,1)=-1; (1,-1)=2; (-200,13)=-213
+component long_sub01 {
+	def main(a: int, b: int) -> int { return int.view(long.!(a) - long.!(b)); }
+}

--- a/test/core/long_sub02.v3
+++ b/test/core/long_sub02.v3
@@ -1,0 +1,4 @@
+//@execute 1=0; 0=1
+component long_sub02 {
+	def main(a: int) -> int { return int.view(1 - long.!(a)); }
+}

--- a/test/core/long_sub03.v3
+++ b/test/core/long_sub03.v3
@@ -1,0 +1,4 @@
+//@execute 1=-1; 0=0
+component long_sub03 {
+	def main(a: int) -> int { return int.view(0 - long.!(a)); }
+}


### PR DESCRIPTION
The following program is incorrect on `x86-64-linux` (with `-O0`):
```
def main() -> int {
    def x: long = 0;
    return int.view(1 - x);
}
```
It returns 0, instead of 1, because the assembly generator only checks the constant `1` against an int.