### PR TITLE
[packing] Reference handling in PackingSolver

### DIFF
--- a/aeneas/src/ir/Normalization.v3
+++ b/aeneas/src/ir/Normalization.v3
@@ -20,7 +20,7 @@ class NormalizerConfig {
 
 	var GetScalar: (Compiler, Program, Type) -> Scalar.set = defaultGetScalar;
 	var GetBitWidth: Type -> byte = defaultGetBitWidth;
-	var MaxScalarWidth: byte = 64;
+	var MaxScalarWidth: byte = 64u8;
 
 	def setSignatureLimits(maxp: int, maxr: int) {
 		if (maxp < MaxParams) MaxParams = maxp;

--- a/aeneas/src/ir/PackingSolver.v3
+++ b/aeneas/src/ir/PackingSolver.v3
@@ -21,12 +21,11 @@ def EMPTY_INTERVAL = Interval(0, 0);
 
 // Contains a number of routines for checking distinguishability of bit patterns and solving for
 // sets of patterns (by choosing assignments of bits).
-class PackingSolver(width: byte, refPatterns: RefPatterns) {
+class PackingSolver(width: byte, nc: NormalizerConfig, UNIFY: bool) {
 	// ----------------- Constants -----------------
 	var SCALAR_LIMIT = 2;
 	def DEBUG = CLOptions.PRINT_PACKING.get();
 	def REF_KEY = -1;
-	def SCALAR_WIDTH = if(refPatterns != null, refPatterns.ptrref.size, width);
 	// ----------------- Data structures -----------------
 	// Array of maps for each case/variant. 
 	// For each map, keys are a width and values are a list of fields with that width
@@ -47,7 +46,7 @@ class PackingSolver(width: byte, refPatterns: RefPatterns) {
 		assignments = HashMap<CaseField, AssignedField>.new(CaseField.hash, CaseField.==);
 
 		if (cases.length == 0) return PackingSolution.new(caseToScalars, assignments, false, problem);
-		caseToScalars.putScalar(widthToFieldMaps, refPatterns);
+		caseToScalars.putScalar(widthToFieldMaps);
 		// Preprocessing before regular field assignments
 		processPreassignments(problem);
 		processRefs(problem, 0);
@@ -70,7 +69,7 @@ class PackingSolver(width: byte, refPatterns: RefPatterns) {
 				if (scalarIdx == SCALAR_LIMIT - 1) return null;
 				if (scalarIdx < caseToScalars.getNumScalars() - 1) continue;
 
-				caseToScalars.putScalar(widthToFieldMaps, refPatterns);
+				caseToScalars.putScalar(widthToFieldMaps);
 				if (caseToScalars.getScalarType(caseToScalars.getNumScalars() - 1) == Scalar.Ref) {
 					processRefs(problem, scalarIdx + 1);
 				}
@@ -117,7 +116,7 @@ class PackingSolver(width: byte, refPatterns: RefPatterns) {
 	// Initializes scalars (ScalarPatterns) for each case
 	def makeCaseToScalars() {
 		def numCases = widthToFieldMaps.length;
-		caseToScalars = CaseToScalars.new(numCases, refPatterns.ptrref.size, REF_KEY);
+		caseToScalars = CaseToScalars.new(numCases, REF_KEY, nc);
 	}
 	// Assigns fields that were preassigned by the problem. Adds the assignments to `assignments`
 	def processPreassignments(problem: PackingProblem) {
@@ -138,6 +137,7 @@ class PackingSolver(width: byte, refPatterns: RefPatterns) {
 			def widthToField = widthToFieldMaps[caseIdx];
 			if (!widthToField.has(REF_KEY)) continue;
 			if (DEBUG) Terminal.put2("Case: %d | Scalar: %d has ref\n", caseIdx, scalarIdx);
+			def refPatterns = if(nc.MaxScalarWidth <= 32, ScalarPatterns.TAGGED_PTR_32, ScalarPatterns.TAGGED_PTR_64);
 			caseToScalars.assignInterval(caseIdx, scalarIdx, refPatterns.refInterval);
 			def caseField = popFromWidthToField(widthToField, REF_KEY);
 			assignments[caseField] = AssignedField(caseField, byte.view(scalarIdx), refPatterns.refInterval);
@@ -178,6 +178,13 @@ class PackingSolver(width: byte, refPatterns: RefPatterns) {
 	def assignFieldsToScalar(caseIdx: int, scalarIdx: int) -> bool {
 		def widthToField: HashMap<int, List<CaseField>> = widthToFieldMaps[caseIdx];
 		if (DEBUG) Terminal.put2("Case: %d | Scalar: %d\n", caseIdx, scalarIdx);
+		// TODO: Enable when operators between references and ints for tagged references become available
+		// Need to change genVariantGetField, genExtractInterval, and genSetInterval to case on the scalar type properly
+		if (!UNIFY && caseToScalars.isRefScalar(scalarIdx)) {
+			if (DEBUG) Terminal.put("Current scalar is a ref scalar\n");
+			if (DEBUG) Terminal.put2("scalar %d: %q\n", scalarIdx, caseToScalars.renderScalar(caseIdx, scalarIdx, _));
+			return false;
+		}
 		var unassignedIntervals: Array<Interval> = caseToScalars.getUnassignedIntervals(caseIdx, scalarIdx);
 		if (DEBUG) Terminal.put1("Unassigned intervals: %q\n", printIntervals(unassignedIntervals, _));
 		if (DEBUG) Terminal.put2("scalar %d: %q\n", scalarIdx, caseToScalars.renderScalar(caseIdx, scalarIdx, _));
@@ -364,10 +371,11 @@ type PackingProblem (
 // Defines functionality for operating on scalars of each variant/case
 class CaseToScalars {
 	// ----------------- Constants -----------------
-	def SCALAR_WIDTH: int;
+	def NC: NormalizerConfig;
 	def DEBUG = CLOptions.PRINT_PACKING.get();
 	def REF_KEY: int;
 	def NUM_CASES: int;
+	var REF_PATTERNS: RefPatterns;
 	// ----------------- Data structures -----------------
 	// Stores the scalars for each case
 	var caseToScalars: Array<Vector<ScalarPattern>>;
@@ -379,17 +387,21 @@ class CaseToScalars {
 	private var taggedRefScalarType: Scalar;
 	// NOTE: The ith scalar of every case should be the same type
 
-	new (NUM_CASES, SCALAR_WIDTH, REF_KEY) {
+	new (NUM_CASES, REF_KEY, NC) {
 		// TODO: Replace with getScalar from NormConfig
-		bNNScalarType = if(SCALAR_WIDTH == 32, Scalar.B32, Scalar.B64);
-		taggedRefScalarType = if(SCALAR_WIDTH == 32, Scalar.R32, Scalar.R64);
+		// bNNScalarType = if(SCALAR_WIDTH == 32, Scalar.B32, Scalar.B64);
+		// taggedRefScalarType = if(SCALAR_WIDTH == 32, Scalar.R32, Scalar.R64);
+		def use32 = NC.MaxScalarWidth <= 32;
+		bNNScalarType = if(use32, Scalar.B32, Scalar.B64);
+		taggedRefScalarType = if(use32, Scalar.R32, Scalar.R64);
+		REF_PATTERNS = if(use32, ScalarPatterns.TAGGED_PTR_32, ScalarPatterns.TAGGED_PTR_64);
 		caseToScalars = Array<Vector<ScalarPattern>>.new(NUM_CASES);
 		for (i < caseToScalars.length) caseToScalars[i] = Vector<ScalarPattern>.new();
 		scalarTypes = Vector<Scalar>.new();
 		caseHasRefArr = Array<bool>.new(NUM_CASES);
 	}
 	// Adds a new scalar to every case, depending on which fields remain
-	def putScalar(widthToFieldMaps: Array<HashMap<int, List<CaseField>>>, refPatterns: RefPatterns) {
+	def putScalar(widthToFieldMaps: Array<HashMap<int, List<CaseField>>>) {
 		// Populate `caseHasRefArr` for use later when determining what type of scalar to use.
 		for (i < NUM_CASES) caseHasRefArr[i] = widthToFieldMaps[i].has(REF_KEY);
 		var allCasesHaveRefs = true;
@@ -401,30 +413,30 @@ class CaseToScalars {
 			if (!oneCaseHasRef && caseHasRefArr[i]) { oneCaseHasRef = true; break; }
 		}
 		if (allCasesHaveRefs) {
-			putRefScalar(refPatterns);
+			putRefScalar();
 		} else if (oneCaseHasRef) {
-			putTaggedRefScalar(refPatterns);
+			putTaggedRefScalar();
 		} else {
-			putNonrefScalar(refPatterns);
+			putNonrefScalar();
 		}
 	}
 	// Adds a basic scalar to every case and updates scalarTypes
-	def putNonrefScalar(refPatterns: RefPatterns) {
-		for (caseScalars in caseToScalars) caseScalars.put(refPatterns.nonref.copy());
+	def putNonrefScalar() {
+		for (caseScalars in caseToScalars) caseScalars.put(REF_PATTERNS.nonref.copy());
 		scalarTypes.put(bNNScalarType);
 	}
 	// Adds a tagged ref scalar to every case and updates scalarTypes. Cases on whether case has a ref
-	def putTaggedRefScalar(refPatterns: RefPatterns) {
+	def putTaggedRefScalar() {
 		for (caseIdx < caseToScalars.length) {
 			def caseScalars = caseToScalars[caseIdx];
-			def scalarPattern = if(caseHasRefArr[caseIdx], refPatterns.ptrref.copy(), refPatterns.nonptrref.copy());
+			def scalarPattern = if(caseHasRefArr[caseIdx], REF_PATTERNS.ptrref.copy(), REF_PATTERNS.nonptrref.copy());
 			caseScalars.put(scalarPattern);	
 		}
 		scalarTypes.put(taggedRefScalarType);
 	}
 	// Adds a ref scalar to every case and updates scalarTypes. Cases on whether case has a ref
-	def putRefScalar(refPatterns: RefPatterns) {
-		for (caseScalars in caseToScalars) caseScalars.put(refPatterns.ptrref.copy());
+	def putRefScalar() {
+		for (caseScalars in caseToScalars) caseScalars.put(REF_PATTERNS.ptrref.copy());
 		scalarTypes.put(Scalar.Ref);
 	}
 	// Returns the scalar type for the ith scalar in every case
@@ -456,7 +468,7 @@ class CaseToScalars {
 		// Find valid start idx
 		if (DEBUG) Terminal.put1("tagLength: %d\n", tagLength);
 		var start = 0u8;
-		for (i < SCALAR_WIDTH) {
+		for (i < NC.MaxScalarWidth) {
 			def b = caseToScalars[0][0].bits[start];
 			match (b) {
 				Unassigned => break;
@@ -464,7 +476,7 @@ class CaseToScalars {
 			}
 		}
 		var tagInterval = Interval(start, start + tagLength);
-		while (tagInterval.end <= byte.view(SCALAR_WIDTH)) {
+		while (tagInterval.end <= byte.view(NC.MaxScalarWidth)) {
 			def result: (bool, byte)  = isTagIntervalValid(tagInterval);
 			if (DEBUG && result.0) Terminal.put1("tagInterval: %q\n", tagInterval.render);
 			if (result.0) return (true, tagInterval);

--- a/aeneas/src/ir/PackingSolver.v3
+++ b/aeneas/src/ir/PackingSolver.v3
@@ -21,7 +21,7 @@ def EMPTY_INTERVAL = Interval(0, 0);
 
 // Contains a number of routines for checking distinguishability of bit patterns and solving for
 // sets of patterns (by choosing assignments of bits).
-class PackingSolver(width: byte, nc: NormalizerConfig, UNIFY: bool) {
+class PackingSolver(MAX_SCALAR_WIDTH: byte, UNIFY: bool) {
 	// ----------------- Constants -----------------
 	var SCALAR_LIMIT = 2;
 	def DEBUG = CLOptions.PRINT_PACKING.get();
@@ -116,7 +116,7 @@ class PackingSolver(width: byte, nc: NormalizerConfig, UNIFY: bool) {
 	// Initializes scalars (ScalarPatterns) for each case
 	def makeCaseToScalars() {
 		def numCases = widthToFieldMaps.length;
-		caseToScalars = CaseToScalars.new(numCases, REF_KEY, nc);
+		caseToScalars = CaseToScalars.new(numCases, REF_KEY, MAX_SCALAR_WIDTH);
 	}
 	// Assigns fields that were preassigned by the problem. Adds the assignments to `assignments`
 	def processPreassignments(problem: PackingProblem) {
@@ -137,7 +137,7 @@ class PackingSolver(width: byte, nc: NormalizerConfig, UNIFY: bool) {
 			def widthToField = widthToFieldMaps[caseIdx];
 			if (!widthToField.has(REF_KEY)) continue;
 			if (DEBUG) Terminal.put2("Case: %d | Scalar: %d has ref\n", caseIdx, scalarIdx);
-			def refPatterns = if(nc.MaxScalarWidth <= 32, ScalarPatterns.TAGGED_PTR_32, ScalarPatterns.TAGGED_PTR_64);
+			def refPatterns = if(MAX_SCALAR_WIDTH <= 32, ScalarPatterns.TAGGED_PTR_32, ScalarPatterns.TAGGED_PTR_64);
 			caseToScalars.assignInterval(caseIdx, scalarIdx, refPatterns.refInterval);
 			def caseField = popFromWidthToField(widthToField, REF_KEY);
 			assignments[caseField] = AssignedField(caseField, byte.view(scalarIdx), refPatterns.refInterval);
@@ -250,7 +250,7 @@ class PackingSolver(width: byte, nc: NormalizerConfig, UNIFY: bool) {
 		if (numElements <= 1) return true;
 
 		var candidates = Vector<(int, int)>.new();
-		for (i < width) {
+		for (i < MAX_SCALAR_WIDTH) {
 			// try to split on this bit
 			var numZeros = 0, numOnes = 0, numUnassigned = 0;
 			for (j < state.length) {
@@ -371,11 +371,11 @@ type PackingProblem (
 // Defines functionality for operating on scalars of each variant/case
 class CaseToScalars {
 	// ----------------- Constants -----------------
-	def NC: NormalizerConfig;
 	def DEBUG = CLOptions.PRINT_PACKING.get();
 	def REF_KEY: int;
 	def NUM_CASES: int;
 	var REF_PATTERNS: RefPatterns;
+	def MAX_SCALAR_WIDTH: byte;
 	// ----------------- Data structures -----------------
 	// Stores the scalars for each case
 	var caseToScalars: Array<Vector<ScalarPattern>>;
@@ -387,11 +387,11 @@ class CaseToScalars {
 	private var taggedRefScalarType: Scalar;
 	// NOTE: The ith scalar of every case should be the same type
 
-	new (NUM_CASES, REF_KEY, NC) {
+	new (NUM_CASES, REF_KEY, MAX_SCALAR_WIDTH) {
 		// TODO: Replace with getScalar from NormConfig
 		// bNNScalarType = if(SCALAR_WIDTH == 32, Scalar.B32, Scalar.B64);
 		// taggedRefScalarType = if(SCALAR_WIDTH == 32, Scalar.R32, Scalar.R64);
-		def use32 = NC.MaxScalarWidth <= 32;
+		def use32 = MAX_SCALAR_WIDTH <= 32;
 		bNNScalarType = if(use32, Scalar.B32, Scalar.B64);
 		taggedRefScalarType = if(use32, Scalar.R32, Scalar.R64);
 		REF_PATTERNS = if(use32, ScalarPatterns.TAGGED_PTR_32, ScalarPatterns.TAGGED_PTR_64);
@@ -468,7 +468,7 @@ class CaseToScalars {
 		// Find valid start idx
 		if (DEBUG) Terminal.put1("tagLength: %d\n", tagLength);
 		var start = 0u8;
-		for (i < NC.MaxScalarWidth) {
+		for (i < MAX_SCALAR_WIDTH) {
 			def b = caseToScalars[0][0].bits[start];
 			match (b) {
 				Unassigned => break;
@@ -476,7 +476,7 @@ class CaseToScalars {
 			}
 		}
 		var tagInterval = Interval(start, start + tagLength);
-		while (tagInterval.end <= byte.view(NC.MaxScalarWidth)) {
+		while (tagInterval.end <= byte.view(MAX_SCALAR_WIDTH)) {
 			def result: (bool, byte)  = isTagIntervalValid(tagInterval);
 			if (DEBUG && result.0) Terminal.put1("tagInterval: %q\n", tagInterval.render);
 			if (result.0) return (true, tagInterval);

--- a/aeneas/src/ir/SsaNormalizer.v3
+++ b/aeneas/src/ir/SsaNormalizer.v3
@@ -1811,6 +1811,7 @@ class SsaRaNormalizer extends SsaRebuilder {
 					def scalarIdx = field.indexes[i];
 					def interval = field.intervals[i];
 					def scalar = ninputs[scalarIdx];
+					if (!IntType.?(scalar.getType())) { vals[i] = scalar; continue; }
 					vals[i] = genExtractInterval(scalar, interval, scalar.getType(), field.tn.at(i));
 				}
 			} else {

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -312,7 +312,7 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		// Run the PackingSolver
 		def packingProblem = PackingProblem(casesPacking, [], explicitTagLength, 1);
 		// TODO: Enable unifying nonrefernces and references into single scalars (i.e tagged references)
-		def packingSolver = PackingSolver.new(nc.MaxScalarWidth, nc, false);
+		def packingSolver = PackingSolver.new(nc.MaxScalarWidth, false);
 		packingSoln = packingSolver.solve(packingProblem);
 		if (packingSoln == null) return false;
 		// Update `assignments`

--- a/aeneas/src/ir/VariantSolver.v3
+++ b/aeneas/src/ir/VariantSolver.v3
@@ -311,8 +311,8 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		}
 		// Run the PackingSolver
 		def packingProblem = PackingProblem(casesPacking, [], explicitTagLength, 1);
-		def refPatterns = if(nc.MaxScalarWidth == 32, ScalarPatterns.TAGGED_PTR_32, ScalarPatterns.TAGGED_PTR_64);
-		def packingSolver = PackingSolver.new(nc.MaxScalarWidth, refPatterns);
+		// TODO: Enable unifying nonrefernces and references into single scalars (i.e tagged references)
+		def packingSolver = PackingSolver.new(nc.MaxScalarWidth, nc, false);
 		packingSoln = packingSolver.solve(packingProblem);
 		if (packingSoln == null) return false;
 		// Update `assignments`
@@ -364,7 +364,8 @@ class VariantSolver(nc: NormalizerConfig, getScalar: Type -> Scalar.set) {
 		// Use NormalizerConfig to determine whether the field is a ref or not
 		def emptySet: Scalar.set;
 		def scalarsForFieldType = getScalar(t);
-		return scalarsForFieldType.Ref;
+		def refScalars = Scalar.Ref | if(nc.MaxScalarWidth <= 32, Scalar.R32, Scalar.R64);
+		return (refScalars & scalarsForFieldType) != emptySet;
 	}
 	private def getWidthFromScalarSet(scalarSet: Scalar.set) -> byte {
 		def scalarSetOfAll32 = Scalar.B32 | Scalar.F32 | Scalar.R32;

--- a/aeneas/test/PackingSolverTest.v3
+++ b/aeneas/test/PackingSolverTest.v3
@@ -25,11 +25,11 @@ class PackingSolverTester(t: Tester) {
 	def useSolver(s: PackingSolver) { solver = s; }
 	def useSolver32() { 
 		def nc = makeNormConfig(Scalar.B32, getScalar_unify0, null, 32);
-		solver = PackingSolver.new(32, nc, true);
+		solver = PackingSolver.new(32, true);
 	}
 	def useSolver64() { 
 		def nc = makeNormConfig(Scalar.B64, getScalar_unify0, null, 64);
-		solver = PackingSolver.new(64, nc, true); 
+		solver = PackingSolver.new(64, true); 
 	}
 	private def trySolve(problem: PackingProblem) -> PackingSolution { return solver.solve(problem); }	
 	def makeNormConfig(usedScalars: Scalar.set, getScalar: Type -> Scalar.set, getBitWidth: Type -> byte, maxScalarWidth: byte) -> NormalizerConfig {
@@ -372,7 +372,7 @@ def I = Interval;
 
 def test_distinguishable(t: PackingSolverTester) {
 	def nc = t.makeNormConfig(Scalar.B32, t.getScalar_noUnify, null, 6);
-	t.useSolver(PackingSolver.new(6, nc, false));
+	t.useSolver(PackingSolver.new(6, false));
 
 	t.assert_indistinguishable([
 		ScalarPatterns.parse("000000"),

--- a/aeneas/test/PackingSolverTest.v3
+++ b/aeneas/test/PackingSolverTest.v3
@@ -23,7 +23,42 @@ def VERBOSE = false;
 class PackingSolverTester(t: Tester) {
 	var solver: PackingSolver;
 	def useSolver(s: PackingSolver) { solver = s; }
+	def useSolver32() { 
+		def nc = makeNormConfig(Scalar.B32, getScalar_unify0, null, 32);
+		solver = PackingSolver.new(32, nc, true);
+	}
+	def useSolver64() { 
+		def nc = makeNormConfig(Scalar.B64, getScalar_unify0, null, 64);
+		solver = PackingSolver.new(64, nc, true); 
+	}
 	private def trySolve(problem: PackingProblem) -> PackingSolution { return solver.solve(problem); }	
+	def makeNormConfig(usedScalars: Scalar.set, getScalar: Type -> Scalar.set, getBitWidth: Type -> byte, maxScalarWidth: byte) -> NormalizerConfig {
+	    var nc = NormalizerConfig.new();
+	    nc.UsedScalars = usedScalars;
+	    nc.MaxScalarWidth = maxScalarWidth;
+	    if (getScalar != null) nc.GetScalar = getScalarWrapper(getScalar, _, _, _);
+	    if (getBitWidth != null) nc.GetBitWidth = getBitWidth;
+	    return nc;
+	}
+	def getScalarWrapper(getScalar: Type -> Scalar.set, compiler: Compiler, prog: Program, t: Type) -> Scalar.set {
+		return getScalar(t);
+	}
+	def getScalar_unify0(t: Type) -> Scalar.set {
+		match (t) {
+			x: IntType => return if(x.width <= 32, Scalar.B32 | Scalar.B64, Scalar.B64);
+			x: FloatType => return if(x.is64, Scalar.F64, Scalar.F32 | Scalar.B32);
+			x: BoolType => return Scalar.B32 | Scalar.B64 | Scalar.F32 | Scalar.F64;
+			_ => return Scalar.Ref;
+		}
+	}
+	def getScalar_noUnify(t: Type) -> Scalar.set {
+		match (t) {
+			x: IntType => return if(x.width > 32, Scalar.B64, Scalar.B32);
+			x: FloatType => return if(x.is64, Scalar.F64, Scalar.F32);
+			x: BoolType => return Scalar.B32;
+			_ => return Scalar.Ref;
+		}
+	}
 	def printPackingField(f: PackingField) {
 		match (f) {
 			Nonref(width) => Terminal.put1("Nonref(%d)", width);
@@ -102,8 +137,13 @@ class PackingSolverTester(t: Tester) {
 		}
 		return false;
 	}
+	// Uses the solver's normalizer config  to return a RefPatterns
+	def getRefPatterns(solver: PackingSolver) -> RefPatterns {
+		return if(solver.nc.MaxScalarWidth <= 32, ScalarPatterns.TAGGED_PTR_32, ScalarPatterns.TAGGED_PTR_64);
+	}
 	// Initializes scalars based on the type of the scalar and the ref patterns
-	def initExpectedScalars(caseToScalars: CaseToScalars, refPatterns: RefPatterns, hasRef: bool) -> Array<ScalarPattern> {
+	def initExpectedScalars(caseToScalars: CaseToScalars, hasRef: bool) -> Array<ScalarPattern> {
+		def refPatterns = getRefPatterns(solver);
 		def expectedScalars = Array<ScalarPattern>.new(caseToScalars.getNumScalars());
 		for (scalarIdx < expectedScalars.length) {
 			match(caseToScalars.getScalarType(scalarIdx)) {
@@ -136,7 +176,8 @@ class PackingSolverTester(t: Tester) {
 			hasRef: bool
 	) -> Array<ScalarPattern> {
 		def caseToScalars = solution.patterns;
-		def expectedScalars = initExpectedScalars(caseToScalars, solver.refPatterns, hasRef);
+		def refPatterns = getRefPatterns(solver);
+		def expectedScalars = initExpectedScalars(caseToScalars, hasRef);
 		for (fieldIdx < fields.length) {
 			def caseField = CaseField(caseIdx, fieldIdx);
 			def assignedField = solution.assignments[caseField];
@@ -165,7 +206,8 @@ class PackingSolverTester(t: Tester) {
 	) {
 		def caseToScalars = solution.patterns;
 		def assignments: HashMap<CaseField, AssignedField> = solution.assignments;
-		def expectedScalars = initExpectedScalars(caseToScalars, solver.refPatterns, hasRef);
+		def refPatterns = getRefPatterns(solver);
+		def expectedScalars = initExpectedScalars(caseToScalars, hasRef);
 		for (fieldIdx < fields.length) {	
 			def caseField = CaseField(caseIdx, fieldIdx);
 			def assignedField = assignments[caseField];
@@ -193,7 +235,7 @@ class PackingSolverTester(t: Tester) {
 				}
 			}
 			Ref => {
-				def refInterval = solver.refPatterns.refInterval;
+				def refInterval = getRefPatterns(solver).refInterval;
 				if (assignedInterval != refInterval) {
 					t.fail2("%q ref @ wrong interval: %q", caseField.render, assignedInterval.render);
 				}
@@ -249,7 +291,7 @@ class PackingSolverTester(t: Tester) {
 		assertWidthToFieldsCorrect(0, fields, widthToField, problem);
 		solver.makeCaseToScalars();
 		solver.assignments = HashMap<CaseField, AssignedField>.new(CaseField.hash, CaseField.==);
-		solver.caseToScalars.putScalar(solver.widthToFieldMaps, solver.refPatterns);
+		solver.caseToScalars.putScalar(solver.widthToFieldMaps);
 		def assignments = solver.assignments;
 		def caseToScalars = solver.caseToScalars;
 		def origScalar = caseToScalars.getScalarCopy(0, 0);
@@ -329,7 +371,8 @@ def CF = CaseField;
 def I = Interval;
 
 def test_distinguishable(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(6, null));
+	def nc = t.makeNormConfig(Scalar.B32, t.getScalar_noUnify, null, 6);
+	t.useSolver(PackingSolver.new(6, nc, false));
 
 	t.assert_indistinguishable([
 		ScalarPatterns.parse("000000"),
@@ -365,7 +408,7 @@ def test_distinguishable(t: PackingSolverTester) {
 	]);
 }
 def test_nonrefs(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(32, ScalarPatterns.TAGGED_PTR_32));
+	t.useSolver32();
 
 	t.assert_solvable0([[NR(32)]]);
 	t.assert_solvable0([[NR(16), NR(16)]]);
@@ -379,7 +422,7 @@ def test_nonrefs(t: PackingSolverTester) {
 }
 
 def test_nonrefs_64(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(64, ScalarPatterns.TAGGED_PTR_64));
+	t.useSolver64();
 
 	t.assert_solvable0([[NR(64)]]);
 	t.assert_solvable0([[NR(32), NR(32)]]);
@@ -392,7 +435,7 @@ def test_nonrefs_64(t: PackingSolverTester) {
 }
 
 def test_nonrefs_assigned(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(32, ScalarPatterns.TAGGED_PTR_32));
+	t.useSolver32();
 
 	t.assert_solvableN(1, 
 		[[NR(16), NR(15)], [NR(16), NR(12)]],
@@ -410,7 +453,7 @@ def test_nonrefs_assigned(t: PackingSolverTester) {
 }
 
 def test_exact_fit(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(32, ScalarPatterns.TAGGED_PTR_32));
+	t.useSolver32();
 	def assert_exact_fittable = t.assert_fittable(t.solver.findExactFits, _, _, _);
 	
 	// Base case: 
@@ -453,7 +496,7 @@ def test_exact_fit(t: PackingSolverTester) {
 }
 
 def test_best_fit(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(32, ScalarPatterns.TAGGED_PTR_32));
+	t.useSolver32();
 	def assert_best_fittable = t.assert_fittable(t.solver.findBestFits, _, _, _);
 	// Simple case no preassigned; Best fit test 
 	assert_best_fittable(
@@ -500,7 +543,7 @@ def test_best_fit(t: PackingSolverTester) {
 }
 
 def test_multi_case(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(32, ScalarPatterns.TAGGED_PTR_32));
+	t.useSolver32();
 	def assert_solvable = t.assert_solvableN(1, _,  _);
 	// Remember that multi-variant ADTs require tagging
 
@@ -536,8 +579,7 @@ def test_multi_case(t: PackingSolverTester) {
 
 
 def test_unify32(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(32, ScalarPatterns.TAGGED_PTR_32));
-	
+	t.useSolver32();
 	// Refs
 	t.assert_solvable0([ [R] ]);
 	t.assert_solvable0([ [R], [R] ]);
@@ -569,8 +611,7 @@ def test_unify32(t: PackingSolverTester) {
 }
 
 def test_unify64(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(64, ScalarPatterns.TAGGED_PTR_64));
-
+	t.useSolver64();
 	// Refs
 	t.assert_solvable0([ [R] ]);
 	t.assert_solvable0([ [R], [R] ]);
@@ -616,7 +657,7 @@ def test_unify64(t: PackingSolverTester) {
 	t.assert_unsolvable0([[R], [NR(63)]]);
 }
 def test_multi_scalar32(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(32, ScalarPatterns.TAGGED_PTR_32));
+	t.useSolver32();
 	def assert_solvable = t.assert_solvableN(2, _, _);
 
 	// Test 2 nonrefs
@@ -652,7 +693,7 @@ def test_multi_scalar32(t: PackingSolverTester) {
 }
 
 def test_multi_scalar64(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(64, ScalarPatterns.TAGGED_PTR_64));
+	t.useSolver64();
 	def assert_solvable = t.assert_solvableN(2, _, _);
 
 	// Test 2 nonrefs
@@ -677,7 +718,7 @@ def test_multi_scalar64(t: PackingSolverTester) {
 }
 
 def test_multi_scalar_multi_case32(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(32, ScalarPatterns.TAGGED_PTR_32));
+	t.useSolver32();
 	def assert_solvable = t.assert_solvableN(2, _, _);
 	def assert_unsolvable = t.assert_unsolvableN(2, _, _);
 	
@@ -702,7 +743,7 @@ def test_multi_scalar_multi_case32(t: PackingSolverTester) {
 }
 
 def test_multi_scalar_multi_case64(t: PackingSolverTester) {
-	t.useSolver(PackingSolver.new(64, ScalarPatterns.TAGGED_PTR_64));
+	t.useSolver64();
 	def assert_solvable = t.assert_solvableN(2, _, _);
 	// Multi case (REMEMBER TAG BITS)
 	assert_solvable([ [ NR(63), NR(64) ],

--- a/test/variants/ub_ref00.v3
+++ b/test/variants/ub_ref00.v3
@@ -1,0 +1,25 @@
+//@execute 0=0; 1=1; 2=2; 3=3; 4=0; 5=1
+class C(i: int) {}
+type A #unboxed #packed {
+	case X(i1: u8, c: C) #unboxed #packed;
+	case Y(i1: u9, c: C) #unboxed #packed;
+}
+def main(a: int) -> int {
+	def C1 = C.new(1);
+	def C2 = C.new(2);
+	def one = A.X(0, C1);
+	def two = A.Y(1, C2);
+	def thr = A.X(2, C2);
+	def fou = A.Y(3, C1);
+	def arr = [one, two, thr, fou];
+
+	match(a) {
+		0 => return A.X.!(arr[0]).i1;
+		1 => return A.Y.!(arr[1]).i1;
+		2 => return A.X.!(arr[2]).i1;
+		3 => return A.Y.!(arr[3]).i1;
+		4 => return int.view<bool>(A.X.!(arr[0]).c == A.Y.!(arr[1]).c);
+		5 => return int.view<bool>(A.X.!(arr[0]).c == A.Y.!(arr[3]).c);
+		_ => return 42;
+	}
+}

--- a/test/variants/ub_ref01.v3
+++ b/test/variants/ub_ref01.v3
@@ -1,0 +1,20 @@
+//@execute 0=0; 1=2; 2=0
+class C(i: int) {}
+type A #unboxed #packed {
+	case X(i1: u8, c: C) #unboxed #packed;
+	case Y(i1: u9, c: C) #unboxed #packed;
+}
+def main(a: int) -> int {
+	def C1 = C.new(1);
+	def C2 = C.new(2);
+	def one = A.X(0, C1);
+	def thr = A.X(2, C2);
+	def arr = [one, thr];
+
+	match(a) {
+		0 => return A.X.!(arr[0]).i1;
+		1 => return A.X.!(arr[1]).i1;
+		2 => return int.view<bool>(A.X.!(arr[0]).c == A.X.!(arr[1]).c);
+		_ => return 42;
+	}
+}

--- a/test/variants/ub_ref02.v3
+++ b/test/variants/ub_ref02.v3
@@ -1,0 +1,18 @@
+//@execute 0=0; 1=2; 2=1; 3=2
+class C(i: int) {}
+type A (i: byte, c: C) #unboxed #packed { }
+def main(a: int) -> int {
+	def C1 = C.new(1);
+	def C2 = C.new(2);
+	def one = A(0, C1);
+	def thr = A(2, C2);
+	def arr = [one, thr];
+
+	match(a) {
+		0 => return arr[0].i;
+		1 => return arr[1].i;
+		2 => return arr[0].c.i;
+		3 => return arr[1].c.i;
+		_ => return 42;
+	}
+}

--- a/test/variants/ub_ref03.v3
+++ b/test/variants/ub_ref03.v3
@@ -1,0 +1,20 @@
+//@execute 0=0; 1=2; 2=1; 3=2
+class C(i: int) {}
+type A #unboxed #packed { 
+	case X(i: byte, c: C) #unboxed #packed;
+}
+def main(a: int) -> int {
+	def C1 = C.new(1);
+	def C2 = C.new(2);
+	def one = A.X(0, C1);
+	def thr = A.X(2, C2);
+	def arr = [one, thr];
+
+	match(a) {
+		0 => return A.X.!(arr[0]).i;
+		1 => return A.X.!(arr[1]).i;
+		2 => return A.X.!(arr[0]).c.i;
+		3 => return A.X.!(arr[1]).c.i;
+		_ => return 42;
+	}
+}

--- a/test/variants/ub_ref04.v3
+++ b/test/variants/ub_ref04.v3
@@ -1,0 +1,18 @@
+//@execute 0=1; 1=2
+type B(j: byte) {}
+type A #unboxed #packed { 
+	case X(b: B) #unboxed #packed;
+}
+def main(a: int) -> int {
+	def b1 = B(1);
+	def b2 = B(2);
+	def one = A.X(b1);
+	def thr = A.X(b2);
+	def arr = [one, thr];
+
+	match(a) {
+		0 => return A.X.!(arr[0]).b.j;
+		1 => return A.X.!(arr[1]).b.j;
+		_ => return 42;
+	}
+}

--- a/test/variants/ub_ref05.v3
+++ b/test/variants/ub_ref05.v3
@@ -1,0 +1,17 @@
+//@execute 0=0; 1=1
+type A #unboxed #packed { 
+	case X(a: Array<int>) #unboxed #packed;
+}
+def main(a: int) -> int {
+	def a1 = Array<int>.new(1);
+	def a2 = Array<int>.new(1);
+	def one = A.X(a1);
+	def thr = A.X(a2);
+	def arr = [one, thr];
+
+	match(a) {
+		0 => return int.view<bool>(A.X.!(arr[0]) == A.X.!(arr[1]));
+		1 => return int.view<bool>(A.X.!(arr[1]) == A.X.!(arr[1]));
+		_ => return 42;
+	}
+}


### PR DESCRIPTION
ub_ref00.v3 was the failing case. 

Problem: Packing references fails. Tagged reference operations are not supported operators in the compiler yet. 

Solution: Avoid packing fields into scalars for references. PackingSolver moves onto next scalar after assigning a ref to a scalar.

PR includes changes to PackingSolver to take in the NormalizerConfig so that the solver can case on the MaxScalarWidth in the future. This allows the solver to determine which reference to use for packing. Targets could modify the NormalizerConfig in their configureCompiler methods to flag whether tagged references are allowed for the target. As of right now, tagged references are supported in the runtime. 