### PR TITLE
[x86] Require a register for the source of a movq

### DIFF
--- a/aeneas/src/x86/X86CodeGen.v3
+++ b/aeneas/src/x86/X86CodeGen.v3
@@ -355,7 +355,7 @@ class X86CodeGen extends OldCodeGen {
 			X86Assembler.movq_sm_s,
 			dfnAt(vars[v.varNum], spill),
 			dfnAt(vars[v.varNum + 1], spill + 1),
-			use(i.input0())));
+			sse(i.input0())));	// movq's source must be a register, not a spill slot
 		return false;
 	}
 	def genWideIntTruncF(i: SsaApplyOp, orig: Operator, v: VReg, isDouble: bool) -> bool {

--- a/test/float/view_spill00.v3
+++ b/test/float/view_spill00.v3
@@ -1,0 +1,69 @@
+//@execute 0=1940904856
+//@heap-size=100000
+// `long.view(double)` is a movq out of an SSE register, so its operand cannot be
+// a spill slot; the x86 backend used an unconstrained use for it. Sixteen live
+// float/double locals is more than the eight XMM registers, which is what puts
+// the operand on the stack.
+def mix(h: int, x: int) -> int {
+	var t = h ^ x;
+	t = t * 0x01000193;
+	return t ^ (t >>> 15);
+}
+def mixl(h: int, x: long) -> int {
+	return mix(mix(h, int.view(u32.view(x))), int.view(u32.view(x >> 32)));
+}
+def mixf(h: int, f: float) -> int {
+	return mix(h, if(f != f, 0x4E614E00, int.view(f)));
+}
+def mixd(h: int, d: double) -> int {
+	if (d != d) return mix(h, 0x4E614E01);
+	return mixl(h, long.view(d));
+}
+def SEED: Array<float> = [
+	0.5f, -1.25f, 2f, -0.75f, 3.5f, -4.25f, 0.125f, -8f,
+	16f, -0.0625f, 7.75f, -2.5f, 1f, -1f, 0.25f, -32f
+];
+def DSEED: Array<double> = [
+	0.5d, -1.25d, 2d, -0.75d, 3.5d, -4.25d, 0.125d, -8d,
+	16d, -0.0625d, 7.75d, -2.5d, 1d, -1d, 0.25d, -32d
+];
+def main(a: int) -> int {
+	var f0 = SEED[0], f1 = SEED[1], f2 = SEED[2], f3 = SEED[3];
+	var f4 = SEED[4], f5 = SEED[5], f6 = SEED[6], f7 = SEED[7];
+	var d0 = DSEED[0], d1 = DSEED[1], d2 = DSEED[2], d3 = DSEED[3];
+	var d4 = DSEED[4], d5 = DSEED[5], d6 = DSEED[6], d7 = DSEED[7];
+	var i0 = 1, i1 = -2, i2 = 3, i3 = -4;
+	var l0: long = 5, l1: long = -6;
+	for (i < 400) {
+		f0 = f0 * 0.5f + float.roundd(d7 * 0.25d);
+		f1 = f1 * 0.5f + f0;
+		f2 = f2 * 0.5f - f1;
+		f3 = f3 * 0.5f + f2;
+		d0 = d0 * 0.5d + f3;			// implicit widening
+		d1 = d1 * 0.5d - d0;
+		d2 = d2 * 0.5d + d1;
+		d3 = d3 * 0.5d - d2;
+		f4 = f4 * 0.5f + float.roundd(d3);
+		f5 = f5 * 0.5f - f4;
+		f6 = f6 * 0.5f + f5;
+		f7 = f7 * 0.5f - f6;
+		d4 = d4 * 0.5d + f7;
+		d5 = d5 * 0.5d - d4;
+		d6 = d6 * 0.5d + d5;
+		d7 = d7 * 0.5d - d6;
+		i0 = i0 + (int.view(u32.view(long.view(d0))) & 0xFF);	// long.view of a spilled double
+		i1 = i1 - i0;
+		i2 = i2 ^ i1;
+		i3 = i3 + i2;
+		l0 = l0 * 3 + i3;
+		l1 = l1 - l0;
+	}
+	var h = mixf(0, f0);
+	h = mixf(h, f1); h = mixf(h, f2); h = mixf(h, f3);
+	h = mixf(h, f4); h = mixf(h, f5); h = mixf(h, f6); h = mixf(h, f7);
+	h = mixd(h, d0); h = mixd(h, d1); h = mixd(h, d2); h = mixd(h, d3);
+	h = mixd(h, d4); h = mixd(h, d5); h = mixd(h, d6); h = mixd(h, d7);
+	h = mix(h, i0); h = mix(h, i1); h = mix(h, i2); h = mix(h, i3);
+	h = mixl(h, l0); h = mixl(h, l1);
+	return h;
+}


### PR DESCRIPTION
genWideIntViewF lowers long.view(double) to a movq out of an SSE register into a frame slot, but declared its operand with a plain unconstrained use. With more live floating-point values than there are XMM registers the allocator puts it in a spill slot instead, and code generation fails outright:

  InternalError: required SSE register: spill#30

The added test keeps sixteen float and double locals live across a loop, which is more than the eight the target has.