### PR TITLE
added new repHint variants

### DIFF
--- a/aeneas/src/vst/Parser.v3
+++ b/aeneas/src/vst/Parser.v3
@@ -289,8 +289,6 @@ component Parser {
 		return
 			Char.isIdentMiddle(c) ||
 			c == '-' ||
-			c == '<' ||
-			c == '>' ||
 			c == ':';
 	}
 	def parseRepHints(p: ParserState) -> List<VstRepHint> {
@@ -305,7 +303,7 @@ component Parser {
 				q++;
 			}
 			var id = extractIdent<void>(p, q);
-			var name = id.name.image;
+			var label = id.name.image;
 			var result: VstRepHint;
 			match (id.kwClass) {
 				Keywords.KC_PACKING => {
@@ -313,11 +311,21 @@ component Parser {
 					result = VstRepHint.Packing(e);
 				}
 				0 => {
-					if (Strings.equal(name, "boxed")) result = VstRepHint.Boxed;
-					else if (Strings.equal(name, "unboxed")) result = VstRepHint.Unboxed;
-					else if (Strings.equal(name, "packed")) result = VstRepHint.Packed;
-					else if (Strings.equal(name, "big-endian")) result = VstRepHint.BigEndian;
-					else result = VstRepHint.Other(name);
+					if (Strings.equal(label, "boxed")) result = VstRepHint.Boxed;
+					else if (Strings.equal(label, "unboxed")) result = VstRepHint.Unboxed;
+					else if (Strings.equal(label, "packed")) result = VstRepHint.Packed;
+					else if (Strings.equal(label, "big-endian")) result = VstRepHint.BigEndian;
+					else if (p.curByte == '(') {
+						// Parse ExprHint: #label(expr, expr, ...)
+						var exprs = parseList(0, p, '(', COMMA, ')', parseExpr);
+						result = VstRepHint.ExprHint(label, exprs);
+					}
+					else if (p.curByte == '<') {
+						// Parse TypeHint: #label<Type, Type, ...>
+						var types = parseList(0, p, '<', COMMA, '>', parseTypeRef);
+						result = VstRepHint.TypeHint(label, types);
+					}
+					else result = VstRepHint.Other(label);
 				}
 				_ => kwError(p, id.name);
 			}

--- a/aeneas/src/vst/Vst.v3
+++ b/aeneas/src/vst/Vst.v3
@@ -455,6 +455,8 @@ type VstRepHint {
 	case Packed;
 	case Packing(p: VstList<VstPackingExpr>);
 	case BigEndian;
+	case ExprHint(label: string, exprs: VstList<Expr>);
+	case TypeHint(label: string, types: VstList<TypeRef>);
 	case Other(hint: string);
 
 	def render(buf: StringBuilder) -> StringBuilder {
@@ -464,6 +466,8 @@ type VstRepHint {
 			Packed => buf.puts("#packed");
 			Packing(p) => buf.puts("#packing(...)");
 			BigEndian => buf.puts("#big-endian");
+			ExprHint(label, exprs) => buf.put1("#%s(...)", label);
+			TypeHint(label, types) => buf.put1("#%s<...>", label);
 			Other(s) => buf.put1("#%s", s);
 		}
 		return buf;

--- a/aeneas/src/vst/VstPrinter.v3
+++ b/aeneas/src/vst/VstPrinter.v3
@@ -127,14 +127,26 @@ class Printer(printer: VstPrinter) {
 			}
 			BigEndian => Terminal.put("#big-endian");
 			Other(s) => Terminal.put1("#%s", s);
+			ExprHint(label, exprs) => {
+				Terminal.put1("#%s", label);
+				Terminal.putc('(');
+				printCommaList(exprs.list, printer.printExpr(_, 0));
+				Terminal.putc(')');
+			}
+			TypeHint(label, types) => {
+				Terminal.put1("#%s", label);
+				Terminal.putc('<');
+				printCommaList(types.list, printTypeRef);
+				Terminal.putc('>');
+			}
 		}
 	}
-        def printRepHints(repHints: List<VstRepHint>) {
-            for (node = repHints; node != null; node = node.tail) {
-                printRepHint(node.head);
-                Terminal.putc(' ');
-            }
-        }
+	def printRepHints(repHints: List<VstRepHint>) {
+		for (node = repHints; node != null; node = node.tail) {
+			printRepHint(node.head);
+			Terminal.putc(' ');
+		}
+	}
 	def printToken(t: Token) {
 		Terminal.put1("%s", t.image);
 	}

--- a/test/core/parser/rephint20.v3
+++ b/test/core/parser/rephint20.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #align(16) { }

--- a/test/core/parser/rephint21.v3
+++ b/test/core/parser/rephint21.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #range(0, 100) { }

--- a/test/core/parser/rephint22.v3
+++ b/test/core/parser/rephint22.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #size(8 * 1024) { }

--- a/test/core/parser/rephint23.v3
+++ b/test/core/parser/rephint23.v3
@@ -1,0 +1,3 @@
+//@parse
+def m() #inline(true) {
+}

--- a/test/core/parser/rephint24.v3
+++ b/test/core/parser/rephint24.v3
@@ -1,0 +1,4 @@
+//@parse
+class Foo {
+	var f = 0 #offset(32);
+}

--- a/test/core/parser/rephint25.v3
+++ b/test/core/parser/rephint25.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #align(8) #size(64) { }

--- a/test/core/parser/rephint26.v3
+++ b/test/core/parser/rephint26.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #name("CustomName") { }

--- a/test/core/parser/rephint27.v3
+++ b/test/core/parser/rephint27.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #hint() { }

--- a/test/core/parser/rephint28.v3
+++ b/test/core/parser/rephint28.v3
@@ -1,0 +1,2 @@
+//@parse = ParseError @ 2:17
+class A #hint(5 { }

--- a/test/core/parser/rephint30.v3
+++ b/test/core/parser/rephint30.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #repr<int> { }

--- a/test/core/parser/rephint31.v3
+++ b/test/core/parser/rephint31.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #wrap<int, bool> { }

--- a/test/core/parser/rephint32.v3
+++ b/test/core/parser/rephint32.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #container<Array<byte>> { }

--- a/test/core/parser/rephint33.v3
+++ b/test/core/parser/rephint33.v3
@@ -1,0 +1,2 @@
+//@parse
+type U #repr<u32> { }

--- a/test/core/parser/rephint34.v3
+++ b/test/core/parser/rephint34.v3
@@ -1,0 +1,5 @@
+//@parse
+class Foo {
+	def m() -> void #rettype<void> {
+	}
+}

--- a/test/core/parser/rephint35.v3
+++ b/test/core/parser/rephint35.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #key<int> #value<string> { }

--- a/test/core/parser/rephint36.v3
+++ b/test/core/parser/rephint36.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #hint<> { }

--- a/test/core/parser/rephint37.v3
+++ b/test/core/parser/rephint37.v3
@@ -1,0 +1,2 @@
+//@parse = ParseError @ 2:18
+class A #hint<int { }

--- a/test/core/parser/rephint40.v3
+++ b/test/core/parser/rephint40.v3
@@ -1,0 +1,2 @@
+//@parse
+class A #packed #align(16) #repr<u64> { }

--- a/test/core/parser/rephint41.v3
+++ b/test/core/parser/rephint41.v3
@@ -1,0 +1,2 @@
+//@parse
+type U #unboxed #size(32) #backend<wasm> { }

--- a/test/core/parser/rephint42.v3
+++ b/test/core/parser/rephint42.v3
@@ -1,0 +1,4 @@
+//@parse
+class Foo {
+	var f = 0 #volatile #offset(0x100) #ftype<u32>;
+}


### PR DESCRIPTION
So we can have e.g. `#V->V->I` for CBD intrinsic stage annotations