### PR TITLE
Add `#inline-into` compiler directive

### DIFF
--- a/aeneas/src/ir/Ir.v3
+++ b/aeneas/src/ir/Ir.v3
@@ -18,6 +18,7 @@ enum IrFlag {
 	M_ABSTRACT,		// the method is abstract
 	M_INLINE,		// method should be inlined whenever possible
 	M_NEVER_INLINE,		// method should never be inlined
+	M_INLINE_INTO,		// callees of this method should be inlined into it
 	M_EMPTY,		// method has no body (should throw)
 	M_NORM,			// method is normalized
 	M_WRAPPER,		// method is a function subsumption wrapper

--- a/aeneas/src/ir/VstIr.v3
+++ b/aeneas/src/ir/VstIr.v3
@@ -153,6 +153,7 @@ class IrBuilder(ctype: Type, parent: IrClass) {
 		var ir = IrMethod.new(ctype, typeArgs, sig);
 		ir.source = m;
 		if (CLOptions.INLINE.val.matches(m)) ir.setFlag(IrFlag.M_INLINE); // XXX: better location to set this?
+		if (CLOptions.INLINE_INTO.val.matches(m)) ir.setFlag(IrFlag.M_INLINE_INTO);
 		if (EmptyStmt.?(m.func.body)) ir.flags |= IrFlag.M_EMPTY;
 		if (m.func.neverInline) ir.flags |= IrFlag.M_NEVER_INLINE;
 		return ir;
@@ -209,6 +210,7 @@ class IrBuilder(ctype: Type, parent: IrClass) {
 			match (l.head) {
 				Inline => ir.setFlag(IrFlag.M_INLINE);
 				NoInline => ir.setFlag(IrFlag.M_NEVER_INLINE);
+				InlineInto => ir.setFlag(IrFlag.M_INLINE_INTO);
 				_ => ;
 			}
 		}

--- a/aeneas/src/main/CLOptions.v3
+++ b/aeneas/src/main/CLOptions.v3
@@ -65,6 +65,8 @@ component CLOptions {
 		"Limit the maximum number of scalars allowed for auto-unboxing variant types.");
 	def INLINE		= sharedOpt.newMatcherOption("inline",
 		"Force inlining of direct calls to the given method(s).");
+	def INLINE_INTO		= sharedOpt.newMatcherOption("inline-into",
+		"Force inlining of direct calls made by the given method(s).");
 	def FIRST_ENABLED	= sharedOpt.newIntOption("first-enabled", -1,
 		"First optimization decision enabled (count from 1)");
 	def LAST_ENABLED	= sharedOpt.newIntOption("last-enabled", Int.MAX_VALUE,

--- a/aeneas/src/main/Compiler.v3
+++ b/aeneas/src/main/Compiler.v3
@@ -404,7 +404,8 @@ class Compilation(compiler: Compiler, prog: Program) {
 		if (meth.ssa == null) {
 			var context = SsaContext.new(compiler, prog).enterSpec(memberRef);
 			var gen = VstSsaGen.new(context, prog.opBuilder);
-			gen.recordDirectCalls = compiler.InlineEarly || CLOptions.INLINE.val != VstMatcher.None;
+			gen.recordDirectCalls = compiler.InlineEarly || CLOptions.INLINE.val != VstMatcher.None
+				|| CLOptions.INLINE_INTO.val != VstMatcher.None;
 			var graph = gen.generate();
 			context.verify();
 			meth.ssa = graph;

--- a/aeneas/src/ssa/SsaInliner.v3
+++ b/aeneas/src/ssa/SsaInliner.v3
@@ -283,6 +283,7 @@ class SsaEarlyInliner(context: SsaContext, compilation: Compilation, gen: VstSsa
 		var flags = inlinee.member.flags;
 		if (flags.M_NEVER_INLINE) return false;		// marked as never inline
 		if (flags.M_INLINE) return true;
+		if (context.method.flags.M_INLINE_INTO) return true;	// caller marked #inline-into
 		return checkGraphSize(ssa, maxInlineBlocks, maxInlineSize);
 	}
 }

--- a/aeneas/src/vst/Parser.v3
+++ b/aeneas/src/vst/Parser.v3
@@ -341,6 +341,7 @@ component Parser {
 					else if (Strings.equal(label, "big-endian")) result = VstRepHint.BigEndian;
 					else if (Strings.equal(label, "inline")) result = VstRepHint.Inline;
 					else if (Strings.equal(label, "no-inline")) result = VstRepHint.NoInline;
+					else if (Strings.equal(label, "inline-into")) result = VstRepHint.InlineInto;
 					else if (p.curByte == '(') {
 						// Parse ExprHint: #label(expr, expr, ...)
 						var exprs = parseList(0, p, '(', COMMA, ')', parseExpr);

--- a/aeneas/src/vst/Vst.v3
+++ b/aeneas/src/vst/Vst.v3
@@ -474,6 +474,7 @@ type VstRepHint {
 	case BigEndian;
 	case Inline;
 	case NoInline;
+	case InlineInto;
 	case ExprHint(label: string, exprs: VstList<Expr>);
 	case TypeHint(label: string, types: VstList<TypeRef>);
 	case Other(hint: string);
@@ -487,6 +488,7 @@ type VstRepHint {
 			BigEndian => buf.puts("#big-endian");
 			Inline => buf.puts("#inline");
 			NoInline => buf.puts("#no-inline");
+			InlineInto => buf.puts("#inline-into");
 			ExprHint(label, exprs) => buf.put1("#%s(...)", label);
 			TypeHint(label, types) => buf.put1("#%s<...>", label);
 			Other(s) => buf.put1("#%s", s);

--- a/doc/grammar-claude.md
+++ b/doc/grammar-claude.md
@@ -268,7 +268,7 @@ HintArgs ::= '<' TypeRef,* '>'          // type hint:  #label<T>
            | '(' Expr,* ')'             // expr hint:  #label(e)
            | PackingExpr                 // packing:    #packing(...)
 
-// Known hints: boxed, unboxed, packed, big-endian, inline, no-inline, packing(...)
+// Known hints: boxed, unboxed, packed, big-endian, inline, no-inline, inline-into, packing(...)
 ```
 
 ---

--- a/test/core/opt_inl02.v3
+++ b/test/core/opt_inl02.v3
@@ -1,0 +1,16 @@
+//@execute 0=3; 5=7; 99=-2
+def find(a: int) -> int {
+	var t = a * 2 + 1;
+	for (i < 10) {
+		var s = i * i + i;
+		if (s > t) return i;
+		if (s == t) return 0 - i;
+	}
+	return -1;
+}
+def top(a: int) -> int #inline-into {
+	return find(a) + find(a + 1);
+}
+def main(a: int) -> int {
+	return top(a);
+}

--- a/test/core/parser/rephint46.v3
+++ b/test/core/parser/rephint46.v3
@@ -1,0 +1,3 @@
+//@parse
+def m() #inline-into {
+}


### PR DESCRIPTION
The `#inline-into` directive is like the opposite of the `#inline` directive. When a function is declared as `#inline-into` the compiler forces any functions/methods that it calls to be inlined into that function. Would be useful for fast handler functions to force the compiler to reduce the number of calls in these hot functions.