### PR TITLE
Remove table maximum for Wasm target

### DIFF
--- a/aeneas/src/wasm/WasmTarget.v3
+++ b/aeneas/src/wasm/WasmTarget.v3
@@ -182,9 +182,8 @@ class WasmTarget extends Target {
 			out.startSection(WasmSection.TABLE.code);
 			out.putb(1);  // 1 table
 			out.putb(WasmTypeConCode.FUNCREF.code);  // type of table
-			out.putb(1);	// flags = contains maximum
+			out.putb(0);	// flags = no maximum
 			out.put_uleb32(table_length);  // initial table length
-			out.put_uleb32(table_length);  // maximum table length
 			out.endSection();
 		}
 


### PR DESCRIPTION
This is necessary for `wave.new_func`, which places references to dynamically generated Wasm functions as new entries in the table.