### PR TITLE
[unboxing] Fix Variant unboxing scalar types representation

### DIFF
--- a/aeneas/src/ir/PackingSolver.v3
+++ b/aeneas/src/ir/PackingSolver.v3
@@ -78,6 +78,7 @@ class PackingSolver(width: byte, refPatterns: RefPatterns) {
 		def solution = PackingSolution.new(caseToScalars, assignments, false, problem);
 		if (DEBUG) Terminal.put1("%q\n", solution.render);
 		if (tagInterval != EMPTY_INTERVAL) solution.explicitTag = tagInterval;
+		if (DEBUG) Terminal.put("Packing success\n");
 		return solution;
 	}	
 	// Iterates over fields and constructs widthToField map for a case. 

--- a/aeneas/src/ir/PackingSolver.v3
+++ b/aeneas/src/ir/PackingSolver.v3
@@ -45,6 +45,12 @@ class PackingSolver(width: byte, refPatterns: RefPatterns) {
 		makeWidthToFieldMaps(problem);
 		makeCaseToScalars();
 		assignments = HashMap<CaseField, AssignedField>.new(CaseField.hash, CaseField.==);
+		// Condition on whether there are any cases before adding a new scalar
+		if (cases.length == 0) {
+			def emptyMap = HashMap<CaseField, AssignedField>.new(CaseField.hash, CaseField.==);
+			return PackingSolution.new(caseToScalars, emptyMap, false, problem);
+		}
+		caseToScalars.putScalar(widthToFieldMaps, refPatterns);
 		// Preprocessing before regular field assignments
 		processPreassignments(problem);
 		processRefs(problem, 0); // Start packing the first ref across each case
@@ -116,7 +122,6 @@ class PackingSolver(width: byte, refPatterns: RefPatterns) {
 	def makeCaseToScalars() {
 		def numCases = widthToFieldMaps.length;
 		caseToScalars = CaseToScalars.new(numCases, refPatterns.ptrref.size, REF_KEY);
-		caseToScalars.putScalar(widthToFieldMaps, refPatterns);
 	}
 	// Assigns fields that were preassigned by the problem. Adds the assignments to `assignments`
 	def processPreassignments(problem: PackingProblem) {

--- a/aeneas/src/ir/PackingSolver.v3
+++ b/aeneas/src/ir/PackingSolver.v3
@@ -47,7 +47,7 @@ class PackingSolver(width: byte, refPatterns: RefPatterns) {
 		assignments = HashMap<CaseField, AssignedField>.new(CaseField.hash, CaseField.==);
 		// Preprocessing before regular field assignments
 		processPreassignments(problem);
-		processRefs(problem, 0);
+		processRefs(problem, 0); // Start packing the first ref across each case
 		if (DEBUG) Terminal.put("Finished processing preassignments and ref\n");
 		// Calc tag interval
 		def defaultTagLength = byte.view(Ints.log2Ceil(u32.view(cases.length)));

--- a/aeneas/src/ir/SsaNormalizer.v3
+++ b/aeneas/src/ir/SsaNormalizer.v3
@@ -1710,7 +1710,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 
 			if (vn.hasExplicitTag()) {
 				var tagIdx = vn.tag.indexes[0];
-				if (IntRepType.?(vn.at(tagIdx))) result[tagIdx] = genSetInterval(result[tagIdx], newGraph.intConst(vn.tagValue), vn.tag.intervals[0], vn.tag.tn.newType, IntRepType.!(vn.at(tagIdx)));
+				if (IntType.?(vn.at(tagIdx))) result[tagIdx] = genSetInterval(result[tagIdx], newGraph.intConst(vn.tagValue), vn.tag.intervals[0], vn.tag.tn.newType, IntType.!(vn.at(tagIdx)));
 				else result[tagIdx] = newGraph.intConst(vn.tagValue);
 			}
 			// Pack the fields into the correct scalars
@@ -1720,7 +1720,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 				var os = f.rf.origIndices.0;
 				for (j < f.indexes.length) {
 					var idx = f.indexes[j];
-					if (IntRepType.?(vn.at(idx)) && f.intervals != null) result[idx] = genSetInterval(result[idx], ai_inputs[os + j], f.intervals[j], f.tn.at(j), IntRepType.!(vn.at(idx)));
+					if (IntType.?(vn.at(idx)) && f.intervals != null) result[idx] = genSetInterval(result[idx], ai_inputs[os + j], f.intervals[j], f.tn.at(j), IntType.!(vn.at(idx)));
 					else result[idx] = genVariantScalarView(f.tn.at(j), vn.at(idx), ai_inputs[os + j]);
 				}
 			}
@@ -1776,7 +1776,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 		}
 		return null;
 	}
-	def genSetInterval(scalar: SsaInstr, value: SsaInstr, interval: Interval, ft: Type, tt: IntRepType) -> SsaInstr {
+	def genSetInterval(scalar: SsaInstr, value: SsaInstr, interval: Interval, ft: Type, tt: IntType) -> SsaInstr {
 		var intRep = genVariantScalarView(ft, tt, value);
 		var width = interval.size();
 		if (width < tt.width && isSignedRep(ft)) {

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -335,15 +335,6 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		curSoln.tagType = tagType;
 		curSoln.hasIntervals = true;
 		return true;	
-		// var cases = Array<VariantPattern>.new(normFields.length);
-		// // build up patterns from the individual cases
-		// for (i < normFields.length) {
-		// 	var patterns = Array<ScalarPattern>.new(curRep.length);
-		// 	for (j < curRep.length) patterns[j] = getScalarPattern(getScalarFromSet(curRep[j]));
-		// 	cases[i] = VariantPattern.new(patterns);
-		// }
-		// state = cases;
-		// return solveField(0);
 	}
 	// Uses the interval assignments from PackingSolver to assign intervals in ScalarPatterns
 	private def assignIntervalsToPatterns(packingSoln: PackingSolution) -> Array<VariantPattern> {

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -212,13 +212,26 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 				}
 			}
 		}
+		// Packing path
+		if (usePacking && solvePacking()) return curSoln;
+		// Normal path 
 		var solvable = tryRepresentationForField(0, 0);
 		return if(solvable, curSoln, null);
 	}
+	// Determines the scalars to use for representing an ADT. 
+	// For a given case and field, tries assigning to a particular scalar
 	private def tryRepresentationForField(curCase: int, curField: int) -> bool {
 		if (curCase >= normFields.length) {
 			// XXX: check distinguishable
-			return solvePacking();
+			var cases = Array<VariantPattern>.new(normFields.length);
+                        // build up patterns from the individual cases
+                        for (i < normFields.length) {
+                        	var patterns = Array<ScalarPattern>.new(curRep.length);
+                        	for (j < curRep.length) patterns[j] = getScalarPattern(getScalarFromSet(curRep[j]));
+                        	cases[i] = VariantPattern.new(patterns);
+                        }
+                        state = cases;
+                        return solveField(0);
 		}
 		if (curField >= normFields[curCase].length) {
 			// move on to next case
@@ -289,52 +302,48 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		return false;
 	}
 	private def solvePacking() -> bool {
-		if (usePacking && curRep.length == 1) {
-			// Compute maxScalarWidth
-			var maxScalarWidth: byte = 0;
-			def curWidth = getWidthFromScalarSet(curRep[0]);
-			maxScalarWidth = if(maxScalarWidth < curWidth, curWidth, maxScalarWidth);
-			// Initialize Packing fields
-			def numCases = normFields.length;
-			def casesPacking = Array<Array<PackingField>>.new(numCases);
-			for (caseIdx < numCases) {
-				def caseNormFields = normFields[caseIdx];
-				def packingFields = Array<PackingField>.new(caseNormFields.length);
-				for (fieldIdx < caseNormFields.length) packingFields[fieldIdx] = getPackingFieldFromType(caseNormFields[fieldIdx]);
-				casesPacking[caseIdx] = packingFields;
-			}
-			// Run the PackingSolver
-			def packingProblem = PackingProblem(casesPacking, [], explicitTagLength, 1);
-			def refPatterns = if(maxScalarWidth == 32, ScalarPatterns.TAGGED_PTR_32, ScalarPatterns.TAGGED_PTR_64);
-			def packingSolver = PackingSolver.new(maxScalarWidth, refPatterns);
-			packingSoln = packingSolver.solve(packingProblem);
-			if (packingSoln == null) return false;
-			// Update `assignments`
-			for (caseIdx < numCases) {
-				for (fieldIdx < normFields[caseIdx].length) {
-					def interval = packingSoln.assignments[CaseField(caseIdx, fieldIdx)].interval;
-					assignments[CaseField(caseIdx, fieldIdx)] = (0, interval);
-				}
-			}
-			// Update `state`
-			state = assignIntervalsToPatterns(packingSoln);
-			// Update `explicitTag`
-			explicitTag = (0, packingSoln.explicitTag);
-			def types = getTypes(false);
-			curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
-			curSoln.tagType = tagType;
-			curSoln.hasIntervals = true;
-			return true;
-		}	
-		var cases = Array<VariantPattern>.new(normFields.length);
-		// build up patterns from the individual cases
-		for (i < normFields.length) {
-			var patterns = Array<ScalarPattern>.new(curRep.length);
-			for (j < curRep.length) patterns[j] = getScalarPattern(getScalarFromSet(curRep[j]));
-			cases[i] = VariantPattern.new(patterns);
+		// Compute maxScalarWidth
+		// Initialize Packing fields
+		def numCases = normFields.length;
+		def casesPacking = Array<Array<PackingField>>.new(numCases);
+		for (caseIdx < numCases) {
+			def caseNormFields = normFields[caseIdx];
+			def packingFields = Array<PackingField>.new(caseNormFields.length);
+			for (fieldIdx < caseNormFields.length) packingFields[fieldIdx] = getPackingFieldFromType(caseNormFields[fieldIdx]);
+			casesPacking[caseIdx] = packingFields;
 		}
-		state = cases;
-		return solveField(0);
+		// Run the PackingSolver
+		def packingProblem = PackingProblem(casesPacking, [], explicitTagLength, 1);
+		def refPatterns = if(nc.MaxScalarWidth == 32, ScalarPatterns.TAGGED_PTR_32, ScalarPatterns.TAGGED_PTR_64);
+		def packingSolver = PackingSolver.new(nc.MaxScalarWidth, refPatterns);
+		packingSoln = packingSolver.solve(packingProblem);
+		if (packingSoln == null) return false;
+		// Update `assignments`
+		for (caseIdx < numCases) {
+			for (fieldIdx < normFields[caseIdx].length) {
+				def interval = packingSoln.assignments[CaseField(caseIdx, fieldIdx)].interval;
+				assignments[CaseField(caseIdx, fieldIdx)] = (0, interval);
+			}
+		}
+		// Update `state`
+		state = assignIntervalsToPatterns(packingSoln);
+		// Update `explicitTag`
+		explicitTag = (0, packingSoln.explicitTag);
+		def scalars: Array<Scalar> = packingSoln.patterns.scalarTypes.extract();
+		def types: Array<Type> = Arrays.map(scalars, Scalar.ty);
+		curSoln = VariantSolution.new(normFields, assignments, state, explicitTag, types);
+		curSoln.tagType = tagType;
+		curSoln.hasIntervals = true;
+		return true;	
+		// var cases = Array<VariantPattern>.new(normFields.length);
+		// // build up patterns from the individual cases
+		// for (i < normFields.length) {
+		// 	var patterns = Array<ScalarPattern>.new(curRep.length);
+		// 	for (j < curRep.length) patterns[j] = getScalarPattern(getScalarFromSet(curRep[j]));
+		// 	cases[i] = VariantPattern.new(patterns);
+		// }
+		// state = cases;
+		// return solveField(0);
 	}
 	// Uses the interval assignments from PackingSolver to assign intervals in ScalarPatterns
 	private def assignIntervalsToPatterns(packingSoln: PackingSolution) -> Array<VariantPattern> {

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -179,7 +179,7 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		reset();
 		normFields = problem.normFields;
 		usePacking = problem.usePacking;
-		assignments = problem.assignments;
+		assignments = problem.assignments.copy(); // Avoid modifying `problem` instance
 		baseState = problem.baseState;
 		tagType = problem.tagType;
 
@@ -231,7 +231,7 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
                         	cases[i] = VariantPattern.new(patterns);
                         }
                         state = cases;
-                        return solveField(0);
+			return solveField(0);
 		}
 		if (curField >= normFields[curCase].length) {
 			// move on to next case

--- a/aeneas/src/jvm/JvmTarget.v3
+++ b/aeneas/src/jvm/JvmTarget.v3
@@ -39,7 +39,6 @@ class JvmTarget extends Target {
 		norm.MaxReturnValues = 10000;
 		norm.GetScalar = getScalar;
 		norm.WrapFuncTypeSubsume = true;
-		norm.MaxScalarWidth = 64;
 	}
 	private def isRefType(t: Type) -> bool {
 		match (t) {

--- a/aeneas/src/jvm/JvmTarget.v3
+++ b/aeneas/src/jvm/JvmTarget.v3
@@ -39,6 +39,7 @@ class JvmTarget extends Target {
 		norm.MaxReturnValues = 10000;
 		norm.GetScalar = getScalar;
 		norm.WrapFuncTypeSubsume = true;
+		norm.MaxScalarWidth = 64;
 	}
 	private def isRefType(t: Type) -> bool {
 		match (t) {

--- a/aeneas/src/os/Darwin.v3
+++ b/aeneas/src/os/Darwin.v3
@@ -24,6 +24,7 @@ class DarwinTarget extends Target {
 			compiler.NormConfig.RangeStartType = it; // XXX: use unsigned for range start type?
 //			compiler.NormConfig.ArrayIndexType = it; // TODO: enable 64-bit array index start?
 		}
+		compiler.NormConfig.MaxScalarWidth = space.addressWidth;
 		compiler.NormConfig.GetScalar = getScalar;
 		compiler.NormConfig.GetBitWidth = getBitWidth;
 		compiler.setLinkingModel(LinkingModel.NONE, LinkingModel.NONE);

--- a/aeneas/src/os/Linux.v3
+++ b/aeneas/src/os/Linux.v3
@@ -25,6 +25,7 @@ class LinuxTarget extends Target {
 			compiler.NormConfig.RangeStartType = it; // XXX: use unsigned for range start type?
 //			compiler.NormConfig.ArrayIndexType = it; // TODO: enable 64-bit array index start?
 		}
+		compiler.NormConfig.MaxScalarWidth = space.addressWidth;
 		compiler.NormConfig.GetScalar = getScalar;
 		compiler.NormConfig.GetBitWidth = getBitWidth;
 		var mod: LinkingModel = if(Debug.UNSTABLE, LinkingModel.SYSV, LinkingModel.NONE);

--- a/aeneas/src/wasm/WasmGcTarget.v3
+++ b/aeneas/src/wasm/WasmGcTarget.v3
@@ -137,6 +137,7 @@ class WasmGcTarget extends Target {
 		compiler.NormConfig.WrapFuncTypeSubsume = true;
 		compiler.NormConfig.AnyRefOverflow = false;
 		compiler.NormConfig.ExplicitRefTypeCast = true;
+		compiler.NormConfig.MaxScalarWidth = WasmCommon.SPACE.addressWidth;
 	}
 	private def getScalar(compiler: Compiler, prog: Program, t: Type) -> Scalar.set {
 		match (t) {

--- a/aeneas/src/wasm/WasmTarget.v3
+++ b/aeneas/src/wasm/WasmTarget.v3
@@ -107,6 +107,7 @@ class WasmTarget extends Target {
 		compiler.NormConfig.GetScalar = getScalar;
 		compiler.NormConfig.WrapFuncTypeSubsume = true;
 		compiler.NormConfig.AnyRefOverflow = false;
+		compiler.NormConfig.MaxScalarWidth = WasmCommon.SPACE.addressWidth;
 		compiler.setLinkingModel(LinkingModel.WASM, LinkingModel.WASM);
 	}
 	private def getScalar(compiler: Compiler, prog: Program, t: Type) -> Scalar.set {

--- a/aeneas/test/PackingSolverTest.v3
+++ b/aeneas/test/PackingSolverTest.v3
@@ -252,6 +252,7 @@ class PackingSolverTester(t: Tester) {
 		solver.assignments = HashMap<CaseField, AssignedField>.new(CaseField.hash, CaseField.==);
 		def assignments = solver.assignments;
 		def caseToScalars = solver.caseToScalars;
+		caseToScalars.putScalar(solver.widthToFieldMaps, solver.refPatterns);
 		def origScalar = caseToScalars.getScalarCopy(0, 0);
 		if (VERBOSE) Terminal.put1("origScalar: %q\n", origScalar.render);
 		solver.processPreassignments(problem);

--- a/aeneas/test/VariantSolverTest.v3
+++ b/aeneas/test/VariantSolverTest.v3
@@ -13,11 +13,12 @@ def getScalarWrapper(getScalar: Type -> Scalar.set, compiler: Compiler, prog: Pr
 	return getScalar(t);
 }
 def makeNormConfig(usedScalars: Scalar.set, getScalar: Type -> Scalar.set, getBitWidth: Type -> byte) -> NormalizerConfig {
-    var nc = NormalizerConfig.new();
-    nc.UsedScalars = usedScalars;
-    if (getScalar != null) nc.GetScalar = getScalarWrapper(getScalar, _, _, _);
-    if (getBitWidth != null) nc.GetBitWidth = getBitWidth;
-    return nc;
+	var nc = NormalizerConfig.new();
+	nc.MaxScalarWidth = 32;
+	nc.UsedScalars = usedScalars;
+	if (getScalar != null) nc.GetScalar = getScalarWrapper(getScalar, _, _, _);
+	if (getBitWidth != null) nc.GetBitWidth = getBitWidth;
+	return nc;
 }
 
 class VariantSolverTester(t: Tester) {
@@ -127,10 +128,12 @@ def test_packing(t: VariantSolverTester) {
 	t.assert_unsolvable_with_size(p, 1); // distinguishability criteria
 	t.assert_solvable_with_size(p, 2);
 
-	    def u64Type = Int.getType(false, 64);
+	nc.MaxScalarWidth = 64;
+	def u64Type = Int.getType(false, 64);
 	p = createProblem([[u64Type], [u64Type]], null, true);
 	t.assert_unsolvable_with_size(p, 1); // distinguishability criteria
 	t.assert_solvable_with_size(p, 2);
+	nc.MaxScalarWidth = 32;
 
 	// Generic packing case
 	p = createProblem([[Int.getType(false, 8), Int.getType(false, 16), Int.getType(false, 7)], 
@@ -185,7 +188,7 @@ def test_packing(t: VariantSolverTester) {
 def getScalar_unify0(t: Type) -> Scalar.set {
 	match (t) {
 		x: IntType => return if(x.width <= 32, Scalar.B32 | Scalar.B64, Scalar.B64);
-		x: FloatType => return if(x.is64, Scalar.F64 | Scalar.B32, Scalar.F32 | Scalar.B32);
+		x: FloatType => return if(x.is64, Scalar.F64, Scalar.F32 | Scalar.B32 | Scalar.F64 | Scalar.B64);
 		x: BoolType => return Scalar.B32 | Scalar.B64 | Scalar.F32 | Scalar.F64;
 		_ => return Scalar.Ref;
 	}
@@ -193,12 +196,14 @@ def getScalar_unify0(t: Type) -> Scalar.set {
 def test_unify(t: VariantSolverTester) {
 	var nc = makeNormConfig(Scalar.B32 | Scalar.F32, getScalar_unify0, null), p: VariantProblem;
 	t.useSolver(VariantSolver.new(nc, getScalar_unify0));
+	t.solver.usePacking = false;
 
 	p = createProblem([[Int.TYPE], [Float.FLOAT32]], null, false);
 	t.assert_unsolvable_with_size(p, 1);
-    t.assert_solvable_with_size(p, 2);
+	t.assert_solvable_with_size(p, 2); // Use B32 for int and float (assuming you can); use another scalar for tag
 
-    p = createProblem([[Int.TYPE], [Float.FLOAT64]], null, false);
-    t.assert_unsolvable_with_size(p, 2);
-    t.assert_solvable_with_size(p, 3);
+	// Assuming that the f64 types can only go in f64 scalars
+	p = createProblem([[Int.TYPE], [Float.FLOAT64]], null, false);
+	t.assert_unsolvable_with_size(p, 2);
+	t.assert_solvable_with_size(p, 3);
 }

--- a/lib/util/Map.v3
+++ b/lib/util/Map.v3
@@ -107,6 +107,13 @@ class HashMap<K, V> extends PartialMap<K, V> {
 			}
 		}
 	}
+	// Creates a new (shallow) copy of this hashmap
+	def copy() -> HashMap<K, V> {
+		def newMap = HashMap<K, V>.new(hash, equals);
+		def addToNew(k: K, v: V) { newMap[k] = v; }
+		this.apply(addToNew);
+		return newMap;
+	}
 	// Remove {key} from this map. Return true if {key} existed.
 	def remove(key: K) -> bool {
 		var c = cache;

--- a/test/open_types/ptag11c.v3
+++ b/test/open_types/ptag11c.v3
@@ -1,0 +1,23 @@
+//@execute 0=-195659606; 1=1; 2=2; 3=3; 4=-195659590; 5=1; 6=2; 7=3; 8=-195725142; 9=1; 10=2; 11=3; 12=!BoundsCheckException
+type X #unboxed #packed {
+	def m() => 0;
+
+	case A(v: i30) { def m() => int.!(v); }
+	case _;
+}
+type Y<T> extends X #unboxed #packed {
+	case B(v: i30);
+	case C(v: i30);
+	case D(v: i30);
+}
+
+def vs: Array<X> = [
+	X.A(0xF45678AA), Y<void>.B(0xFF00FF0A), Y<void>.C(-1), Y<void>.D(-1),
+	X.A(0xF45678BA), Y<byte>.B(0xFF00EF0A), Y<byte>.C(-1), Y<byte>.D(-1),
+	X.A(0xF45578AA), Y<byte>.B(0xFE00FF0A), Y<long>.C(-1), Y<long>.D(-1)
+];
+
+def main(a: int) -> int {
+	var v = vs[a];
+	return v.tag + v.m();
+}

--- a/test/variants/sign_pack_multi00a.v3
+++ b/test/variants/sign_pack_multi00a.v3
@@ -1,0 +1,10 @@
+//@execute 0=-100
+type B2 #unboxed #packed {
+	case T(a: i16, b: i8) #unboxed #packed;
+	case F #unboxed #packed;
+}
+def main(k: int) -> int {
+	var v: B2 = B2.T(i16.view(k - 100), i8.view(k - 60));
+	var t = B2.T.!(v);
+	return int.!(t.a);
+}


### PR DESCRIPTION
ptag11c.v3 was the failing test case. 

Problem: The default unboxing logic and the packing solver each have their own logic for determining the scalar representation of the unboxed ADT. When packing occurs, the variant solver mixed the representations.

Solution: Isolate the packing solver logic from the default unboxing logic. Variant solver first tries to invoke the packing solver. If that fails, then we default to the original unboxing logic: 1 field per scalar.