### PR TITLE
Fix Makefile line controlling running of jvm tests

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -15,7 +15,7 @@ ifneq ($(findstring x86-64-darwin,$(HOSTS)),)
 ALL += x86-64--darwin-runs
 endif
 
-ifneq ($(findstring jar,$(HOSTS)),jar)
+ifneq ($(findstring jar,$(HOSTS)),)
 ALL += jvm-runs
 endif
 


### PR DESCRIPTION
The findstring test was wrong so these runs never fired from ALL