### PR TITLE
[enums] Added Enum set case to norm type method in Normalization

### DIFF
--- a/aeneas/src/ir/Normalization.v3
+++ b/aeneas/src/ir/Normalization.v3
@@ -274,6 +274,9 @@ class ReachabilityNormalizer(config: NormalizerConfig, ra: ReachabilityAnalyzer)
 			ENUM => {
 				tn = TypeNorm.new(t, V3.getVariantTagType(t), null);
 			}
+			ENUM_SET => {
+				tn = TypeNorm.new(t, EnumSetType.!(t).repType, null);
+			}
 			REF => {
 				var sub = [
 					V3.arrayByteType,


### PR DESCRIPTION
Prior to this, encountering an enumset during normalization did not lead to errors. This PR is made for the sake of consistency.