### PR TITLE
[unboxing] Fix Type Queries for Unboxed Tagless Variants

### DIFF
--- a/aeneas/src/ir/SsaNormalizer.v3
+++ b/aeneas/src/ir/SsaNormalizer.v3
@@ -1110,11 +1110,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 	}
 	// Returns whether `parent` VariantNorm has `child` as a VariantNorm in `parent.children`
 	def isVNParentChild(parent: VariantNorm, child: VariantNorm) -> bool {
-		for (l = parent.children; l != null; l = l.tail) {
-			def curChild: VariantNorm = l.head;
-			if (curChild == child) return true;
-		}
-		return false;
+ 		return Lists.find(parent.children, child) != -1;
 	}
 	def opAnd(left: SsaInstr, right: SsaInstr) -> SsaInstr {
 		return if(left == null, right, curBlock.opBoolAnd0(left, right));

--- a/aeneas/src/ir/SsaNormalizer.v3
+++ b/aeneas/src/ir/SsaNormalizer.v3
@@ -1077,10 +1077,13 @@ class SsaRaNormalizer extends SsaRebuilder {
 			VARIANT_QUERY => {
 				if (VariantNorm.?(atn) && VariantNorm.?(rtn)) {
 					var avn = VariantNorm.!(atn), rvn = VariantNorm.!(rtn);
+					def isParentChild = isVNParentChild(avn, rvn) || isVNParentChild(rvn, avn);
 					var actualTag = normVariantGetTag(avn, ai_old[offset ...]);
 					var tagType = avn.tagType();
 					var check: SsaInstr;
-					if (rvn.tagValue == rvn.tagHi || rvn.tagHi < 0) {
+					if (tagType == null && rvn.tagType() == null  && isParentChild) {
+						return left;
+					} else if (rvn.tagValue == rvn.tagHi || rvn.tagHi < 0) {
 						// Leaf (or uninitialized tagHi): exact equality test.
 						var expected = newGraph.intConst(rvn.tagValue);
 						check = curBlock.pure(V3Op.newIntEq(tagType), [actualTag, expected]);
@@ -1104,6 +1107,14 @@ class SsaRaNormalizer extends SsaRebuilder {
 			left = opAnd(left, curBlock.opTypeQuery(atn.newType, rtn.newType, ai_old[offset]));
 		}
 		return left;
+	}
+	// Returns whether `parent` VariantNorm has `child` as a VariantNorm in `parent.children`
+	def isVNParentChild(parent: VariantNorm, child: VariantNorm) -> bool {
+		for (l = parent.children; l != null; l = l.tail) {
+			def curChild: VariantNorm = l.head;
+			if (curChild == child) return true;
+		}
+		return false;
 	}
 	def opAnd(left: SsaInstr, right: SsaInstr) -> SsaInstr {
 		return if(left == null, right, curBlock.opBoolAnd0(left, right));

--- a/aeneas/src/ir/VariantNormalizer.v3
+++ b/aeneas/src/ir/VariantNormalizer.v3
@@ -39,7 +39,7 @@ class VariantNorm extends TypeNorm {
 		return size == 1 && tag != null && fields.length == 0; 
 	}
 	def isEnumCase() -> bool { return size == 1 && tag != null && tagValue >= 0 && fields.length == 0; }
-	def tagType() -> IntType { return if(tag == null, IntType.!(tag.tn.first())); }
+	def tagType() -> IntType { return if(tag != null, IntType.!(tag.tn.first())); }
 	def tagIndex() -> int { return tag.indexes[0]; }
 
 	// represent single-case, unboxed variant without its tag

--- a/aeneas/src/ir/VariantNormalizer.v3
+++ b/aeneas/src/ir/VariantNormalizer.v3
@@ -39,7 +39,7 @@ class VariantNorm extends TypeNorm {
 		return size == 1 && tag != null && fields.length == 0; 
 	}
 	def isEnumCase() -> bool { return size == 1 && tag != null && tagValue >= 0 && fields.length == 0; }
-	def tagType() -> IntType { return if(tag == null, null, IntType.!(tag.tn.first())); }
+	def tagType() -> IntType { return if(tag == null, IntType.!(tag.tn.first())); }
 	def tagIndex() -> int { return tag.indexes[0]; }
 
 	// represent single-case, unboxed variant without its tag

--- a/aeneas/src/ir/VariantNormalizer.v3
+++ b/aeneas/src/ir/VariantNormalizer.v3
@@ -184,7 +184,7 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 		var shouldPack = rc.orig.packed;
 
 		var solver = VariantSolver.new(nc, getScalar);
-		var solution = solver.solve(VariantProblem.new([normFields], null, false, V3.getVariantTagType(rc.orig.ctype)));
+		var solution = solver.solve(VariantProblem.new([normFields], null, false, V3.getVariantTagType(rc.orig.ctype), false));
 
 		var vn = VariantNorm.new(rc.oldType, Tuple.newType(Lists.fromArray(solution.types)), solution.types, rc.variantFields, null);
 
@@ -247,11 +247,10 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 		// now that we know it's not recursive, we can safely assign the variant norm
 
 		var shouldPack = checkPackable(rc, normFields);
-		var needsTagScalar = !shouldPack;
 
 		var solver = VariantSolver.new(nc, getScalar);
 		def numOrigVariants: int = ClassType.!(rc.orig.ctype).classDecl.cases.length;
-		var solution = solver.solve(VariantProblem.new(normFields, null, shouldPack, V3.getVariantTagType(rc.orig.ctype)));
+		var solution = solver.solve(VariantProblem.new(normFields, null, shouldPack, V3.getVariantTagType(rc.orig.ctype), true));
 		if (solution == null) return false; // XXX: warn that no solution was found
 
 		var tagField: VariantField;

--- a/aeneas/src/ir/VariantNormalizer.v3
+++ b/aeneas/src/ir/VariantNormalizer.v3
@@ -254,10 +254,7 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 		if (solution == null) return false; // XXX: warn that no solution was found
 
 		var tagField: VariantField;
-		if (solution.hasTagScalar) {
-			tagField = VariantField.new(null, rn.norm(solution.tagType), [solution.types.length - 1]);
-			tagField.intervals = [Interval(0, solution.tagType.width)];
-		} else if (solution.explicitTag.0 >= 0) {
+		if (solution.explicitTag.0 >= 0) {
 			tagField = VariantField.new(null, rn.norm(solution.tagType), [solution.explicitTag.0]);
 			tagField.intervals = [solution.explicitTag.1];
 		}

--- a/aeneas/src/ir/VariantNormalizer.v3
+++ b/aeneas/src/ir/VariantNormalizer.v3
@@ -184,7 +184,7 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 		var shouldPack = rc.orig.packed;
 
 		var solver = VariantSolver.new(nc, getScalar);
-		var solution = solver.solve(VariantProblem.new([normFields], null, false, V3.getVariantTagType(rc.orig.ctype), false));
+		var solution = solver.solve(VariantProblem.new([normFields], null, false, V3.getVariantTagType(rc.orig.ctype)));
 
 		var vn = VariantNorm.new(rc.oldType, Tuple.newType(Lists.fromArray(solution.types)), solution.types, rc.variantFields, null);
 
@@ -239,7 +239,6 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 		var numChildren = Lists.length(rc.children);
 		var normFields = Array<Array<Type>>.new(numChildren);
 		
-
 		var caseIdx = 0;
 		for (l = rc.children; l != null; l = l.tail) normFields[caseIdx++] = getNormFieldsForCase(l.head);
 
@@ -247,11 +246,10 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 		// now that we know it's not recursive, we can safely assign the variant norm
 
 		var shouldPack = checkPackable(rc, normFields);
-		var needTag = normFields.length > 1;
 
 		var solver = VariantSolver.new(nc, getScalar);
 		def numOrigVariants: int = ClassType.!(rc.orig.ctype).classDecl.cases.length;
-		var solution = solver.solve(VariantProblem.new(normFields, null, shouldPack, V3.getVariantTagType(rc.orig.ctype), needTag));
+		var solution = solver.solve(VariantProblem.new(normFields, null, shouldPack, V3.getVariantTagType(rc.orig.ctype)));
 		if (solution == null) return false; // XXX: warn that no solution was found
 
 		var tagField: VariantField;

--- a/aeneas/src/ir/VariantNormalizer.v3
+++ b/aeneas/src/ir/VariantNormalizer.v3
@@ -39,7 +39,7 @@ class VariantNorm extends TypeNorm {
 		return size == 1 && tag != null && fields.length == 0; 
 	}
 	def isEnumCase() -> bool { return size == 1 && tag != null && tagValue >= 0 && fields.length == 0; }
-	def tagType() -> IntType { return IntType.!(tag.tn.first()); }
+	def tagType() -> IntType { return if(tag == null, null, IntType.!(tag.tn.first())); }
 	def tagIndex() -> int { return tag.indexes[0]; }
 
 	// represent single-case, unboxed variant without its tag
@@ -247,10 +247,11 @@ class VariantNormalizer(nc: NormalizerConfig, rn: ReachabilityNormalizer, verbos
 		// now that we know it's not recursive, we can safely assign the variant norm
 
 		var shouldPack = checkPackable(rc, normFields);
+		var needTag = normFields.length > 1;
 
 		var solver = VariantSolver.new(nc, getScalar);
 		def numOrigVariants: int = ClassType.!(rc.orig.ctype).classDecl.cases.length;
-		var solution = solver.solve(VariantProblem.new(normFields, null, shouldPack, V3.getVariantTagType(rc.orig.ctype), true));
+		var solution = solver.solve(VariantProblem.new(normFields, null, shouldPack, V3.getVariantTagType(rc.orig.ctype), needTag));
 		if (solution == null) return false; // XXX: warn that no solution was found
 
 		var tagField: VariantField;

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -38,9 +38,8 @@ class VariantProblem {
 	var assignments = HashMap<CaseField, (int, Interval)>.new(CaseField.hash, CaseField.==); // pre-existing interval assignments
 	var usePacking: bool;					// whether to pack multiple fields into the same scalar
 	var tagType: IntType;
-	var needTag: bool;
 
-	new(normFields, baseState, usePacking, tagType, needTag) {}
+	new(normFields, baseState, usePacking, tagType) {}
 
 	def render(buf: StringBuilder) -> StringBuilder {
 		for (i < normFields.length) {
@@ -147,7 +146,6 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 	var state: Array<VariantPattern>;
 	var explicitTag: (int, Interval) = (-1, EMPTY_INTERVAL);
 	var explicitTagLength: byte;
-	var needTag: bool;
 
 	var curRep = Vector<Scalar.set>.new();
 	var curUsed = Vector<byte>.new();
@@ -182,7 +180,6 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		assignments = problem.assignments;
 		baseState = problem.baseState;
 		tagType = problem.tagType;
-		needTag = problem.needTag;
 
 
 		explicitTagLength = if(tagType != null, tagType.width, 0);
@@ -375,11 +372,11 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 	}
 	private def solveField(idx: int) -> bool {
 		if (idx >= fields.length) {
-			def distinguishable = checkDistinguishable();
-			if (!distinguishable) appendTagScalarToVariantPatterns();
-			// Case 1.) Packing not used and needTag=true (ex. unboxUsingTaggedVariantNorm
+			if (needTagScalar()) appendTagScalarToVariantPatterns();
+			def multiCase = normFields.length > 1;
+			// Case 1.) Packing not used and multiCase=true (ex. unboxUsingTaggedVariantNorm
 			// Case 2.) Packing failed and tag is needed
-			def useTagScalar = (!usePacking || (usePacking && packingSoln == null)) && needTag;
+			def useTagScalar = (!usePacking || (usePacking && packingSoln == null)) && multiCase;
 			var types = getTypes(useTagScalar);
 			curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
 			curSoln.tagType = tagType;
@@ -431,19 +428,18 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		// TODO - this is where unassigned bits will get assigned
 	}
 	// Return whether a tag is needed
-	private def checkDistinguishable() -> bool {
+	private def needTagScalar() -> bool {
 		// Cases
-		// 1.1) usePacking and packing success- the refactored packing already does tagging
-		// 1.2) usePacking but packing fails - default case and need explicit tag scalar
-		// 2.) !usePacking - could have 1 case or multicase
-		// 2.1) called from unboxUsingTaggedVariantNorm but one case reachable - no tag needed
-		// 2.2) called from unboxUsingTaglessVariantNorm - no need for a tag
+		// 1.) usePacking and packing success- the refactored packing already does tagging
+		// 2.) usePacking but packing fails - default case and need explicit tag scalar
 		if (usePacking) {
-			if (packingSoln != null) return true;
-			return false; // separate tagging scalar needed
+			if (packingSoln != null) return false;
+			return true; // separate tagging scalar needed
 		}
-		// TODO: if no use packing, case on the number of cases
-		return !needTag;
+		// No tag needed when: 
+		// 1.) called from unboxUsingTaggedVariantNorm but one case reachable
+		// 2.) called from unboxUsingTaglessVariantNorm
+		return normFields.length > 1;
 	}
 	private def getTypes(useTagScalar: bool) -> Array<Type> {
 		var types = Array<Type>.new(curRep.length + if(useTagScalar, 1));
@@ -453,8 +449,7 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		// since there will be no casting necessary
 		var uniqueTypes = Array<Type>.new(curRep.length);
 		var uses = Array<int>.new(curRep.length);
-
-		if (!useTagScalar && explicitTag.0 >= 0) uses[explicitTag.0]++;
+		if (!useTagScalar && explicitTag.0 >= 0 && explicitTag.1 != EMPTY_INTERVAL) uses[explicitTag.0]++;
 		for (i < normFields.length) {
 			var caseUses = Array<int>.new(curRep.length);
 			for (j < normFields[i].length) {

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -436,10 +436,8 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		// 1.1) usePacking and packing success- the refactored packing already does tagging
 		// 1.2) usePacking but packing fails - default case and need explicit tag scalar
 		// 2.) !usePacking - could have 1 case or multicase
-		// 2.1) called from unboxUsingEnumVariantNorm - no tagging
-		// 2.2) called from unboxUsingTaggedVariantNorm but one case reachable
-		// - For now, need tag for type queries if not packed (must be in separate tag scalar
-		// 2.3) called from unboxUsingTaglessVariantNorm - no need for a tag
+		// 2.1) called from unboxUsingTaggedVariantNorm but one case reachable - no tag needed
+		// 2.2) called from unboxUsingTaglessVariantNorm - no need for a tag
 		if (usePacking) {
 			if (packingSoln != null) return true;
 			return false; // separate tagging scalar needed

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -83,7 +83,6 @@ class VariantSolution {
 	var types: Array<Type>;
 
 	var hasIntervals = false;
-	var hasTagScalar = false;
 	var tagType: IntType;
 
 	var cachedScore = -1;
@@ -100,7 +99,6 @@ class VariantSolution {
 		);
 		vs.tagType = tagType;
 		vs.hasIntervals = hasIntervals;
-		vs.hasTagScalar = hasTagScalar;
 		return vs;
 	}
 	def render(buf: StringBuilder) -> StringBuilder {
@@ -322,6 +320,7 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 			// Update `state`
 			state = assignIntervalsToPatterns(packingSoln);
 			// Update `explicitTag`
+			// TODO: PackingSolver only assigns tag to the 0th scalar for now. Allow any scalar later
 			explicitTag = (0, packingSoln.explicitTag);
 			def types = getTypes(false);
 			curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
@@ -377,8 +376,14 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 	private def solveField(idx: int) -> bool {
 		if (idx >= fields.length) {
 			def distinguishable = checkDistinguishable();
-			if (!distinguishable) createSolnWithTagScalar();
-			else createSolnForPackedADT();
+			if (!distinguishable) appendTagScalarToVariantPatterns();
+			// Case 1.) Packing not used and needTag=true (ex. unboxUsingTaggedVariantNorm
+			// Case 2.) Packing failed and tag is needed
+			def useTagScalar = (!usePacking || (usePacking && packingSoln == null)) && needTag;
+			var types = getTypes(useTagScalar);
+			curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
+			curSoln.tagType = tagType;
+			curSoln.hasIntervals = usePacking;
 			return true;
 		}
 		var field = fields[idx];
@@ -400,37 +405,23 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		}
 		return false;
 	}
-	private def createSolnWithTagScalar() {
-		// NOTE: This is the worst scenario where a tag scalar is added 
+	// Appends a tag scalar to the state for each variant
+	private def appendTagScalarToVariantPatterns() {
 		def newState = Array<VariantPattern>.new(state.length);
-		var maxScalarWidth: byte = 0;
+		var maxScalarWidth = 0u8;
 		def curWidth = getWidthFromScalarSet(curRep[0]);
 		maxScalarWidth = if(maxScalarWidth < curWidth, curWidth, maxScalarWidth);
 		def refPatterns = if(maxScalarWidth == 32, ScalarPatterns.TAGGED_PTR_32, ScalarPatterns.TAGGED_PTR_64);
 		explicitTag = (state[0].scalars.length, Interval(0, tagType.width));
 		for (caseIdx < state.length) {
-			def variantPattern = state[caseIdx];
+			def variantPattern: VariantPattern = state[caseIdx];
 			def tagScalarPattern = refPatterns.nonref.copy();
 			// assign the tag
 			tagScalarPattern.assignInterval(explicitTag.1);
 			def newScalars = Arrays.append<ScalarPattern>(tagScalarPattern, variantPattern.scalars);
 			newState[caseIdx] = VariantPattern.new(newScalars);
 		}
-		var types = getTypes(true);
-		curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
-		curSoln.tagType = tagType;
-		curSoln.hasTagScalar = true;
-		curSoln.hasIntervals = usePacking;
-
-	}
-	private def createSolnForPackedADT() {
-		// Assuming that that ADT is packed. By default, the tag is in the 0th scalar
-		// TODO: Allow the tag to be packed in other scalars in the future 
-		var types = getTypes(false);
-		curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
-		curSoln.tagType = tagType;
-		curSoln.hasTagScalar = true;
-		curSoln.hasIntervals = usePacking;
+		state = newState;
 	}
 	private def getScalarPattern(s: Scalar) -> ScalarPattern {
 		// XXX: Should be based on scalar type
@@ -453,36 +444,8 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 			if (packingSoln != null) return true;
 			return false; // separate tagging scalar needed
 		}
-		// TODO: if nose use packing, case on the number of cases
+		// TODO: if no use packing, case on the number of cases
 		return !needTag;
-		
-
-		// if (normFields.length <= 1) {
-		// 	var types = getTypes(false);
-		// 	curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
-		// 	curSoln.hasIntervals = usePacking;
-		// 	return true; // single case is always distinguishable
-		// }
-
-		// var packedTag: bool;
-		// if (!usePacking) packedTag = tryExplicitTaggingHeuristic();
-
-		// var types = getTypes(!packedTag);
-		// curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
-		// /**
-		//  * As long as: 
-		//  * a.) the tag is packed into the same scalar as other fields 
-		//  * or 
-		//  * b.) the tag is placed in its own scalar
-		//  * tagType is valid because the tag bits are not dispersed
-		//  */
-		// curSoln.tagType = tagType;
-		// curSoln.hasTagScalar = !packedTag;
-		// curSoln.hasIntervals = usePacking;
-
-
-		// // TODO: try difficult tagging
-		// return true;
 	}
 	private def getTypes(useTagScalar: bool) -> Array<Type> {
 		var types = Array<Type>.new(curRep.length + if(useTagScalar, 1));

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -429,16 +429,8 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 	}
 	// Return whether a tag is needed
 	private def needTagScalar() -> bool {
-		// Cases
-		// 1.) usePacking and packing success- the refactored packing already does tagging
-		// 2.) usePacking but packing fails - default case and need explicit tag scalar
-		if (usePacking) {
-			if (packingSoln != null) return false;
-			return true; // separate tagging scalar needed
-		}
-		// No tag needed when: 
-		// 1.) called from unboxUsingTaggedVariantNorm but one case reachable
-		// 2.) called from unboxUsingTaglessVariantNorm
+		 // PackingSolver handles tag already if packing successful
+		if (usePacking && packingSoln != null) return false;
 		return normFields.length > 1;
 	}
 	private def getTypes(useTagScalar: bool) -> Array<Type> {

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -38,8 +38,9 @@ class VariantProblem {
 	var assignments = HashMap<CaseField, (int, Interval)>.new(CaseField.hash, CaseField.==); // pre-existing interval assignments
 	var usePacking: bool;					// whether to pack multiple fields into the same scalar
 	var tagType: IntType;
+	var needTag: bool;
 
-	new(normFields, baseState, usePacking, tagType) {}
+	new(normFields, baseState, usePacking, tagType, needTag) {}
 
 	def render(buf: StringBuilder) -> StringBuilder {
 		for (i < normFields.length) {
@@ -148,6 +149,7 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 	var state: Array<VariantPattern>;
 	var explicitTag: (int, Interval) = (-1, EMPTY_INTERVAL);
 	var explicitTagLength: byte;
+	var needTag: bool;
 
 	var curRep = Vector<Scalar.set>.new();
 	var curUsed = Vector<byte>.new();
@@ -182,6 +184,7 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		assignments = problem.assignments;
 		baseState = problem.baseState;
 		tagType = problem.tagType;
+		needTag = problem.needTag;
 
 
 		explicitTagLength = if(tagType != null, tagType.width, 0);
@@ -373,7 +376,10 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 	}
 	private def solveField(idx: int) -> bool {
 		if (idx >= fields.length) {
-			return checkDistinguishable();
+			def distinguishable = checkDistinguishable();
+			if (!distinguishable) createSolnWithTagScalar();
+			else createSolnForPackedADT();
+			return true;
 		}
 		var field = fields[idx];
 		var scalarIdx = assignments[field].0;
@@ -394,6 +400,38 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		}
 		return false;
 	}
+	private def createSolnWithTagScalar() {
+		// NOTE: This is the worst scenario where a tag scalar is added 
+		def newState = Array<VariantPattern>.new(state.length);
+		var maxScalarWidth: byte = 0;
+		def curWidth = getWidthFromScalarSet(curRep[0]);
+		maxScalarWidth = if(maxScalarWidth < curWidth, curWidth, maxScalarWidth);
+		def refPatterns = if(maxScalarWidth == 32, ScalarPatterns.TAGGED_PTR_32, ScalarPatterns.TAGGED_PTR_64);
+		explicitTag = (state[0].scalars.length, Interval(0, tagType.width));
+		for (caseIdx < state.length) {
+			def variantPattern = state[caseIdx];
+			def tagScalarPattern = refPatterns.nonref.copy();
+			// assign the tag
+			tagScalarPattern.assignInterval(explicitTag.1);
+			def newScalars = Arrays.append<ScalarPattern>(tagScalarPattern, variantPattern.scalars);
+			newState[caseIdx] = VariantPattern.new(newScalars);
+		}
+		var types = getTypes(true);
+		curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
+		curSoln.tagType = tagType;
+		curSoln.hasTagScalar = true;
+		curSoln.hasIntervals = usePacking;
+
+	}
+	private def createSolnForPackedADT() {
+		// Assuming that that ADT is packed. By default, the tag is in the 0th scalar
+		// TODO: Allow the tag to be packed in other scalars in the future 
+		var types = getTypes(false);
+		curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
+		curSoln.tagType = tagType;
+		curSoln.hasTagScalar = true;
+		curSoln.hasIntervals = usePacking;
+	}
 	private def getScalarPattern(s: Scalar) -> ScalarPattern {
 		// XXX: Should be based on scalar type
 		return ScalarPattern.new(Array<PackingBit>.new(s.width));
@@ -401,33 +439,50 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 	private def canDistinguish(active: Array<bool>) {
 		// TODO - this is where unassigned bits will get assigned
 	}
+	// Return whether a tag is needed
 	private def checkDistinguishable() -> bool {
-		if (normFields.length <= 1) {
-			var types = getTypes(false);
-			curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
-			curSoln.hasIntervals = usePacking;
-			return true; // single case is always distinguishable
+		// Cases
+		// 1.1) usePacking and packing success- the refactored packing already does tagging
+		// 1.2) usePacking but packing fails - default case and need explicit tag scalar
+		// 2.) !usePacking - could have 1 case or multicase
+		// 2.1) called from unboxUsingEnumVariantNorm - no tagging
+		// 2.2) called from unboxUsingTaggedVariantNorm but one case reachable
+		// - For now, need tag for type queries if not packed (must be in separate tag scalar
+		// 2.3) called from unboxUsingTaglessVariantNorm - no need for a tag
+		if (usePacking) {
+			if (packingSoln != null) return true;
+			return false; // separate tagging scalar needed
 		}
+		// TODO: if nose use packing, case on the number of cases
+		return !needTag;
+		
 
-		var packedTag: bool;
-		if (usePacking) packedTag = tryExplicitTaggingHeuristic();
+		// if (normFields.length <= 1) {
+		// 	var types = getTypes(false);
+		// 	curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
+		// 	curSoln.hasIntervals = usePacking;
+		// 	return true; // single case is always distinguishable
+		// }
 
-		var types = getTypes(!packedTag);
-		curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
-		/**
-		 * As long as: 
-		 * a.) the tag is packed into the same scalar as other fields 
-		 * or 
-		 * b.) the tag is placed in its own scalar
-		 * tagType is valid because the tag bits are not dispersed
-		 */
-		curSoln.tagType = tagType;
-		curSoln.hasTagScalar = !packedTag;
-		curSoln.hasIntervals = usePacking;
+		// var packedTag: bool;
+		// if (!usePacking) packedTag = tryExplicitTaggingHeuristic();
+
+		// var types = getTypes(!packedTag);
+		// curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
+		// /**
+		//  * As long as: 
+		//  * a.) the tag is packed into the same scalar as other fields 
+		//  * or 
+		//  * b.) the tag is placed in its own scalar
+		//  * tagType is valid because the tag bits are not dispersed
+		//  */
+		// curSoln.tagType = tagType;
+		// curSoln.hasTagScalar = !packedTag;
+		// curSoln.hasIntervals = usePacking;
 
 
-		// TODO: try difficult tagging
-		return true;
+		// // TODO: try difficult tagging
+		// return true;
 	}
 	private def getTypes(useTagScalar: bool) -> Array<Type> {
 		var types = Array<Type>.new(curRep.length + if(useTagScalar, 1));

--- a/aeneas/test/VariantSolverTest.v3
+++ b/aeneas/test/VariantSolverTest.v3
@@ -77,9 +77,8 @@ def getScalar_noUnify(t: Type) -> Scalar.set {
 }
 
 def createProblem(normFields: Array<Array<Type>>, baseState: Array<VariantPattern>, usePacking: bool) -> VariantProblem {
-	def needTag = !usePacking && normFields.length > 0;
 	def tagLength = Ints.log2Ceil(u32.view(normFields.length));
-	return VariantProblem.new(normFields, baseState, usePacking, Int.getType(false, tagLength), needTag);
+	return VariantProblem.new(normFields, baseState, usePacking, Int.getType(false, tagLength));
 }
 
 def test_simple(t: VariantSolverTester) {

--- a/aeneas/test/VariantSolverTest.v3
+++ b/aeneas/test/VariantSolverTest.v3
@@ -77,8 +77,9 @@ def getScalar_noUnify(t: Type) -> Scalar.set {
 }
 
 def createProblem(normFields: Array<Array<Type>>, baseState: Array<VariantPattern>, usePacking: bool) -> VariantProblem {
+	def needTag = !usePacking && normFields.length > 0;
 	def tagLength = Ints.log2Ceil(u32.view(normFields.length));
-	return VariantProblem.new(normFields, baseState, usePacking, Int.getType(false, tagLength));
+	return VariantProblem.new(normFields, baseState, usePacking, Int.getType(false, tagLength), needTag);
 }
 
 def test_simple(t: VariantSolverTester) {

--- a/lib/util/List.v3
+++ b/lib/util/List.v3
@@ -117,4 +117,13 @@ component Lists {
 		}
 		return buf;
 	}
+	// Returns the index of the element if it exists. Otherwise, returns -1
+	def find<T>(l: List<T>, target: T) -> int {
+		var idx = 0;
+		for (cur = l; cur != null; cur = cur.tail) { 
+			if (cur.head == target) return idx; 
+			else idx += 1;
+		}
+		return -1;
+	}
 }

--- a/test/variants/ub_tag06.v3
+++ b/test/variants/ub_tag06.v3
@@ -1,0 +1,26 @@
+//@execute 0=1; 1=0; 2=1; 3=1; 4=2; 5=3; 6=1; 7=4; 8=5 
+type A #unboxed {
+	case One(x: int, y: byte) #unboxed;
+	case Two(a: byte, y: bool) #unboxed; 
+}
+
+def arr: Array<A> = [
+	A.One(0, 1),
+	A.One(2, 3),
+	A.One(4, 5)
+];
+// NOTE: No tag should be used because only one variant is used
+def main(a: int) -> int {
+	match (a) {
+		0 => return int.view<bool>(A.One.?(arr[0])); // Testing type queries 
+		1 => return A.One.!(arr[0]).x;
+		2 => return A.One.!(arr[0]).y;
+		3 => return int.view<bool>(A.One.?(arr[1])); // Testing type queries 
+		4 => return A.One.!(arr[1]).x;
+		5 => return A.One.!(arr[1]).y;
+		6 => return int.view<bool>(A.One.?(arr[2])); // Testing type queries 
+		7 => return A.One.!(arr[2]).x;
+		8 => return A.One.!(arr[2]).y;
+		_ => return 42;
+	}
+}

--- a/test/variants/ub_tag07.v3
+++ b/test/variants/ub_tag07.v3
@@ -1,0 +1,24 @@
+//@execute 0=1; 1=0; 2=1; 3=1; 4=2; 5=3; 6=1; 7=4; 8=5 
+type A #unboxed {
+	case One(x: int, y: byte) #unboxed;
+	case Two(a: byte, y: bool) #unboxed; 
+}
+
+def foo0() -> A { return A.One(0, 1); }
+def foo1() -> A { return A.One(2, 3); }
+def foo2() -> A { return A.One(4, 5); }
+// NOTE: No tag should be used because only one variant is used
+def main(a: int) -> int {
+	match (a) {
+		0 => return int.view<bool>(A.One.?(foo0())); // Testing type queries 
+		1 => return A.One.!(foo0()).x;
+		2 => return A.One.!(foo0()).y;
+		3 => return int.view<bool>(A.One.?(foo1())); // Testing type queries 
+		4 => return A.One.!(foo1()).x;
+		5 => return A.One.!(foo1()).y;
+		6 => return int.view<bool>(A.One.?(foo2())); // Testing type queries 
+		7 => return A.One.!(foo2()).x;
+		8 => return A.One.!(foo2()).y;
+		_ => return 42;
+	}
+}

--- a/test/variants/ub_tag08.v3
+++ b/test/variants/ub_tag08.v3
@@ -1,0 +1,27 @@
+//@execute 0=1; 1=0; 2=0; 3=1; 4=2; 5=1; 6=1; 7=4; 8=0 
+type A #unboxed {
+	case One(x: int, y: byte) #unboxed;
+	case Two(x: byte, y: bool) #unboxed; 
+	case Three(x: bool, y: bool) #unboxed; 
+}
+
+def arr: Array<A> = [
+	A.Two(0, false),
+	A.Two(2, true),
+	A.Two(4, false)
+];
+// NOTE: No tag should be used because only one variant is used
+def main(a: int) -> int {
+	match (a) {
+		0 => return int.view<bool>(A.Two.?(arr[0])); // Testing type queries 
+		1 => return A.Two.!(arr[0]).x;
+		2 => return int.view<bool>(A.Two.!(arr[0]).y);
+		3 => return int.view<bool>(A.Two.?(arr[1])); // Testing type queries 
+		4 => return A.Two.!(arr[1]).x;
+		5 => return int.view<bool>(A.Two.!(arr[1]).y);
+		6 => return int.view<bool>(A.Two.?(arr[2])); // Testing type queries 
+		7 => return A.Two.!(arr[2]).x;
+		8 => return int.view<bool>(A.Two.!(arr[2]).y);
+		_ => return 42;
+	}
+}

--- a/test/variants/ub_tag09.v3
+++ b/test/variants/ub_tag09.v3
@@ -1,0 +1,25 @@
+//@execute 0=1; 1=0; 2=1; 3=1; 4=2; 5=0; 6=1; 7=4; 8=1 
+type A #unboxed {
+	case One(x: int, y: byte) #unboxed;
+	case Two(x: byte, y: bool) #unboxed; 
+	case Three(a: bool, y: bool) #unboxed; 
+}
+
+def foo0() -> A { return A.Two(0, true); }
+def foo1() -> A { return A.Two(2, false); }
+def foo2() -> A { return A.Two(4, true); }
+// NOTE: No tag should be used because only one variant is used
+def main(a: int) -> int {
+	match (a) {
+		0 => return int.view<bool>(A.Two.?(foo0())); // Testing type queries 
+		1 => return A.Two.!(foo0()).x;
+		2 => return int.view<bool>(A.Two.!(foo0()).y);
+		3 => return int.view<bool>(A.Two.?(foo1())); // Testing type queries 
+		4 => return A.Two.!(foo1()).x;
+		5 => return int.view<bool>(A.Two.!(foo1()).y);
+		6 => return int.view<bool>(A.Two.?(foo2())); // Testing type queries 
+		7 => return A.Two.!(foo2()).x;
+		8 => return int.view<bool>(A.Two.!(foo2()).y);
+		_ => return 42;
+	}
+}


### PR DESCRIPTION
Fix for https://github.com/titzer/virgil/issues/649
Unboxed Tagless Variants have a null VariantField. VariantNorm.tagType() doesn't case on the possibility of tag being null. VariantSolver slightly refactored to make tagging logic more clear.  