### PR TITLE
fix: Set return type of VariantRepTag and VariantGetRepTag to Int.TYPE

### DIFF
--- a/aeneas/src/core/Operator.v3
+++ b/aeneas/src/core/Operator.v3
@@ -290,11 +290,11 @@ component V3Op {
 	}
 	def newVariantRepTag(vtype: Type) -> Operator {
 		var vt = [vtype];
-		return newOp0(Opcode.VariantRepTag, vt, arr_v, V3.classDecl(vtype).tagType); // TODO: representation tag type may be inaccurate
+		return newOp0(Opcode.VariantRepTag, vt, arr_v, Int.TYPE);
 	}
 	def newVariantGetRepTag(vtype: Type) -> Operator {
 		var vt = [vtype];
-		return newOp0(Opcode.VariantGetRepTag, vt, vt, V3.classDecl(vtype).tagType); // TODO: representation tag type may be inaccurate
+		return newOp0(Opcode.VariantGetRepTag, vt, vt, Int.TYPE);
 	}
 	def newVariantAlloc(t: Type, fieldTypes: Array<Type>) -> Operator {
 		return newOp0(Opcode.VariantAlloc, [t], fieldTypes, t);

--- a/test/open_types/ptag11.v3
+++ b/test/open_types/ptag11.v3
@@ -1,0 +1,24 @@
+//@execute 0=-195659606
+//@execute 0=-195659606; 1=1; 2=2; 3=3; 4=-195659590; 5=1; 6=2; 7=3; 8=-195725142; 9=1; 10=2; 11=3; 12=!BoundsCheckException
+type X {
+	def m() => 0;
+
+	case A(v: i30) { def m() => int.!(v); }
+	case _;
+}
+type Y<T> extends X {
+	case B(v: i30);
+	case C(v: i30);
+	case D(v: i30);
+}
+
+def vs: Array<X> = [
+	X.A(0xF45678AA), Y<void>.B(0xFF00FF0A), Y<void>.C(-1), Y<void>.D(-1),
+	X.A(0xF45678BA), Y<byte>.B(0xFF00EF0A), Y<byte>.C(-1), Y<byte>.D(-1),
+	X.A(0xF45578AA), Y<byte>.B(0xFE00FF0A), Y<long>.C(-1), Y<long>.D(-1)
+];
+
+def main(a: int) -> int {
+	var v = vs[a];
+	return v.tag + v.m();
+}


### PR DESCRIPTION
Problem: Through parsing, VstClasses have a tag type whose width is based on the largest source tag value. After normalization, polymorphic variants also contribute to the rep tag count. As a result, the rep tag type could be larger than that of the source tag type. 

Fix: Set the return type of VariantGetRepTag and VariantGetTag to be an i32.